### PR TITLE
fix(sandbox): name requested enforcement-health when execution degrades

### DIFF
--- a/crates/assay-cli/src/cli/commands/sandbox.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox.rs
@@ -31,6 +31,10 @@ use tmp::create_scoped_tmp;
 /// A refusal happens before the child runs, so there is genuinely nothing to profile and no
 /// enforcement to describe. Writing an empty artifact would be worse than writing none: it
 /// would look like a measured run. What the caller is owed is the sentence, not the file.
+fn note_unwritten_artifact(flag: &str, path: &std::path::Path, reason: &str) {
+    eprintln!("NOTE: {flag} {} not written: {reason}", path.display());
+}
+
 fn report_unwritten_artifacts(args: &SandboxArgs, reason: &str) {
     for (flag, path) in [
         ("--profile", args.profile.as_ref()),
@@ -39,8 +43,17 @@ fn report_unwritten_artifacts(args: &SandboxArgs, reason: &str) {
         ("--otel-jsonl", args.otel_jsonl.as_ref()),
     ] {
         if let Some(path) = path {
-            eprintln!("NOTE: {flag} {} not written: {reason}", path.display());
+            note_unwritten_artifact(flag, path, reason);
         }
+    }
+}
+
+/// A requested `--enforcement-health` path that cannot exist because execution
+/// degraded to audit before the v1 producer. Profile/bundle/otel may still be
+/// written after the child runs; do not reuse `report_unwritten_artifacts` here.
+fn report_unwritten_enforcement_health(args: &SandboxArgs, reason: &str) {
+    if let Some(path) = args.enforcement_health.as_ref() {
+        note_unwritten_artifact("--enforcement-health", path, reason);
     }
 }
 
@@ -80,6 +93,7 @@ pub async fn run(args: SandboxArgs) -> anyhow::Result<i32> {
         eprintln!(
             "WARN: Active enforcement requested but not supported. Falling back to Audit mode."
         );
+        report_unwritten_enforcement_health(&args, "execution degraded to audit");
     }
 
     if !args.quiet {
@@ -273,6 +287,7 @@ pub async fn run(args: SandboxArgs) -> anyhow::Result<i32> {
         eprintln!(
             "WARN: Degrading to Audit mode (no containment). use --fail-closed to make this fatal."
         );
+        report_unwritten_enforcement_health(&args, "execution degraded to audit");
         metrics::increment("degraded_to_audit_conflict");
         actual_enforcement = false;
     }

--- a/crates/assay-cli/tests/contract_sandbox_enforcement_health_degrade.rs
+++ b/crates/assay-cli/tests/contract_sandbox_enforcement_health_degrade.rs
@@ -1,0 +1,189 @@
+//! #2637: name a requested `--enforcement-health` artifact when execution
+//! degrades to audit before the v1 producer.
+//!
+//! Binary contract: child is `echo MARKER` on stdout.
+//!
+//! Unsupported-backend (`--enforce`, no Landlock) compiles on non-Linux only.
+//! Policy-conflict (`actual_enforcement` plus deny-inside-allow) compiles on
+//! Linux only. That is a fail-closed precondition: on Linux without Landlock
+//! the test still runs and panics because `CONFLICT_WARN` was not reached.
+//! A panic is not GREEN for that callsite. No skip-return. No test-only
+//! backend override. macOS/Windows CI excludes `assay-cli`.
+
+#![cfg(unix)]
+
+use assert_cmd::Command;
+#[cfg(target_os = "linux")]
+use std::io::Write;
+use std::path::Path;
+
+const MARKER: &str = "ASSAY_CHILD_RAN_MARKER";
+const DEGRADE_REASON: &str = "execution degraded to audit";
+const UNSUPPORTED_WARN: &str =
+    "Active enforcement requested but not supported. Falling back to Audit mode.";
+#[cfg(target_os = "linux")]
+const CONFLICT_WARN: &str = "Landlock policy conflict detected (Deny rule inside Allow root).";
+
+struct Run {
+    code: Option<i32>,
+    stderr: String,
+    child_ran: bool,
+    _data_home: tempfile::TempDir,
+}
+
+fn run_sandbox(extra: &[&str], policy: Option<&Path>) -> Run {
+    let data_home = tempfile::tempdir().expect("temp data home");
+    let mut cmd = Command::cargo_bin("assay").expect("binary");
+    cmd.env("XDG_DATA_HOME", data_home.path());
+    cmd.arg("sandbox");
+    cmd.args(extra);
+    if let Some(p) = policy {
+        cmd.arg("--policy").arg(p);
+    }
+    cmd.args(["--", "echo", MARKER]);
+    let out = cmd.assert().get_output().clone();
+    Run {
+        code: out.status.code(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        child_ran: String::from_utf8_lossy(&out.stdout).contains(MARKER),
+        _data_home: data_home,
+    }
+}
+
+fn assert_continuing(run: &Run, path_warn: &str) {
+    assert_eq!(run.code, Some(0), "stderr:\n{}", run.stderr);
+    assert!(run.child_ran, "child must run.\nstderr:\n{}", run.stderr);
+    assert!(
+        run.stderr.contains(path_warn),
+        "this callsite was not reached.\nstderr:\n{}",
+        run.stderr
+    );
+    for flag in ["--profile", "--bundle", "--otel-jsonl"] {
+        assert!(
+            !run.stderr.contains(&format!("NOTE: {flag} ")),
+            "must not claim {flag} unwritten on a continuing run.\nstderr:\n{}",
+            run.stderr
+        );
+    }
+}
+
+fn assert_named_health(run: &Run, health: &Path, path_warn: &str) {
+    assert_continuing(run, path_warn);
+    let note = format!(
+        "NOTE: --enforcement-health {} not written: {DEGRADE_REASON}",
+        health.display()
+    );
+    assert!(
+        run.stderr.contains(&note),
+        "missing health NOTE.\nstderr:\n{}",
+        run.stderr
+    );
+    assert!(!health.exists(), "must not synthesize a v1 artifact");
+}
+
+fn assert_silent_health(run: &Run, path_warn: &str) {
+    assert_continuing(run, path_warn);
+    assert!(
+        !run.stderr.contains("--enforcement-health") && !run.stderr.contains(DEGRADE_REASON),
+        "no health path requested.\nstderr:\n{}",
+        run.stderr
+    );
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn unsupported_backend_names_requested_enforcement_health_as_unwritten() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let health = tmp.path().join("health.json");
+    let profile = tmp.path().join("prof.yaml");
+    let hs = health.to_string_lossy();
+    let ps = profile.to_string_lossy();
+    let run = run_sandbox(
+        &[
+            "--enforce",
+            "--enforce-net",
+            "--enforcement-health",
+            hs.as_ref(),
+            "--profile",
+            ps.as_ref(),
+        ],
+        None,
+    );
+    assert_named_health(&run, &health, UNSUPPORTED_WARN);
+    assert!(
+        profile.exists(),
+        "profile must still be written.\nstderr:\n{}",
+        run.stderr
+    );
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn no_enforcement_health_path_stays_silent_on_unsupported_backend_degrade() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let profile = tmp.path().join("prof.yaml");
+    let ps = profile.to_string_lossy();
+    let run = run_sandbox(
+        &["--enforce", "--enforce-net", "--profile", ps.as_ref()],
+        None,
+    );
+    assert_silent_health(&run, UNSUPPORTED_WARN);
+    assert!(profile.exists(), "stderr:\n{}", run.stderr);
+}
+
+#[cfg(target_os = "linux")]
+fn conflict_policy() -> tempfile::NamedTempFile {
+    let home = std::env::var("HOME").expect("HOME");
+    let deny = std::path::PathBuf::from(&home).join(".ssh");
+    let mut f = tempfile::NamedTempFile::new().expect("temp policy");
+    writeln!(
+        f,
+        "api_version: assay/v1\nfs:\n  allow:\n    - {home}\n  deny:\n    - {}\nnet:\n  allow: []\n  deny: []",
+        deny.display()
+    )
+    .expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+#[cfg(target_os = "linux")]
+fn run_conflict(with_health: bool) -> (Run, tempfile::TempDir, tempfile::NamedTempFile) {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let health = tmp.path().join("health.json");
+    let profile = tmp.path().join("prof.yaml");
+    let policy = conflict_policy();
+    let hs = health.to_string_lossy();
+    let ps = profile.to_string_lossy();
+    let mut extra = vec!["--enforce", "--enforce-net", "--profile", ps.as_ref()];
+    if with_health {
+        extra.extend(["--enforcement-health", hs.as_ref()]);
+    }
+    let run = run_sandbox(&extra, Some(policy.path()));
+    if run.stderr.contains(UNSUPPORTED_WARN) {
+        panic!(
+            "policy-conflict callsite was not reached (no Landlock). \
+             This is not GREEN for that branch.\nstderr:\n{}",
+            run.stderr
+        );
+    }
+    (run, tmp, policy)
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn policy_conflict_names_requested_enforcement_health_as_unwritten() {
+    let (run, tmp, _policy) = run_conflict(true);
+    let health = tmp.path().join("health.json");
+    let profile = tmp.path().join("prof.yaml");
+    assert_named_health(&run, &health, CONFLICT_WARN);
+    assert!(profile.exists(), "stderr:\n{}", run.stderr);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn no_enforcement_health_path_stays_silent_on_policy_conflict_degrade() {
+    let (run, tmp, _policy) = run_conflict(false);
+    let profile = tmp.path().join("prof.yaml");
+    assert_silent_health(&run, CONFLICT_WARN);
+    assert!(profile.exists(), "stderr:\n{}", run.stderr);
+}

--- a/docs/reference/cli/sandbox.md
+++ b/docs/reference/cli/sandbox.md
@@ -35,6 +35,7 @@ This is the recommended way to run untrusted MCP servers in CI/CD or development
 | `--fail-closed` | Exit if policy cannot be fully enforced (no degradation) |
 | `--enforce` | Require active Landlock filesystem enforcement |
 | `--enforce-net` | Enforce an explicit TCP destination-port allowlist; requires `--enforce` |
+| `--enforcement-health <path>` | Write `assay.enforcement_health.v1` (Landlock TCP-connect) to this path; requires `--enforce-net` |
 | `--dry-run` | Audit without active blocking; conflicts with `--enforce` |
 
 ### Environment Control
@@ -221,6 +222,12 @@ When degraded execution continues and profiling is enabled, the evidence profile
 sidecar can carry a typed `assay.sandbox.degraded` signal for the supported
 fallback paths. Intentional audit/permissive runs and fail-closed aborts do not
 emit that signal.
+
+`--enforcement-health` requires `--enforce-net`. If execution degrades to audit
+before Landlock is applied (unsupported backend, or a policy conflict that is
+not `--fail-closed`), the mechanism artifact is not written and Assay names the
+requested path on stderr. That diagnostic is not an `assay.enforcement_health.v1`
+record.
 
 ---
 


### PR DESCRIPTION
## Summary

When `--enforcement-health` is requested and execution degrades to audit before the v1 producer, name that path on stderr. Profile/bundle/otel can still be written after the child runs, so the four-flag refusal helper is not reused on continue paths.

- Shared `note_unwritten_artifact` formatter; refusal `report_unwritten_artifacts` wording and call sites unchanged
- Sibling `report_unwritten_enforcement_health` on both continue paths (unsupported backend; Landlock deny-inside-allow without `--fail-closed`)
- Binary contract for the named NOTE vs silent control
- Docs: degrade can leave the mechanism artifact absent; the diagnostic is not a v1 record

Refs #2637. Does not implement #2511.

## Evidence (Darwin writer)

- Base: `d3d674d7a58b661acd44939f07efae355511ce11`
- Head: `69609e6ac0b9d1f32e792080b2ecf4f97532e9cb`
- RED then GREEN: `unsupported_backend_names_requested_enforcement_health_as_unwritten`
- Control GREEN: `no_enforcement_health_path_stays_silent_on_unsupported_backend_degrade`
- Mutation A (remove only the unsupported-backend call): test A RED (`missing health NOTE`), control GREEN; call restored
- Refusal contract `contract_sandbox_policy_load_fail_closed` 5/5 GREEN
- `cargo fmt --all -- --check`, `cargo clippy -p assay-cli -- -D warnings`, `git diff --check` clean

## Non-claims

- Mutation B / policy-conflict path: **unproven on this Darwin writer**. Conflict compiles on Linux only. Linux without Landlock panics (`CONFLICT_WARN` not reached); that panic is not GREEN. Claim B only after an exact-head Linux run whose stderr contains `Landlock policy conflict detected (Deny rule inside Allow root).`
- Not #2511 additive machine projection. No `Absent` in `assay.enforcement_health.v1`. No synthesized v1. No `doctor_report` as runtime evidence.
- No Landlock / egress / seal proof. Refusal exits and four-flag helper behavior unchanged.
- macOS/Windows CI excludes `assay-cli`; these tests will not bind there.

## Test plan

- [x] Focused degrade contract on Darwin (2 tests)
- [x] Mutation A on Darwin
- [ ] Linux CI (or Linux host) reaches `CONFLICT_WARN` and binds mutation B
- [ ] Refusal wording stays the existing four-flag NOTE on fail-closed paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `--enforcement-health <path>` option for recording enforcement-health results when network enforcement is enabled.
  - Added clear reporting when enforcement health cannot be recorded during degraded audit execution.
- **Bug Fixes**
  - Audit-mode execution now continues when enforcement support is unavailable or conflicting, while still producing other available artifacts.
  - Prevented unavailable enforcement-health files from being created or misidentified as valid records.
- **Documentation**
  - Documented the new option and degraded-execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->