### PR TITLE
feat(cli): project one enforcement-health document

### DIFF
--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -9,6 +9,7 @@ pub mod evidence;
 pub mod import;
 pub mod mcp;
 pub mod policy;
+pub mod project_enforcement_health;
 pub mod project_otel;
 pub mod registry;
 pub mod replay;
@@ -27,6 +28,7 @@ pub use evidence::*;
 pub use import::*;
 pub use mcp::*;
 pub use policy::*;
+pub use project_enforcement_health::*;
 pub use project_otel::*;
 pub use registry::*;
 pub use replay::*;
@@ -103,6 +105,8 @@ pub enum Command {
     Coverage(CoverageArgs),
     /// Project assay evidence into the OTel GenAI + OpenInference view (`assay.otel_projection.v0`)
     ProjectOtel(ProjectOtelArgs),
+    /// Project one existing enforcement-health document (`assay.enforcement_health_projection.v0`)
+    ProjectEnforcementHealth(ProjectEnforcementHealthArgs),
     /// Explain a test result or trace decision
     Explain(super::commands::explain::ExplainArgs),
     /// Generate and run the local demo project

--- a/crates/assay-cli/src/cli/args/project_enforcement_health.rs
+++ b/crates/assay-cli/src/cli/args/project_enforcement_health.rs
@@ -1,0 +1,16 @@
+use std::path::PathBuf;
+
+/// Project one existing `assay.enforcement_health.v0` or `.v1` document.
+///
+/// Read-only, one-directional, lossy. Absence of a projection is no claim and
+/// never a pass. `--input` is required: no input means no document.
+#[derive(clap::Args, Debug, Clone)]
+pub struct ProjectEnforcementHealthArgs {
+    /// Output format. Only `json` is accepted.
+    #[arg(long = "format", value_parser = ["json"])]
+    pub format: String,
+
+    /// Path to exactly one existing `assay.enforcement_health.v0` or `.v1` JSON document.
+    #[arg(long = "input")]
+    pub input: PathBuf,
+}

--- a/crates/assay-cli/src/cli/commands/dispatch.rs
+++ b/crates/assay-cli/src/cli/commands/dispatch.rs
@@ -28,6 +28,7 @@ pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
         Command::Migrate(args) => super::migrate::cmd_migrate(args),
         Command::Coverage(args) => super::coverage::cmd_coverage(args).await,
         Command::ProjectOtel(args) => super::project_otel::run(args),
+        Command::ProjectEnforcementHealth(args) => super::project_enforcement_health::run(args),
         Command::Explain(args) => super::explain::run(args).await,
         Command::Demo(args) => super::demo::cmd_demo(args).await,
         Command::InitCi(args) => super::init_ci::cmd_init_ci(args),

--- a/crates/assay-cli/src/cli/commands/mod.rs
+++ b/crates/assay-cli/src/cli/commands/mod.rs
@@ -35,6 +35,7 @@ pub mod profile;
 #[cfg(test)]
 mod profile_simulation_test;
 pub mod profile_types;
+pub mod project_enforcement_health;
 pub mod project_otel;
 pub(crate) mod quarantine;
 pub mod record;

--- a/crates/assay-cli/src/cli/commands/project_enforcement_health.rs
+++ b/crates/assay-cli/src/cli/commands/project_enforcement_health.rs
@@ -2,7 +2,8 @@
 //!
 //! Guardrail: one private mapping function is the only source of observation
 //! truth. The CLI reads a bounded input, dispatches on `schema`, deserializes
-//! the matching typed carrier, reduces to a source status, and writes JSON.
+//! the matching typed carrier, checks producer-legal `active` before reducing
+//! to a source status, and writes JSON.
 
 use std::fs::File;
 use std::io::Read;
@@ -12,9 +13,11 @@ use serde::Serialize;
 
 use crate::cli::args::ProjectEnforcementHealthArgs;
 use crate::cli::commands::monitor::monitor_next::enforcement_health::{
-    EnforcementHealth, NetworkEnforcement, SCHEMA_V0,
+    EnforcementClass as V0Class, EnforcementHealth, NetworkEnforcement, SCHEMA_V0,
 };
-use crate::enforcement_health_v1::{EnforcementHealthV1, Status as V1Status, SCHEMA_V1};
+use crate::enforcement_health_v1::{
+    EnforcementClass as V1Class, EnforcementHealthV1, Status as V1Status, SCHEMA_V1,
+};
 use crate::exit_codes::EXIT_CONFIG_ERROR;
 use crate::output_write::write_stdout_json;
 
@@ -73,17 +76,44 @@ fn read_bounded(path: &Path) -> Result<Vec<u8>, ()> {
     Ok(buf)
 }
 
+/// `active` is applied only when the producer invariants still hold.
+/// Failed/absent stay status-only; this slice does not grow a failed framework.
+fn v0_active_is_producer_legal(health: &EnforcementHealth) -> bool {
+    health.attach_confirmed && health.enforcement_class == V0Class::Strong
+}
+
+fn v1_active_is_producer_legal(health: &EnforcementHealthV1) -> bool {
+    health.enforcement_class == V1Class::Strong
+        && health.failure.is_none()
+        && health.landlock.no_new_privs_confirmed
+        && health.landlock.restrict_self_confirmed
+}
+
 fn parse_health(bytes: &[u8]) -> Option<SourceStatus> {
     let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
     let schema = value.get("schema")?.as_str()?;
     match schema {
         SCHEMA_V0 => {
             let health: EnforcementHealth = serde_json::from_value(value).ok()?;
-            (health.schema == SCHEMA_V0).then_some(SourceStatus::V0(health.network_enforcement))
+            if health.schema != SCHEMA_V0 {
+                return None;
+            }
+            if health.network_enforcement == NetworkEnforcement::Active
+                && !v0_active_is_producer_legal(&health)
+            {
+                return None;
+            }
+            Some(SourceStatus::V0(health.network_enforcement))
         }
         SCHEMA_V1 => {
             let health: EnforcementHealthV1 = serde_json::from_value(value).ok()?;
-            (health.schema == SCHEMA_V1).then_some(SourceStatus::V1(health.status))
+            if health.schema != SCHEMA_V1 {
+                return None;
+            }
+            if health.status == V1Status::Active && !v1_active_is_producer_legal(&health) {
+                return None;
+            }
+            Some(SourceStatus::V1(health.status))
         }
         _ => None,
     }

--- a/crates/assay-cli/src/cli/commands/project_enforcement_health.rs
+++ b/crates/assay-cli/src/cli/commands/project_enforcement_health.rs
@@ -1,0 +1,112 @@
+//! `assay project-enforcement-health` — project one existing health document.
+//!
+//! Guardrail: one private mapping function is the only source of observation
+//! truth. The CLI reads a bounded input, dispatches on `schema`, deserializes
+//! the matching typed carrier, reduces to a source status, and writes JSON.
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::cli::args::ProjectEnforcementHealthArgs;
+use crate::cli::commands::monitor::monitor_next::enforcement_health::{
+    EnforcementHealth, NetworkEnforcement, SCHEMA_V0,
+};
+use crate::enforcement_health_v1::{EnforcementHealthV1, Status as V1Status, SCHEMA_V1};
+use crate::exit_codes::EXIT_CONFIG_ERROR;
+use crate::output_write::write_stdout_json;
+
+pub const SCHEMA_PROJECTION_V0: &str = "assay.enforcement_health_projection.v0";
+pub const MAX_INPUT_BYTES: u64 = 65_536;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Observation {
+    Applied,
+    Degraded,
+    NotRequested,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct Projection {
+    schema: &'static str,
+    lossy: bool,
+    source_schema: &'static str,
+    observation: Observation,
+}
+
+/// Status extracted from a fully typed carrier. Small enough that clippy
+/// does not ask for a Box; mapping truth lives only here.
+enum SourceStatus {
+    V0(NetworkEnforcement),
+    V1(V1Status),
+}
+
+fn project_health(status: SourceStatus) -> Option<Projection> {
+    let (source_schema, observation) = match status {
+        SourceStatus::V0(NetworkEnforcement::Active) => (SCHEMA_V0, Observation::Applied),
+        SourceStatus::V0(NetworkEnforcement::Failed) => (SCHEMA_V0, Observation::Degraded),
+        SourceStatus::V0(NetworkEnforcement::Absent) => (SCHEMA_V0, Observation::NotRequested),
+        SourceStatus::V0(NetworkEnforcement::NotApplicable) => return None,
+        SourceStatus::V1(V1Status::Active) => (SCHEMA_V1, Observation::Applied),
+        SourceStatus::V1(V1Status::Failed) => (SCHEMA_V1, Observation::Degraded),
+    };
+    Some(Projection {
+        schema: SCHEMA_PROJECTION_V0,
+        lossy: true,
+        source_schema,
+        observation,
+    })
+}
+
+fn read_bounded(path: &Path) -> Result<Vec<u8>, ()> {
+    let file = File::open(path).map_err(|_| ())?;
+    let mut buf = Vec::new();
+    file.take(MAX_INPUT_BYTES + 1)
+        .read_to_end(&mut buf)
+        .map_err(|_| ())?;
+    if buf.len() as u64 > MAX_INPUT_BYTES {
+        return Err(());
+    }
+    Ok(buf)
+}
+
+fn parse_health(bytes: &[u8]) -> Option<SourceStatus> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    let schema = value.get("schema")?.as_str()?;
+    match schema {
+        SCHEMA_V0 => {
+            let health: EnforcementHealth = serde_json::from_value(value).ok()?;
+            (health.schema == SCHEMA_V0).then_some(SourceStatus::V0(health.network_enforcement))
+        }
+        SCHEMA_V1 => {
+            let health: EnforcementHealthV1 = serde_json::from_value(value).ok()?;
+            (health.schema == SCHEMA_V1).then_some(SourceStatus::V1(health.status))
+        }
+        _ => None,
+    }
+}
+
+fn fail_closed() -> anyhow::Result<i32> {
+    Ok(EXIT_CONFIG_ERROR)
+}
+
+pub fn run(args: ProjectEnforcementHealthArgs) -> anyhow::Result<i32> {
+    if args.format != "json" {
+        return fail_closed();
+    }
+    let bytes = match read_bounded(&args.input) {
+        Ok(bytes) => bytes,
+        Err(()) => return fail_closed(),
+    };
+    let Some(status) = parse_health(&bytes) else {
+        return fail_closed();
+    };
+    let Some(projection) = project_health(status) else {
+        return fail_closed();
+    };
+    let json = serde_json::to_string(&projection)?;
+    Ok(write_stdout_json(&json))
+}

--- a/crates/assay-cli/tests/project_enforcement_health_cli.rs
+++ b/crates/assay-cli/tests/project_enforcement_health_cli.rs
@@ -3,8 +3,8 @@
 //! `assay project-enforcement-health --format json --input PATH`
 //!
 //! Success bytes are exact. Fail-closed paths are nonzero with empty stdout.
-//! Valid `active` fixtures are constructor-legal (v0 attach+strong; v1 both
-//! Landlock confirmations, strong, no failure). Forged `active` fails closed.
+//! Valid `active` fixtures are constructor-legal (v0 attach+strong; committed
+//! v1 `active_no_probe`). Each near-miss violates exactly one producer arm.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -43,6 +43,12 @@ fn v0(status: &str) -> String {
     )
 }
 
+fn v0_active_near(attach: bool, class: &str) -> String {
+    format!(
+        r#"{{"schema":"{V0}","scope":"ipv4_tcp_connect","network_enforcement":"active","attach_confirmed":{attach},"blocked_count":0,"allowed_count":0,"enforcement_class":"{class}"}}"#
+    )
+}
+
 fn v1(status: &str) -> String {
     let (nnp, restrict, class) = if status == "active" {
         ("true", "true", "strong")
@@ -52,6 +58,24 @@ fn v1(status: &str) -> String {
     format!(
         r#"{{"schema":"{V1}","status":"{status}","mechanism":"landlock","scope":"tcp_connect_landlock_port","policy_semantics":"allowlist","enforcement_class":"{class}","landlock":{{"abi":4,"no_new_privs_confirmed":{nnp},"restrict_self_confirmed":{restrict}}},"probe":null,"non_claims":[]}}"#
     )
+}
+
+/// Producer-legal v1 `active` except the named arm. Remaining fields match
+/// the committed `active_no_probe` shape plus an optional typed `failure`.
+fn v1_active_near(class: &str, nnp: bool, restrict: bool, with_failure: bool) -> String {
+    let failure = if with_failure {
+        r#","failure":{"reason_code":"landlock_abi_too_old","detail":"Landlock ABI 4 is required for TCP connect port allowlists"}"#
+    } else {
+        ""
+    };
+    format!(
+        r#"{{"schema":"{V1}","status":"active","mechanism":"landlock","scope":"tcp_connect_landlock_port","policy_semantics":"allowlist","enforcement_class":"{class}"{failure},"landlock":{{"abi":4,"handled_access_net":["connect_tcp"],"allowed_connect_tcp_ports":[443],"no_new_privs_confirmed":{nnp},"restrict_self_confirmed":{restrict}}},"probe":null,"non_claims":["no ip or cidr enforcement","no hostname enforcement","no destination identity enforcement","no udp or quic enforcement","no http or tls route policy","not a replacement for cgroup/connect4 endpoint enforcement"]}}"#
+    )
+}
+
+fn committed_v1_active_no_probe() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/enforcement_health/v1/active_no_probe.json")
 }
 
 fn expected(source_schema: &str, observation: &str) -> String {
@@ -91,6 +115,18 @@ fn assert_fail_args(args: &[&str]) {
     );
 }
 
+fn assert_fail_body(name: &str, body: &str) {
+    let dir = tmp();
+    let path = write(dir.path(), name, body);
+    assert_fail_args(&[
+        "project-enforcement-health",
+        "--format",
+        "json",
+        "--input",
+        path.to_str().unwrap(),
+    ]);
+}
+
 #[test]
 fn v0_active_maps_to_applied() {
     let dir = tmp();
@@ -114,9 +150,7 @@ fn v0_absent_maps_to_not_requested() {
 
 #[test]
 fn v1_active_maps_to_applied() {
-    let dir = tmp();
-    let path = write(dir.path(), "v1-active.json", &v1("active"));
-    assert_exact_ok(&path, V1, "applied");
+    assert_exact_ok(&committed_v1_active_no_probe(), V1, "applied");
 }
 
 #[test]
@@ -224,35 +258,46 @@ fn v0_not_applicable_is_nonzero_empty_stdout() {
 }
 
 #[test]
-fn v0_active_without_confirmed_attach_is_nonzero_empty_stdout() {
-    let dir = tmp();
-    let path = write(
-        dir.path(),
-        "v0-forged-active.json",
-        r#"{"schema":"assay.enforcement_health.v0","scope":"ipv4_tcp_connect","network_enforcement":"active","attach_confirmed":false,"blocked_count":0,"allowed_count":0,"enforcement_class":"basic"}"#,
+fn v0_active_attach_false_strong_is_nonzero_empty_stdout() {
+    assert_fail_body(
+        "v0-attach-false-strong.json",
+        &v0_active_near(false, "strong"),
     );
-    assert_fail_args(&[
-        "project-enforcement-health",
-        "--format",
-        "json",
-        "--input",
-        path.to_str().unwrap(),
-    ]);
 }
 
 #[test]
-fn v1_active_without_restrict_confirmations_is_nonzero_empty_stdout() {
-    let dir = tmp();
-    let path = write(
-        dir.path(),
-        "v1-forged-active.json",
-        r#"{"schema":"assay.enforcement_health.v1","status":"active","mechanism":"landlock","scope":"tcp_connect_landlock_port","policy_semantics":"allowlist","enforcement_class":"basic","landlock":{"abi":4,"no_new_privs_confirmed":false,"restrict_self_confirmed":false},"probe":null,"non_claims":[]}"#,
+fn v0_active_attach_true_basic_is_nonzero_empty_stdout() {
+    assert_fail_body("v0-attach-true-basic.json", &v0_active_near(true, "basic"));
+}
+
+#[test]
+fn v1_active_with_failure_is_nonzero_empty_stdout() {
+    assert_fail_body(
+        "v1-active-failure.json",
+        &v1_active_near("strong", true, true, true),
     );
-    assert_fail_args(&[
-        "project-enforcement-health",
-        "--format",
-        "json",
-        "--input",
-        path.to_str().unwrap(),
-    ]);
+}
+
+#[test]
+fn v1_active_basic_class_is_nonzero_empty_stdout() {
+    assert_fail_body(
+        "v1-active-basic.json",
+        &v1_active_near("basic", true, true, false),
+    );
+}
+
+#[test]
+fn v1_active_no_new_privs_false_is_nonzero_empty_stdout() {
+    assert_fail_body(
+        "v1-active-nnp-false.json",
+        &v1_active_near("strong", false, true, false),
+    );
+}
+
+#[test]
+fn v1_active_restrict_self_false_is_nonzero_empty_stdout() {
+    assert_fail_body(
+        "v1-active-restrict-false.json",
+        &v1_active_near("strong", true, false, false),
+    );
 }

--- a/crates/assay-cli/tests/project_enforcement_health_cli.rs
+++ b/crates/assay-cli/tests/project_enforcement_health_cli.rs
@@ -1,0 +1,212 @@
+//! #2511: project one existing enforcement-health document.
+//!
+//! `assay project-enforcement-health --format json --input PATH`
+//!
+//! Success bytes are exact. Fail-closed paths are nonzero with empty stdout.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+
+const SCHEMA: &str = "assay.enforcement_health_projection.v0";
+const V0: &str = "assay.enforcement_health.v0";
+const V1: &str = "assay.enforcement_health.v1";
+/// Same cap the CLI must apply before parse. A syntactically valid document
+/// larger than this must fail closed.
+const MAX_INPUT_BYTES: usize = 65_536;
+
+fn assay() -> Command {
+    Command::cargo_bin("assay").expect("binary")
+}
+
+fn tmp() -> tempfile::TempDir {
+    tempfile::tempdir().expect("tempdir")
+}
+
+fn write(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, body).expect("write fixture");
+    path
+}
+
+fn v0(status: &str) -> String {
+    format!(
+        r#"{{"schema":"{V0}","scope":"ipv4_tcp_connect","network_enforcement":"{status}","attach_confirmed":false,"blocked_count":0,"allowed_count":0,"enforcement_class":"basic"}}"#
+    )
+}
+
+fn v1(status: &str) -> String {
+    format!(
+        r#"{{"schema":"{V1}","status":"{status}","mechanism":"landlock","scope":"tcp_connect_landlock_port","policy_semantics":"allowlist","enforcement_class":"basic","landlock":{{"abi":4,"no_new_privs_confirmed":false,"restrict_self_confirmed":false}},"probe":null,"non_claims":[]}}"#
+    )
+}
+
+fn expected(source_schema: &str, observation: &str) -> String {
+    format!(
+        r#"{{"schema":"{SCHEMA}","lossy":true,"source_schema":"{source_schema}","observation":"{observation}"}}"#
+    )
+}
+
+fn project(path: &Path) -> assert_cmd::assert::Assert {
+    assay()
+        .args([
+            "project-enforcement-health",
+            "--format",
+            "json",
+            "--input",
+            path.to_str().expect("utf8"),
+        ])
+        .assert()
+}
+
+fn assert_exact_ok(path: &Path, source_schema: &str, observation: &str) {
+    let out = project(path).success().get_output().clone();
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    let want = format!("{}\n", expected(source_schema, observation));
+    assert_eq!(
+        stdout, want,
+        "stdout must be exact projection bytes plus newline"
+    );
+}
+
+fn assert_fail_args(args: &[&str]) {
+    let out = assay().args(args).assert().failure().get_output().clone();
+    assert!(
+        out.stdout.is_empty(),
+        "fail-closed stdout must be empty, got {:?}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn v0_active_maps_to_applied() {
+    let dir = tmp();
+    let path = write(dir.path(), "v0-active.json", &v0("active"));
+    assert_exact_ok(&path, V0, "applied");
+}
+
+#[test]
+fn v0_failed_maps_to_degraded() {
+    let dir = tmp();
+    let path = write(dir.path(), "v0-failed.json", &v0("failed"));
+    assert_exact_ok(&path, V0, "degraded");
+}
+
+#[test]
+fn v0_absent_maps_to_not_requested() {
+    let dir = tmp();
+    let path = write(dir.path(), "v0-absent.json", &v0("absent"));
+    assert_exact_ok(&path, V0, "not_requested");
+}
+
+#[test]
+fn v1_active_maps_to_applied() {
+    let dir = tmp();
+    let path = write(dir.path(), "v1-active.json", &v1("active"));
+    assert_exact_ok(&path, V1, "applied");
+}
+
+#[test]
+fn v1_failed_maps_to_degraded() {
+    let dir = tmp();
+    let path = write(dir.path(), "v1-failed.json", &v1("failed"));
+    assert_exact_ok(&path, V1, "degraded");
+}
+
+#[test]
+fn source_schema_is_the_input_identity() {
+    let dir = tmp();
+    let v0_path = write(dir.path(), "src-v0.json", &v0("active"));
+    let v1_path = write(dir.path(), "src-v1.json", &v1("failed"));
+    assert_exact_ok(&v0_path, V0, "applied");
+    assert_exact_ok(&v1_path, V1, "degraded");
+}
+
+#[test]
+fn missing_input_flag_is_clap_nonzero_empty_stdout() {
+    assert_fail_args(&["project-enforcement-health", "--format", "json"]);
+}
+
+#[test]
+fn missing_path_is_nonzero_empty_stdout() {
+    assert_fail_args(&[
+        "project-enforcement-health",
+        "--format",
+        "json",
+        "--input",
+        "/no/such/enforcement-health.json",
+    ]);
+}
+
+#[test]
+fn unknown_schema_is_nonzero_empty_stdout() {
+    let dir = tmp();
+    let path = write(
+        dir.path(),
+        "unknown.json",
+        r#"{"schema":"assay.not_enforcement_health.v0"}"#,
+    );
+    assert_fail_args(&[
+        "project-enforcement-health",
+        "--format",
+        "json",
+        "--input",
+        path.to_str().unwrap(),
+    ]);
+}
+
+#[test]
+fn malformed_json_is_nonzero_empty_stdout() {
+    let dir = tmp();
+    let path = write(dir.path(), "malformed.json", "{");
+    assert_fail_args(&[
+        "project-enforcement-health",
+        "--format",
+        "json",
+        "--input",
+        path.to_str().unwrap(),
+    ]);
+}
+
+#[test]
+fn oversized_valid_json_is_nonzero_empty_stdout() {
+    let dir = tmp();
+    let mut body = v0("active");
+    body.push_str(&" ".repeat(MAX_INPUT_BYTES));
+    assert!(body.len() > MAX_INPUT_BYTES);
+    let path = write(dir.path(), "oversized.json", &body);
+    assert_fail_args(&[
+        "project-enforcement-health",
+        "--format",
+        "json",
+        "--input",
+        path.to_str().unwrap(),
+    ]);
+}
+
+#[test]
+fn forged_v1_absent_is_nonzero_empty_stdout() {
+    let dir = tmp();
+    let path = write(dir.path(), "forged-absent.json", &v1("absent"));
+    assert_fail_args(&[
+        "project-enforcement-health",
+        "--format",
+        "json",
+        "--input",
+        path.to_str().unwrap(),
+    ]);
+}
+
+#[test]
+fn v0_not_applicable_is_nonzero_empty_stdout() {
+    let dir = tmp();
+    let path = write(dir.path(), "v0-na.json", &v0("not_applicable"));
+    assert_fail_args(&[
+        "project-enforcement-health",
+        "--format",
+        "json",
+        "--input",
+        path.to_str().unwrap(),
+    ]);
+}

--- a/crates/assay-cli/tests/project_enforcement_health_cli.rs
+++ b/crates/assay-cli/tests/project_enforcement_health_cli.rs
@@ -3,6 +3,8 @@
 //! `assay project-enforcement-health --format json --input PATH`
 //!
 //! Success bytes are exact. Fail-closed paths are nonzero with empty stdout.
+//! Valid `active` fixtures are constructor-legal (v0 attach+strong; v1 both
+//! Landlock confirmations, strong, no failure). Forged `active` fails closed.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -31,14 +33,24 @@ fn write(dir: &Path, name: &str, body: &str) -> PathBuf {
 }
 
 fn v0(status: &str) -> String {
+    let (attach, class) = if status == "active" {
+        ("true", "strong")
+    } else {
+        ("false", "basic")
+    };
     format!(
-        r#"{{"schema":"{V0}","scope":"ipv4_tcp_connect","network_enforcement":"{status}","attach_confirmed":false,"blocked_count":0,"allowed_count":0,"enforcement_class":"basic"}}"#
+        r#"{{"schema":"{V0}","scope":"ipv4_tcp_connect","network_enforcement":"{status}","attach_confirmed":{attach},"blocked_count":0,"allowed_count":0,"enforcement_class":"{class}"}}"#
     )
 }
 
 fn v1(status: &str) -> String {
+    let (nnp, restrict, class) = if status == "active" {
+        ("true", "true", "strong")
+    } else {
+        ("false", "false", "basic")
+    };
     format!(
-        r#"{{"schema":"{V1}","status":"{status}","mechanism":"landlock","scope":"tcp_connect_landlock_port","policy_semantics":"allowlist","enforcement_class":"basic","landlock":{{"abi":4,"no_new_privs_confirmed":false,"restrict_self_confirmed":false}},"probe":null,"non_claims":[]}}"#
+        r#"{{"schema":"{V1}","status":"{status}","mechanism":"landlock","scope":"tcp_connect_landlock_port","policy_semantics":"allowlist","enforcement_class":"{class}","landlock":{{"abi":4,"no_new_privs_confirmed":{nnp},"restrict_self_confirmed":{restrict}}},"probe":null,"non_claims":[]}}"#
     )
 }
 
@@ -202,6 +214,40 @@ fn forged_v1_absent_is_nonzero_empty_stdout() {
 fn v0_not_applicable_is_nonzero_empty_stdout() {
     let dir = tmp();
     let path = write(dir.path(), "v0-na.json", &v0("not_applicable"));
+    assert_fail_args(&[
+        "project-enforcement-health",
+        "--format",
+        "json",
+        "--input",
+        path.to_str().unwrap(),
+    ]);
+}
+
+#[test]
+fn v0_active_without_confirmed_attach_is_nonzero_empty_stdout() {
+    let dir = tmp();
+    let path = write(
+        dir.path(),
+        "v0-forged-active.json",
+        r#"{"schema":"assay.enforcement_health.v0","scope":"ipv4_tcp_connect","network_enforcement":"active","attach_confirmed":false,"blocked_count":0,"allowed_count":0,"enforcement_class":"basic"}"#,
+    );
+    assert_fail_args(&[
+        "project-enforcement-health",
+        "--format",
+        "json",
+        "--input",
+        path.to_str().unwrap(),
+    ]);
+}
+
+#[test]
+fn v1_active_without_restrict_confirmations_is_nonzero_empty_stdout() {
+    let dir = tmp();
+    let path = write(
+        dir.path(),
+        "v1-forged-active.json",
+        r#"{"schema":"assay.enforcement_health.v1","status":"active","mechanism":"landlock","scope":"tcp_connect_landlock_port","policy_semantics":"allowlist","enforcement_class":"basic","landlock":{"abi":4,"no_new_privs_confirmed":false,"restrict_self_confirmed":false},"probe":null,"non_claims":[]}"#,
+    );
     assert_fail_args(&[
         "project-enforcement-health",
         "--format",

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -50,6 +50,7 @@ assay.cli.describe.v0 | crates/assay-cli/src/cli/commands/describe.rs | -
 assay.doctor_report.v0 | crates/assay-cli/src/cli/commands/doctor/implementation.rs | crates/assay-cli/src/diagnostics/probes.rs
 assay.enforcement_health.v0 | crates/assay-cli/src/cli/commands/monitor_next/enforcement_health.rs | -
 assay.enforcement_health.v1 | crates/assay-cli/src/enforcement_health_v1.rs | -
+assay.enforcement_health_projection.v0 | crates/assay-cli/src/cli/commands/project_enforcement_health.rs | -
 assay.evidence.schema.list.v1 | crates/assay-cli/src/cli/commands/evidence/schema/write.rs | crates/assay-cli/src/cli/commands/evidence/schema/reports.rs
 assay.evidence.schema.show.v1 | crates/assay-cli/src/cli/commands/evidence/schema/write.rs | crates/assay-cli/src/cli/commands/evidence/schema/reports.rs
 assay.evidence.schema.validation.v1 | crates/assay-cli/src/cli/commands/evidence/schema/write.rs | crates/assay-cli/src/cli/commands/evidence/schema/reports.rs

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -42,6 +42,7 @@ assay --version
 | [`assay watch`](watch.md) | Re-run on config/policy/trace changes |
 | [`assay monitor`](../../guides/runtime-monitor.md) | **Runtime Security** (Linux Kernel Enforcement) |
 | [`assay mcp`](mcp-server.md) | MCP runtime commands: wrap, preflight, discover, kill, config-path, and tool signing |
+| [`assay project-enforcement-health`](project-enforcement-health.md) | Project one existing enforcement-health document (lossy observation) |
 | [CLI Command Grouping RFC](command-grouping-rfc.md) | Selective command grouping direction and compatibility contract |
 
 ---

--- a/docs/reference/cli/project-enforcement-health.md
+++ b/docs/reference/cli/project-enforcement-health.md
@@ -1,0 +1,36 @@
+# assay project-enforcement-health
+
+Project one existing `assay.enforcement_health.v0` or `assay.enforcement_health.v1`
+document into a lossy observation.
+
+```bash
+assay project-enforcement-health --format json --input PATH
+```
+
+`--input` is required. No input means no projection document and no claim.
+
+## Output
+
+On success, stdout is exactly one `assay.enforcement_health_projection.v0` document:
+
+```json
+{"schema":"assay.enforcement_health_projection.v0","lossy":true,"source_schema":"...","observation":"applied|degraded|not_requested"}
+```
+
+`source_schema` is the input identity. Mapping:
+
+| source | source value | observation |
+|---|---|---|
+| v0 | `active` | `applied` |
+| v0 | `failed` | `degraded` |
+| v0 | `absent` | `not_requested` |
+| v1 | `active` | `applied` |
+| v1 | `failed` | `degraded` |
+
+v0 `not_applicable`, unknown schema or status, forged v1 `absent`, and
+malformed, missing, or oversized input exit nonzero with empty stdout.
+
+## Normative
+
+Absence of a projection is **no claim**. It is never a pass. This command does
+not prove enforcement efficacy, egress absence, or a sealed sandbox.

--- a/docs/reference/cli/project-enforcement-health.md
+++ b/docs/reference/cli/project-enforcement-health.md
@@ -27,8 +27,11 @@ On success, stdout is exactly one `assay.enforcement_health_projection.v0` docum
 | v1 | `active` | `applied` |
 | v1 | `failed` | `degraded` |
 
-v0 `not_applicable`, unknown schema or status, forged v1 `absent`, and
-malformed, missing, or oversized input exit nonzero with empty stdout.
+`active` maps to `applied` only when the supporting producer invariants hold
+(v0 confirmed attach and `strong`; v1 both Landlock confirmations, `strong`,
+and no failure). Constructor-illegal `active`, v0 `not_applicable`, unknown
+schema or status, forged v1 `absent`, and malformed, missing, or oversized
+input exit nonzero with empty stdout.
 
 ## Normative
 

--- a/docs/reference/cli/project-enforcement-health.md
+++ b/docs/reference/cli/project-enforcement-health.md
@@ -37,3 +37,6 @@ input exit nonzero with empty stdout.
 
 Absence of a projection is **no claim**. It is never a pass. This command does
 not prove enforcement efficacy, egress absence, or a sealed sandbox.
+
+The projection checks coherence of an already-typed document, not authenticity
+or provenance. A coherent handwritten carrier can therefore project.


### PR DESCRIPTION
## Summary

Add `assay project-enforcement-health` to project one existing health document into a lossy observation. Dispatch on the input's own `schema`; map v0/v1 status through one private `project_health`; fail closed with empty stdout on unknown, forged, missing, oversized, or constructor-illegal `active` input.

- Command: `assay project-enforcement-health --format json --input PATH`
- Success stdout is exact compact JSON plus newline from `write_stdout_json`
- Mapping: v0 `active→applied`, `failed→degraded`, `absent→not_requested`; v1 `active→applied`, `failed→degraded`
- `active` becomes `applied` only when producer invariants hold (v0 confirmed attach + `strong`; v1 both Landlock confirmations, `strong`, no failure)
- Each illegal-`active` fixture violates exactly one arm
- v0 `not_applicable`, unknown schema/status, forged v1 `absent`, constructor-illegal `active`, malformed/missing/oversized input: nonzero, empty stdout
- Parse fully into existing typed carriers, check producer-legal `active`, then reduce to private `SourceStatus`. No `Box`, no `#[allow]`, no new validator framework, no `seal_eligibility`, no `deny_unknown_fields`, no carrier change
- Identity row in `CLI-JSON-IDENTITIES.md`. Docs: absence of a projection is never a pass. The projection checks coherence, not authenticity or provenance; a coherent handwritten carrier can therefore project

Refs #2511. Does not implement #2641.

## Evidence (Darwin writer)

- Base: `147c87843441b90b5bc6a78b9abe04556463d4ed`
- Head: `8ae069ca547cff855e9825511a1becae76a32b86`
- Allowlist this follow-up: `project_enforcement_health_cli.rs`, `docs/reference/cli/project-enforcement-health.md` (test + docs only; no production-code change)
- RED then GREEN: `project_enforcement_health_cli` 19/19
- Legal controls: constructor-legal v0 `active`; committed `tests/fixtures/enforcement_health/v1/active_no_probe.json`
- Also GREEN: `cli_json_identities` 14/14, `stdout_json_write_contract` 31/31 (+1 ignored), `contract_docs_generate_explain` 2/2
- `cargo fmt --all -- --check`, `cargo clippy -p assay-cli -- -D warnings`, `git diff --check` clean

### Arm-level mutations on `8ae069ca547cff855e9825511a1becae76a32b86`

Drop exactly one production conjunct; matching near-miss RED; legal `active` GREEN; restore.

| # | Dropped arm | RED near-miss | Control GREEN |
|---|---|---|---|
| A | v0 `attach_confirmed` | `v0_active_attach_false_strong_is_nonzero_empty_stdout` | `v0_active_maps_to_applied` |
| B | v0 `enforcement_class == Strong` | `v0_active_attach_true_basic_is_nonzero_empty_stdout` | `v0_active_maps_to_applied` |
| C | v1 `failure.is_none()` | `v1_active_with_failure_is_nonzero_empty_stdout` | `v1_active_maps_to_applied` (committed `active_no_probe`) |
| D | v1 `enforcement_class == Strong` | `v1_active_basic_class_is_nonzero_empty_stdout` | `v1_active_maps_to_applied` |
| E | v1 `no_new_privs_confirmed` | `v1_active_no_new_privs_false_is_nonzero_empty_stdout` | `v1_active_maps_to_applied` |
| F | v1 `restrict_self_confirmed` | `v1_active_restrict_self_false_is_nonzero_empty_stdout` | `v1_active_maps_to_applied` |

Tree restored after each arm. Failed stays status-only.

## Non-claims

- Projects one observed health document. Not a domain survey, whole-action verdict, audit-fallback proof, capability report, or egress-absence claim
- Absence of a projection is no claim and never a pass
- Coherence is not authenticity or provenance: a coherent handwritten carrier can project
- Does not implement #2641 (`assay.sandbox.degraded` bundle path)
- No Profile/doctor/bundle/stderr input. No synthetic no-claim document. No `--out`
- No Landlock / seal / enforcement-efficacy proof
- macOS/Windows CI excludes `assay-cli`; these tests bind on Linux CI

## Test plan

- [x] 19 focused CLI tests (mapping + fail-closed, including six one-arm near-misses)
- [x] Arm-level mutations A–F, each relevant target RED and legal `active` GREEN
- [x] Identities table, stdout write contract, docs generate/explain
- [ ] Linux CI `assay-cli` tests on this head