### PR TITLE
feat(cli): dump resolved policy as assay.policy.resolved.v0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- `assay policy resolve --format json` emits one `assay.policy.resolved.v0`
-  document after the same load and schema-compile path as `assay policy validate`.
-  The whole-policy digest is `McpPolicy::policy_digest()` under `jcs:mcp_policy`.
-  Validate stdout stays `assay.run_summary.v1` (#2510).
+- `assay policy resolve --input PATH --format json` emits one
+  `assay.policy.resolved.v0` document after the same load and schema-compile
+  path as `assay policy validate`. The whole-policy digest is
+  `McpPolicy::policy_digest()` under `jcs:mcp_policy`. Malformed YAML keeps
+  typed `E_POLICY_PARSE` on stderr with empty stdout. Validate stdout stays
+  `assay.run_summary.v1` (#2510).
 
 - The Claude plugin workflow now runs its bounded model session with
   `--output-format stream-json --verbose` and classifies the transcript through one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `assay policy resolve --format json` emits one `assay.policy.resolved.v0`
+  document after the same load and schema-compile path as `assay policy validate`.
+  The whole-policy digest is `McpPolicy::policy_digest()` under `jcs:mcp_policy`.
+  Validate stdout stays `assay.run_summary.v1` (#2510).
+
 - The Claude plugin workflow now runs its bounded model session with
   `--output-format stream-json --verbose` and classifies the transcript through one
   validator, `classify_model_mediated_call`, that fixture replay and the live path both

--- a/crates/assay-cli/src/cli/args/policy.rs
+++ b/crates/assay-cli/src/cli/args/policy.rs
@@ -30,6 +30,9 @@ pub enum PolicyCommand {
 
     /// Format policy YAML (normalizes formatting)
     Fmt(PolicyFmtArgs),
+
+    /// Dump the resolved policy this Assay version would load
+    Resolve(PolicyResolveArgs),
 }
 
 #[derive(Args, Clone, Debug)]
@@ -81,4 +84,19 @@ pub struct PolicyFmtArgs {
     /// Output file (default: overwrite input)
     #[arg(short, long)]
     pub output: Option<PathBuf>,
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct PolicyResolveArgs {
+    /// Policy file path (YAML)
+    #[arg(short, long)]
+    pub input: PathBuf,
+
+    /// Fail if deprecated v1 policy format is detected
+    #[arg(long)]
+    pub deny_deprecations: bool,
+
+    /// Output format; only json emits a document
+    #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+    pub format: OutputFormat,
 }

--- a/crates/assay-cli/src/cli/args/policy.rs
+++ b/crates/assay-cli/src/cli/args/policy.rs
@@ -92,10 +92,6 @@ pub struct PolicyResolveArgs {
     #[arg(short, long)]
     pub input: PathBuf,
 
-    /// Fail if deprecated v1 policy format is detected
-    #[arg(long)]
-    pub deny_deprecations: bool,
-
     /// Output format; only json emits a document
     #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
     pub format: OutputFormat,

--- a/crates/assay-cli/src/cli/commands/policy/mod.rs
+++ b/crates/assay-cli/src/cli/commands/policy/mod.rs
@@ -3,7 +3,21 @@ pub mod migrate;
 pub mod resolve;
 pub mod validate;
 
+use std::path::Path;
+
 use crate::cli::args::{PolicyArgs, PolicyCommand};
+use crate::cli_failure::CliFailure;
+
+/// Shared load-error classifier for `policy validate` and `policy resolve`.
+pub(crate) fn classify_load_error(path: &Path, error: anyhow::Error) -> anyhow::Error {
+    if error
+        .downcast_ref::<assay_core::mcp::policy::McpPolicyError>()
+        .is_some_and(|error| error.is_parse_failure())
+    {
+        return CliFailure::policy_parse(path, error).into();
+    }
+    error.context(format!("failed to load policy {}", path.display()))
+}
 
 pub async fn run(args: PolicyArgs) -> anyhow::Result<i32> {
     match args.cmd {

--- a/crates/assay-cli/src/cli/commands/policy/mod.rs
+++ b/crates/assay-cli/src/cli/commands/policy/mod.rs
@@ -1,5 +1,6 @@
 pub mod fmt;
 pub mod migrate;
+pub mod resolve;
 pub mod validate;
 
 use crate::cli::args::{PolicyArgs, PolicyCommand};
@@ -11,5 +12,6 @@ pub async fn run(args: PolicyArgs) -> anyhow::Result<i32> {
         PolicyCommand::Validate(a) => validate::run(a).await,
         PolicyCommand::Migrate(a) => migrate::run(a).await,
         PolicyCommand::Fmt(a) => fmt::run(a).await,
+        PolicyCommand::Resolve(a) => resolve::run(a).await,
     }
 }

--- a/crates/assay-cli/src/cli/commands/policy/resolve.rs
+++ b/crates/assay-cli/src/cli/commands/policy/resolve.rs
@@ -1,0 +1,84 @@
+//! `assay policy resolve` — dump the policy this Assay version would load.
+//!
+//! Guardrail: one `McpPolicy::policy_digest()` call is the only digest authority.
+//! The CLI does not call JCS itself.
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use assay_common::limits::{LimitKind, LimitReader};
+use assay_core::mcp::policy::McpPolicy;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::cli::args::{OutputFormat, PolicyResolveArgs};
+use crate::exit_codes::EXIT_CONFIG_ERROR;
+use crate::output_write::write_stdout_json;
+
+pub const SCHEMA_RESOLVED_V0: &str = "assay.policy.resolved.v0";
+/// Must stay equal to `POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY`.
+const CANONICALIZATION_PROFILE: &str = "jcs:mcp_policy";
+const MAX_INPUT_BYTES: u64 = 1_000_000;
+
+#[derive(Serialize)]
+struct ResolvedDocument {
+    schema: &'static str,
+    canonicalization_profile: &'static str,
+    assay_version: &'static str,
+    input_sha256: String,
+    policy_digest: String,
+    policy: serde_json::Value,
+}
+
+fn fail_closed() -> anyhow::Result<i32> {
+    Ok(EXIT_CONFIG_ERROR)
+}
+
+fn read_bounded(path: &Path) -> Result<Vec<u8>, ()> {
+    let file = File::open(path).map_err(|_| ())?;
+    let mut reader = LimitReader::new(file, MAX_INPUT_BYTES, LimitKind::SourceBytes);
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf).map_err(|_| ())?;
+    Ok(buf)
+}
+
+fn input_sha256(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{}", hex::encode(hasher.finalize()))
+}
+
+pub async fn run(args: PolicyResolveArgs) -> anyhow::Result<i32> {
+    if args.format != OutputFormat::Json {
+        return fail_closed();
+    }
+    if args.deny_deprecations {
+        std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1");
+    }
+    let bytes = match read_bounded(&args.input) {
+        Ok(bytes) => bytes,
+        Err(()) => return fail_closed(),
+    };
+    let policy = match McpPolicy::from_slice(&bytes) {
+        Ok(policy) => policy,
+        Err(_) => return fail_closed(),
+    };
+    if policy.try_compile_all_schemas().is_err() {
+        return fail_closed();
+    }
+    let Some(policy_digest) = policy.policy_digest() else {
+        return fail_closed();
+    };
+    let policy_value = serde_json::to_value(&policy)?;
+    let document = ResolvedDocument {
+        schema: SCHEMA_RESOLVED_V0,
+        canonicalization_profile: CANONICALIZATION_PROFILE,
+        assay_version: env!("CARGO_PKG_VERSION"),
+        input_sha256: input_sha256(&bytes),
+        policy_digest,
+        policy: policy_value,
+    };
+    let json = serde_json::to_string(&document)?;
+    Ok(write_stdout_json(&json))
+}

--- a/crates/assay-cli/src/cli/commands/policy/resolve.rs
+++ b/crates/assay-cli/src/cli/commands/policy/resolve.rs
@@ -8,6 +8,7 @@ use std::io::Read;
 use std::path::Path;
 
 use assay_common::limits::{LimitKind, LimitReader};
+use assay_core::mcp::decision::POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY;
 use assay_core::mcp::policy::McpPolicy;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -17,8 +18,6 @@ use crate::exit_codes::EXIT_CONFIG_ERROR;
 use crate::output_write::write_stdout_json;
 
 pub const SCHEMA_RESOLVED_V0: &str = "assay.policy.resolved.v0";
-/// Must stay equal to `POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY`.
-const CANONICALIZATION_PROFILE: &str = "jcs:mcp_policy";
 const MAX_INPUT_BYTES: u64 = 1_000_000;
 
 #[derive(Serialize)]
@@ -31,15 +30,11 @@ struct ResolvedDocument {
     policy: serde_json::Value,
 }
 
-fn fail_closed() -> anyhow::Result<i32> {
-    Ok(EXIT_CONFIG_ERROR)
-}
-
-fn read_bounded(path: &Path) -> Result<Vec<u8>, ()> {
-    let file = File::open(path).map_err(|_| ())?;
+fn read_bounded(path: &Path) -> anyhow::Result<Vec<u8>> {
+    let file = File::open(path)?;
     let mut reader = LimitReader::new(file, MAX_INPUT_BYTES, LimitKind::SourceBytes);
     let mut buf = Vec::new();
-    reader.read_to_end(&mut buf).map_err(|_| ())?;
+    reader.read_to_end(&mut buf)?;
     Ok(buf)
 }
 
@@ -51,29 +46,23 @@ fn input_sha256(bytes: &[u8]) -> String {
 
 pub async fn run(args: PolicyResolveArgs) -> anyhow::Result<i32> {
     if args.format != OutputFormat::Json {
-        return fail_closed();
+        return Ok(EXIT_CONFIG_ERROR);
     }
-    if args.deny_deprecations {
-        std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1");
-    }
-    let bytes = match read_bounded(&args.input) {
-        Ok(bytes) => bytes,
-        Err(()) => return fail_closed(),
-    };
-    let policy = match McpPolicy::from_slice(&bytes) {
-        Ok(policy) => policy,
-        Err(_) => return fail_closed(),
-    };
-    if policy.try_compile_all_schemas().is_err() {
-        return fail_closed();
-    }
-    let Some(policy_digest) = policy.policy_digest() else {
-        return fail_closed();
-    };
+    let bytes = read_bounded(&args.input).map_err(|error| {
+        error.context(format!("failed to load policy {}", args.input.display()))
+    })?;
+    let policy = McpPolicy::from_slice(&bytes)
+        .map_err(|error| super::classify_load_error(&args.input, error))?;
+    policy
+        .try_compile_all_schemas()
+        .map_err(|error| anyhow::anyhow!("policy schemas failed to compile: {error}"))?;
+    let policy_digest = policy
+        .policy_digest()
+        .ok_or_else(|| anyhow::anyhow!("failed to canonicalize policy digest"))?;
     let policy_value = serde_json::to_value(&policy)?;
     let document = ResolvedDocument {
         schema: SCHEMA_RESOLVED_V0,
-        canonicalization_profile: CANONICALIZATION_PROFILE,
+        canonicalization_profile: POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY,
         assay_version: env!("CARGO_PKG_VERSION"),
         input_sha256: input_sha256(&bytes),
         policy_digest,

--- a/crates/assay-cli/src/cli/commands/policy/validate.rs
+++ b/crates/assay-cli/src/cli/commands/policy/validate.rs
@@ -1,7 +1,5 @@
-use std::path::Path;
-
 use crate::cli::args::PolicyValidateArgs;
-use crate::cli_failure::{summary_from_outcome, write_summary_stdout, CliFailure};
+use crate::cli_failure::{summary_from_outcome, write_summary_stdout};
 use crate::exit_codes;
 use crate::exit_codes::RunOutcome;
 use anyhow::Result;
@@ -13,7 +11,7 @@ pub async fn run(args: PolicyValidateArgs) -> Result<i32> {
 
     // Let core handle parsing + auto-migration warnings.
     let policy = assay_core::mcp::policy::McpPolicy::from_file(&args.input)
-        .map_err(|error| classify_load_error(&args.input, error))?;
+        .map_err(|error| super::classify_load_error(&args.input, error))?;
 
     // Force schema compilation so failures happen here (not at runtime).
     policy
@@ -27,14 +25,4 @@ pub async fn run(args: PolicyValidateArgs) -> Result<i32> {
         return Ok(write_summary_stdout(&summary));
     }
     Ok(exit_codes::OK)
-}
-
-fn classify_load_error(path: &Path, error: anyhow::Error) -> anyhow::Error {
-    if error
-        .downcast_ref::<assay_core::mcp::policy::McpPolicyError>()
-        .is_some_and(|error| error.is_parse_failure())
-    {
-        return CliFailure::policy_parse(path, error).into();
-    }
-    error.context(format!("failed to load policy {}", path.display()))
 }

--- a/crates/assay-cli/tests/policy_resolve_cli.rs
+++ b/crates/assay-cli/tests/policy_resolve_cli.rs
@@ -1,0 +1,229 @@
+//! #2510: `assay policy resolve --input PATH --format json`
+//!
+//! Success stdout is one `assay.policy.resolved.v0` document. Fail-closed
+//! paths are nonzero with empty stdout. Validate JSON stays `assay.run_summary.v1`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assay_core::mcp::policy::McpPolicy;
+use assert_cmd::Command;
+use serde_json::Value;
+
+const SCHEMA: &str = "assay.policy.resolved.v0";
+const PROFILE: &str = "jcs:mcp_policy";
+const MAX_INPUT_BYTES: usize = 1_000_000;
+
+const VALID: &str = r#"version: "2.0"
+name: resolve-fixture
+tools:
+  allow:
+    - echo
+"#;
+
+const REORDERED: &str = r#"name: resolve-fixture
+tools:
+  allow:
+    - echo
+version: "2.0"
+"#;
+
+const EFFECTIVE: &str = r#"version: "2.0"
+name: resolve-fixture
+tools:
+  allow:
+    - echo
+    - extra
+"#;
+
+const LEGACY: &str = r#"version: "1.0"
+allow:
+  - echo
+"#;
+
+const LEGACY_NORMALIZED: &str = r#"version: "1.0"
+tools:
+  allow:
+    - echo
+"#;
+
+const BAD_SCHEMA: &str = r#"version: "2.0"
+tools:
+  allow: [demo]
+schemas:
+  demo:
+    type: object
+    properties:
+      value:
+        type: string
+        pattern: "["
+"#;
+
+fn assay() -> Command {
+    Command::cargo_bin("assay").expect("binary")
+}
+
+fn tmp() -> tempfile::TempDir {
+    tempfile::tempdir().expect("tempdir")
+}
+
+fn write(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, body).expect("write fixture");
+    path
+}
+
+fn resolve(path: &Path) -> assert_cmd::assert::Assert {
+    assay()
+        .args([
+            "policy",
+            "resolve",
+            "--input",
+            path.to_str().expect("utf8"),
+            "--format",
+            "json",
+        ])
+        .assert()
+}
+
+fn parse_ok(path: &Path) -> Value {
+    let out = resolve(path).success().get_output().clone();
+    serde_json::from_slice(&out.stdout).expect("resolved json")
+}
+
+fn assert_fail_empty(path: &Path) {
+    let out = resolve(path).failure().get_output().clone();
+    assert!(
+        out.stdout.is_empty(),
+        "fail-closed stdout must be empty, got {:?}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn valid_policy_emits_resolved_v0() {
+    let dir = tmp();
+    let path = write(dir.path(), "ok.yaml", VALID);
+    let v = parse_ok(&path);
+    assert_eq!(v["schema"], SCHEMA);
+    assert_eq!(v["canonicalization_profile"], PROFILE);
+    assert_eq!(v["assay_version"], env!("CARGO_PKG_VERSION"));
+    assert!(
+        v["input_sha256"]
+            .as_str()
+            .is_some_and(|s| s.starts_with("sha256:")),
+        "input_sha256 {v:?}"
+    );
+    assert!(
+        v["policy_digest"]
+            .as_str()
+            .is_some_and(|s| s.starts_with("sha256:")),
+        "policy_digest {v:?}"
+    );
+    assert!(v.get("policy").is_some(), "policy object required");
+    assert!(v.get("schema_version").is_none());
+    assert!(v.get("path").is_none());
+    assert!(v.get("input").is_none());
+    assert!(v.get("declared_constraint_digest").is_none());
+    assert!(v.get("declared_constraint_digest_experimental").is_none());
+    let loaded = McpPolicy::from_slice(VALID.as_bytes()).expect("load");
+    assert_eq!(
+        v["policy_digest"],
+        loaded.policy_digest().expect("digest"),
+        "document digest must be McpPolicy::policy_digest()"
+    );
+}
+
+#[test]
+fn effective_change_moves_digest_not_schema() {
+    let dir = tmp();
+    let a = parse_ok(&write(dir.path(), "a.yaml", VALID));
+    let b = parse_ok(&write(dir.path(), "b.yaml", EFFECTIVE));
+    assert_eq!(a["schema"], b["schema"]);
+    assert_ne!(a["policy_digest"], b["policy_digest"]);
+}
+
+#[test]
+fn reordered_equivalent_mapping_does_not_move_digest() {
+    let dir = tmp();
+    let a = parse_ok(&write(dir.path(), "a.yaml", VALID));
+    let b = parse_ok(&write(dir.path(), "b.yaml", REORDERED));
+    assert_eq!(a["policy_digest"], b["policy_digest"]);
+    assert_ne!(
+        a["input_sha256"], b["input_sha256"],
+        "source bytes differ so input_sha256 must move"
+    );
+}
+
+#[test]
+fn path_rename_does_not_move_digest_or_input_hash() {
+    let dir = tmp();
+    let a = write(dir.path(), "one.yaml", VALID);
+    let b = write(dir.path(), "two.yaml", VALID);
+    let va = parse_ok(&a);
+    let vb = parse_ok(&b);
+    assert_eq!(va["policy_digest"], vb["policy_digest"]);
+    assert_eq!(va["input_sha256"], vb["input_sha256"]);
+    assert_eq!(va["policy"], vb["policy"]);
+}
+
+#[test]
+fn legacy_normalized_form_is_digested() {
+    let dir = tmp();
+    let a = parse_ok(&write(dir.path(), "legacy.yaml", LEGACY));
+    let b = parse_ok(&write(dir.path(), "norm.yaml", LEGACY_NORMALIZED));
+    assert_eq!(a["policy_digest"], b["policy_digest"]);
+}
+
+#[test]
+fn schema_compilation_failure_emits_no_document() {
+    let dir = tmp();
+    assert_fail_empty(&write(dir.path(), "bad-schema.yaml", BAD_SCHEMA));
+}
+
+#[test]
+fn malformed_yaml_emits_no_document() {
+    let dir = tmp();
+    assert_fail_empty(&write(dir.path(), "bad.yaml", ":\n  -"));
+}
+
+#[test]
+fn oversized_input_emits_no_document() {
+    let dir = tmp();
+    let mut body = VALID.to_string();
+    body.push_str(&" ".repeat(MAX_INPUT_BYTES));
+    assert!(body.len() > MAX_INPUT_BYTES);
+    assert_fail_empty(&write(dir.path(), "huge.yaml", &body));
+}
+
+#[test]
+fn missing_input_is_clap_nonzero_empty_stdout() {
+    let out = assay()
+        .args(["policy", "resolve", "--format", "json"])
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    assert!(out.stdout.is_empty());
+}
+
+#[test]
+fn validate_json_stays_run_summary_v1() {
+    let dir = tmp();
+    let path = write(dir.path(), "ok.yaml", VALID);
+    let out = assay()
+        .args([
+            "policy",
+            "validate",
+            "--input",
+            path.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let v: Value = serde_json::from_slice(&out.stdout).expect("validate json");
+    assert_eq!(v["schema"], "assay.run_summary.v1");
+}

--- a/crates/assay-cli/tests/policy_resolve_cli.rs
+++ b/crates/assay-cli/tests/policy_resolve_cli.rs
@@ -1,17 +1,16 @@
 //! #2510: `assay policy resolve --input PATH --format json`
 //!
 //! Success stdout is one `assay.policy.resolved.v0` document. Fail-closed
-//! paths are nonzero with empty stdout. Validate JSON stays `assay.run_summary.v1`.
+//! paths keep empty stdout. Validate JSON stays `assay.run_summary.v1`.
 
-use std::fs;
-use std::path::{Path, PathBuf};
-
+use assay_core::fingerprint::sha256_hex;
+use assay_core::mcp::decision::POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY;
+use assay_core::mcp::jcs;
 use assay_core::mcp::policy::McpPolicy;
 use assert_cmd::Command;
 use serde_json::Value;
 
 const SCHEMA: &str = "assay.policy.resolved.v0";
-const PROFILE: &str = "jcs:mcp_policy";
 const MAX_INPUT_BYTES: usize = 1_000_000;
 
 const VALID: &str = r#"version: "2.0"
@@ -47,6 +46,17 @@ tools:
     - echo
 "#;
 
+const V1_CONSTRAINTS: &str = r#"version: "1.0"
+name: resolve-legacy
+allow:
+  - read_file
+constraints:
+  - tool: "read_file"
+    params:
+      path:
+        matches: "^/app/.*"
+"#;
+
 const BAD_SCHEMA: &str = r#"version: "2.0"
 tools:
   allow: [demo]
@@ -67,13 +77,13 @@ fn tmp() -> tempfile::TempDir {
     tempfile::tempdir().expect("tempdir")
 }
 
-fn write(dir: &Path, name: &str, body: &str) -> PathBuf {
+fn write(dir: &std::path::Path, name: &str, body: &str) -> std::path::PathBuf {
     let path = dir.join(name);
-    fs::write(&path, body).expect("write fixture");
+    std::fs::write(&path, body).expect("write fixture");
     path
 }
 
-fn resolve(path: &Path) -> assert_cmd::assert::Assert {
+fn resolve(path: &std::path::Path) -> assert_cmd::assert::Assert {
     assay()
         .args([
             "policy",
@@ -86,17 +96,30 @@ fn resolve(path: &Path) -> assert_cmd::assert::Assert {
         .assert()
 }
 
-fn parse_ok(path: &Path) -> Value {
+fn parse_ok(path: &std::path::Path) -> Value {
     let out = resolve(path).success().get_output().clone();
     serde_json::from_slice(&out.stdout).expect("resolved json")
 }
 
-fn assert_fail_empty(path: &Path) {
-    let out = resolve(path).failure().get_output().clone();
+fn assert_empty_stdout_failure(output: &std::process::Output) {
     assert!(
-        out.stdout.is_empty(),
+        output.stdout.is_empty(),
         "fail-closed stdout must be empty, got {:?}",
-        String::from_utf8_lossy(&out.stdout)
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+fn assert_reconstructable(v: &Value) {
+    assert_eq!(v["schema"], SCHEMA);
+    assert_eq!(
+        v["canonicalization_profile"],
+        POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY
+    );
+    let canonical = jcs::to_string(&v["policy"]).expect("jcs of emitted policy");
+    let digest = format!("sha256:{}", sha256_hex(&canonical));
+    assert_eq!(
+        v["policy_digest"], digest,
+        "RFC8785/JCS of emitted policy must hash to policy_digest"
     );
 }
 
@@ -105,8 +128,7 @@ fn valid_policy_emits_resolved_v0() {
     let dir = tmp();
     let path = write(dir.path(), "ok.yaml", VALID);
     let v = parse_ok(&path);
-    assert_eq!(v["schema"], SCHEMA);
-    assert_eq!(v["canonicalization_profile"], PROFILE);
+    assert_reconstructable(&v);
     assert_eq!(v["assay_version"], env!("CARGO_PKG_VERSION"));
     assert!(
         v["input_sha256"]
@@ -114,13 +136,6 @@ fn valid_policy_emits_resolved_v0() {
             .is_some_and(|s| s.starts_with("sha256:")),
         "input_sha256 {v:?}"
     );
-    assert!(
-        v["policy_digest"]
-            .as_str()
-            .is_some_and(|s| s.starts_with("sha256:")),
-        "policy_digest {v:?}"
-    );
-    assert!(v.get("policy").is_some(), "policy object required");
     assert!(v.get("schema_version").is_none());
     assert!(v.get("path").is_none());
     assert!(v.get("input").is_none());
@@ -132,6 +147,33 @@ fn valid_policy_emits_resolved_v0() {
         loaded.policy_digest().expect("digest"),
         "document digest must be McpPolicy::policy_digest()"
     );
+}
+
+#[test]
+fn emitted_policy_jcs_reconstructs_digest_for_legacy_v1() {
+    let dir = tmp();
+    assert_reconstructable(&parse_ok(&write(dir.path(), "legacy.yaml", LEGACY)));
+    assert_reconstructable(&parse_ok(&write(
+        dir.path(),
+        "constraints.yaml",
+        V1_CONSTRAINTS,
+    )));
+}
+
+#[test]
+fn v1_constraints_are_normalized_into_schemas() {
+    let dir = tmp();
+    let v = parse_ok(&write(dir.path(), "v1.yaml", V1_CONSTRAINTS));
+    assert!(
+        v["policy"]["schemas"]["read_file"].is_object(),
+        "v1 constraints must become schemas: {v:?}"
+    );
+    assert_eq!(
+        v["policy"]["constraints"],
+        serde_json::json!([]),
+        "migrated constraints must be empty"
+    );
+    assert_reconstructable(&v);
 }
 
 #[test]
@@ -178,13 +220,52 @@ fn legacy_normalized_form_is_digested() {
 #[test]
 fn schema_compilation_failure_emits_no_document() {
     let dir = tmp();
-    assert_fail_empty(&write(dir.path(), "bad-schema.yaml", BAD_SCHEMA));
+    let out = resolve(&write(dir.path(), "bad-schema.yaml", BAD_SCHEMA))
+        .failure()
+        .get_output()
+        .clone();
+    assert_empty_stdout_failure(&out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("policy schemas failed to compile"),
+        "schema failure must stay honest stderr-only: {stderr}"
+    );
+    assert!(
+        !stderr.contains("E_POLICY_PARSE"),
+        "schema compile must not be typed as parse: {stderr}"
+    );
 }
 
 #[test]
 fn malformed_yaml_emits_no_document() {
     let dir = tmp();
-    assert_fail_empty(&write(dir.path(), "bad.yaml", ":\n  -"));
+    let out = resolve(&write(dir.path(), "bad.yaml", ":\n  -"))
+        .failure()
+        .get_output()
+        .clone();
+    assert_empty_stdout_failure(&out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("E_POLICY_PARSE"),
+        "malformed policy must retain typed E_POLICY_PARSE: {stderr}"
+    );
+}
+
+#[test]
+fn missing_policy_file_is_untyped_stderr() {
+    let dir = tmp();
+    let path = dir.path().join("missing.yaml");
+    let out = resolve(&path).failure().get_output().clone();
+    assert_empty_stdout_failure(&out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("failed to load policy") || stderr.contains("fatal:"),
+        "missing file must stay honest stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("E_POLICY_PARSE"),
+        "missing file must not be typed as parse: {stderr}"
+    );
 }
 
 #[test]
@@ -193,7 +274,11 @@ fn oversized_input_emits_no_document() {
     let mut body = VALID.to_string();
     body.push_str(&" ".repeat(MAX_INPUT_BYTES));
     assert!(body.len() > MAX_INPUT_BYTES);
-    assert_fail_empty(&write(dir.path(), "huge.yaml", &body));
+    let out = resolve(&write(dir.path(), "huge.yaml", &body))
+        .failure()
+        .get_output()
+        .clone();
+    assert_empty_stdout_failure(&out);
 }
 
 #[test]
@@ -205,6 +290,23 @@ fn missing_input_is_clap_nonzero_empty_stdout() {
         .get_output()
         .clone();
     assert!(out.stdout.is_empty());
+}
+
+#[test]
+fn deny_deprecations_is_not_a_resolve_flag() {
+    let out = assay()
+        .args(["policy", "resolve", "--help"])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("deny-deprecations"),
+        "resolve must not expose --deny-deprecations: {stdout}"
+    );
+    assert!(stdout.contains("--input"));
+    assert!(stdout.contains("--format"));
 }
 
 #[test]

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -144,7 +144,8 @@ pub enum ArgsCheck {
 
 /// Canonical JCS bytes of a loaded `McpPolicy`. Shared by `policy_digest`.
 pub(crate) fn canonical_mcp_policy_jcs(policy: &McpPolicy) -> anyhow::Result<String> {
-    jcs::to_string(policy)
+    let value = serde_json::to_value(policy)?;
+    jcs::to_string(&value)
 }
 
 impl McpPolicy {
@@ -589,6 +590,56 @@ tools:
 
     fn load(src: &str) -> McpPolicy {
         McpPolicy::from_slice(src.as_bytes()).expect("load")
+    }
+
+    const V1_CONSTRAINTS: &str = r#"version: "1.0"
+name: resolve-legacy
+allow:
+  - read_file
+constraints:
+  - tool: "read_file"
+    params:
+      path:
+        matches: "^/app/.*"
+"#;
+
+    #[test]
+    fn helper_serializer_is_rfc8785_jcs_of_policy_value() {
+        let p = load(VALID);
+        let value = serde_json::to_value(&p).expect("value");
+        let via_jcs = crate::mcp::jcs::to_string(&value).expect("jcs");
+        let helper = canonical_mcp_policy_jcs(&p).expect("helper");
+        assert_eq!(
+            helper, via_jcs,
+            "helper must be RFC8785/JCS of the policy Value"
+        );
+        let via_json = serde_json::to_string(&p).expect("json");
+        assert_ne!(
+            helper, via_json,
+            "fixture must distinguish JCS from serde_json so a helper-serializer mutation bites"
+        );
+    }
+
+    #[test]
+    fn v1_constraints_normalized_digest_differs_from_raw_yaml_jcs() {
+        let loaded = load(V1_CONSTRAINTS);
+        assert!(loaded.constraints.is_empty());
+        assert!(loaded.schemas.contains_key("read_file"));
+        let normalized = canonical_mcp_policy_jcs(&loaded).expect("normalized jcs");
+        let raw = serde_json::json!({
+            "version": "1.0",
+            "name": "resolve-legacy",
+            "allow": ["read_file"],
+            "constraints": [{
+                "tool": "read_file",
+                "params": {"path": {"matches": "^/app/.*"}}
+            }]
+        });
+        let raw_jcs = crate::mcp::jcs::to_string(&raw).expect("raw jcs");
+        assert_ne!(
+            normalized, raw_jcs,
+            "raw-parse JCS must not be the normalized digest preimage"
+        );
     }
 
     #[test]

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -142,6 +142,11 @@ pub enum ArgsCheck {
     Malformed,
 }
 
+/// Canonical JCS bytes of a loaded `McpPolicy`. Shared by `policy_digest`.
+pub(crate) fn canonical_mcp_policy_jcs(policy: &McpPolicy) -> anyhow::Result<String> {
+    jcs::to_string(policy)
+}
+
 impl McpPolicy {
     pub fn new() -> Self {
         Self::default()
@@ -223,7 +228,7 @@ impl McpPolicy {
     }
 
     pub fn policy_digest(&self) -> Option<String> {
-        let canonical = jcs::to_string(self).ok()?;
+        let canonical = canonical_mcp_policy_jcs(self).ok()?;
         Some(format!("sha256:{}", sha256_hex(&canonical)))
     }
 
@@ -542,5 +547,75 @@ mod declared_constraint_digest_experimental_tests {
         )
         .declared_constraint_digest_experimental();
         assert_ne!(explicit_only, legacy_new_tool);
+    }
+}
+
+#[cfg(test)]
+mod resolve_digest_tests {
+    use super::*;
+
+    const VALID: &str = r#"version: "2.0"
+name: resolve-fixture
+tools:
+  allow:
+    - echo
+"#;
+
+    const REORDERED: &str = r#"name: resolve-fixture
+tools:
+  allow:
+    - echo
+version: "2.0"
+"#;
+
+    const EFFECTIVE: &str = r#"version: "2.0"
+name: resolve-fixture
+tools:
+  allow:
+    - echo
+    - extra
+"#;
+
+    const LEGACY: &str = r#"version: "1.0"
+allow:
+  - echo
+"#;
+
+    const LEGACY_NORMALIZED: &str = r#"version: "1.0"
+tools:
+  allow:
+    - echo
+"#;
+
+    fn load(src: &str) -> McpPolicy {
+        McpPolicy::from_slice(src.as_bytes()).expect("load")
+    }
+
+    #[test]
+    fn canonical_helper_is_policy_digest_preimage() {
+        let p = load(VALID);
+        let via_helper = format!(
+            "sha256:{}",
+            sha256_hex(&canonical_mcp_policy_jcs(&p).expect("jcs"))
+        );
+        assert_eq!(p.policy_digest().as_deref(), Some(via_helper.as_str()));
+    }
+
+    #[test]
+    fn reordered_mapping_does_not_move_digest() {
+        assert_eq!(load(VALID).policy_digest(), load(REORDERED).policy_digest());
+    }
+
+    #[test]
+    fn effective_change_moves_digest() {
+        assert_ne!(load(VALID).policy_digest(), load(EFFECTIVE).policy_digest());
+    }
+
+    #[test]
+    fn legacy_and_normalized_share_digest() {
+        assert_eq!(
+            load(LEGACY).policy_digest(),
+            load(LEGACY_NORMALIZED).policy_digest()
+        );
     }
 }

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -63,6 +63,7 @@ assay.mcp_preflight.v0 | crates/assay-cli/src/cli/commands/mcp/preflight.rs | -
 assay.mcp_server_inventory.v0 | crates/assay-cli/src/cli/commands/inventory.rs | crates/assay-core/src/discovery/inventory_carrier.rs
 assay.monitor.observed_peers.v0 | crates/assay-cli/src/cli/commands/monitor_next/observed_peers.rs | -
 assay.otel_projection.v0 | crates/assay-cli/src/cli/commands/project_otel.rs | crates/assay-core/src/otel/projection.rs
+assay.policy.resolved.v0 | crates/assay-cli/src/cli/commands/policy/resolve.rs | -
 assay.runner.observation_health.v0 | crates/assay-cli/src/cli/commands/monitor_next/observation_health.rs | crates/assay-runner-schema/src/health.rs
 assay.privileged_mcp_action.verify.report.v0 | crates/assay-cli/src/cli/commands/evidence/verify_privileged_mcp_action.rs | -
 assay.run_report.v1 | crates/assay-core/src/report/json.rs | -

--- a/docs/reference/cli/policy.md
+++ b/docs/reference/cli/policy.md
@@ -25,6 +25,7 @@ assay policy <COMMAND> [OPTIONS]
 | `assay policy validate` | Validate policy syntax and v2 JSON Schemas. |
 | `assay policy migrate` | Migrate v1.x constraints policies to v2.0 schemas. |
 | `assay policy fmt` | Format policy YAML. |
+| `assay policy resolve` | Dump the resolved policy this Assay version would load. |
 
 ---
 
@@ -63,6 +64,45 @@ path until they receive honest reason mappings. An empty stdout on those
 failures is not a clean result; callers must still check the exit code. This
 command reuses the existing summary envelope rather than introducing a new
 schema; schema-identity evolution remains tracked in issue #2167.
+
+---
+
+
+### Resolve A Policy
+
+```bash
+assay policy resolve --input policy.yaml --format json
+```
+
+Success writes one `assay.policy.resolved.v0` document to stdout. The only
+flags are `--input` and `--format`. JSON is the default; any other format
+exits nonzero with empty stdout.
+
+Exact success fields:
+
+- `schema`: `assay.policy.resolved.v0`
+- `canonicalization_profile`: `jcs:mcp_policy` (`POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY`)
+- `assay_version`: this CLI crate version
+- `input_sha256`: SHA-256 of the bounded original bytes
+- `policy_digest`: `McpPolicy::policy_digest()` over the loaded, normalized policy
+- `policy`: the normalized policy object (`compiled` is omitted)
+
+RFC8785/JCS of the emitted `policy` object, under that profile, hashes to
+`policy_digest`. Consumers can reconstruct those bytes from `policy` +
+`canonicalization_profile`. Whole-policy JCS is Vec-structural: reordered
+object keys do not move the digest; permuting an allow-list does.
+
+A YAML parse failure exits `2` with typed `E_POLICY_PARSE` on stderr and
+empty stdout. Missing files and schema-compile failures stay on the honest
+stderr-only path until they have a dedicated reason code. Do not treat an
+empty stdout as success.
+
+This dump is what this Assay version would load after successful
+validation and schema compile. It does not claim that any runtime applied
+the policy, that the policy is complete, safe, or compliant, or that the
+producer is authenticated. The whole-policy digest is not the experimental
+declared-constraint digest. The filename is not identity. Absence of a dump
+is not a claim.
 
 ---
 


### PR DESCRIPTION
Refs #2510

## Pins

- base `852b09905120a9a919ed7a98ce07afd266736ffa` (`feat(cli): project one enforcement-health document (#2642)`)
- head `d99c8677de52dfeace1f19bf854aee9906b71b2d` (`fix(cli): share policy load classifier and pin JCS helper`)
- prior slice `ad4424a4bd932cb1d8775d5e7ee1b34ebb979fc2`
- branch `ruley/2510-policy-resolve`
- worktree `/Users/roelschuurkes/wt-ruley-2510-policy-resolve`

Any push invalidates prior advisory notes. This body is bound to `d99c8677`.

## Command

`assay policy resolve --input PATH --format json`

Only `--input` and `--format`. JSON is the default. Document `assay.policy.resolved.v0`:

- `schema`
- `canonicalization_profile`: `POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY` (`jcs:mcp_policy`)
- `assay_version` (`CARGO_PKG_VERSION`)
- `input_sha256` over bounded original bytes
- `policy_digest` from only `McpPolicy::policy_digest()`
- normalized `policy` object

RFC8785/JCS of the emitted `policy` Value hashes to `policy_digest`, including a real v1 constraints→schemas fixture.

## RED → GREEN (repair)

- First RED on `ad4424a4`: `malformed_yaml_emits_no_document` (stderr empty; no `E_POLICY_PARSE`)
- GREEN on `d99c8677`: 14/14 `policy_resolve_cli`, 6/6 `resolve_digest_tests`

## Implementation

- Bound input at 1_000_000 bytes with `LimitReader` before `from_slice`. `McpPolicy::from_file` unchanged.
- `from_slice` then `try_compile_all_schemas`; emit only after both succeed.
- `canonical_mcp_policy_jcs` JCSs `serde_json::to_value(policy)`; `policy_digest` calls it. CLI does not call `serde_jcs`.
- Shared `classify_load_error` in `crates/assay-cli/src/cli/commands/policy/mod.rs`. Validate and resolve both call it. Malformed YAML is typed `E_POLICY_PARSE` on stderr with empty stdout. Missing file and schema-compile stay honest stderr-only; no invented reason code.
- `--deny-deprecations` removed from resolve. Documented in `docs/reference/cli/policy.md`.
- Validate stdout stays `assay.run_summary.v1`.

## Production-path mutations (scratch, restore)

| # | production-path mutation | matching RED | no-op control |
|---|---|---|---|
| M_helper | only the helper line `jcs::to_string(&value)` → `Ok(serde_json::to_string(&value)?)` (compiles; does not touch the test oracle `crate::mcp::jcs::to_string`) | `helper_serializer_is_rfc8785_jcs_of_policy_value` | `effective_change_moves_digest` |
| M_raw | CLI `policy_digest` replaced with JCS of raw YAML Value instead of `McpPolicy::policy_digest()` | `v1_constraints_are_normalized_into_schemas` (reconstruction) | `validate_json_stays_run_summary_v1` |

Earlier first-slice mutations still held where re-checked: skip compile, skip LimitReader, schema `resolved.v1`.

## Guards

- `policy_resolve_cli` 14
- `resolve_digest_tests` 6
- `cli_json_identities` 14
- `policy_validate_machine_contract` 18
- `contract_docs_generate_explain` 2
- `cargo fmt --all -- --check`
- `cargo clippy -p assay-cli -p assay-core -- -D warnings`
- `git diff --check`
- pre-push: workspace clippy + linux compile gate

## Non-claims

- What this Assay version would load after successful validation+compile. Not that any runtime applied it.
- Not complete, safe, or compliant. Not an authenticated producer.
- Whole-policy digest is not the experimental declared-constraint digest.
- Filename is not identity. Whole-policy JCS is Vec-structural: reordered object keys do not move digest; permuting an allow-list does.
- Not #2491 / #2487 / #2511. Absence of a dump is no claim.
- `McpPolicy::from_file` remains unbounded.

Do not ready, merge, or add reviewers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `assay policy resolve` to output validated, normalized policies as versioned JSON.
  * Included canonical policy metadata, input hash, policy digest, and policy content.
  * Added support for legacy policy normalization and constraint migration.

* **Bug Fixes**
  * Improved policy load and parse error reporting while keeping failed output empty.
  * Preserved existing `policy validate` output behavior.

* **Documentation**
  * Documented the new command, JSON format, flags, digest semantics, and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->