### PR TITLE
fix(mcp): authorize value equals forwarded value

### DIFF
--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -19,6 +19,7 @@ categories = ["command-line-utilities", "development-tools::testing"]
 # a release blocker either way — it is the downstream `cargo test` that this protects.
 exclude = [
     "tests/e2e_mcp_wrap_assert_cmd.rs",
+    "tests/mcp_wrap_authorize_forward.rs",
     # Workspace-only contract: reads generated docs and shared test support outside this package.
     "tests/agent_golden_path_contract.rs",
     # Workspace-only contract: imports shared test support outside this package.

--- a/crates/assay-cli/tests/mcp_wrap_authorize_forward.rs
+++ b/crates/assay-cli/tests/mcp_wrap_authorize_forward.rs
@@ -335,6 +335,56 @@ fn wrap_escaped_duplicate_object_is_not_forwarded() {
     }
 }
 
+/// Unique JSON with a `method` member that cannot type as `JsonRpcRequest`
+/// (missing `jsonrpc`). Abstract fixture only.
+const MISSING_JSONRPC_CALL: &str =
+    r#"{"id":1,"method":"tools/call","params":{"name":"danger","arguments":{}}}"#;
+
+#[test]
+fn wrap_method_bearing_typed_parse_fail_is_invalid_request() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mut conn, raw, interpret, decisions) = spawn_wrap(dir.path(), "last");
+    conn.send_line(MISSING_JSONRPC_CALL);
+    let r = conn.read_json();
+    assert_eq!(
+        r["error"]["code"], -32600,
+        "method-bearing unique JSON that fails typed request parse must be INVALID_REQUEST: {r}"
+    );
+    assert_eq!(r["id"], 1, "INVALID_REQUEST must echo the request id: {r}");
+    conn.send_line(
+        r#"{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"echo","arguments":{}}}"#,
+    );
+    let follow = conn.read_response_for_id(12);
+    assert!(
+        follow.get("error").is_none(),
+        "follow-up unique call must still work: {follow}"
+    );
+    let _ = conn.shutdown();
+
+    let body = std::fs::read_to_string(&raw).unwrap_or_default();
+    assert!(
+        !body.contains(MISSING_JSONRPC_CALL),
+        "typed-parse-fail request must not reach the oracle: {body}"
+    );
+    assert!(
+        !body.contains("danger"),
+        "typed-parse-fail request must not reach the oracle: {body}"
+    );
+    if let Some(seen) = last_interpret(&interpret) {
+        assert_ne!(
+            seen["name"], "danger",
+            "oracle must not see a forwarded typed-parse-fail call: {seen}"
+        );
+    }
+    assert_eq!(
+        tool_decision_count(&decisions),
+        1,
+        "fixture must mint no decision; only the follow-up echo is authorized: {}",
+        std::fs::read_to_string(&decisions).unwrap_or_default()
+    );
+    assert_eq!(last_decision_tool(&decisions).as_deref(), Some("echo"));
+}
+
 #[test]
 fn wrap_unparsable_method_bearing_frame_is_not_forwarded() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/assay-cli/tests/mcp_wrap_authorize_forward.rs
+++ b/crates/assay-cli/tests/mcp_wrap_authorize_forward.rs
@@ -107,6 +107,16 @@ fn raw_contains_tools_call(path: &Path) -> bool {
         .contains("tools/call")
 }
 
+fn tool_decision_count(path: &Path) -> usize {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<Value>(l).ok())
+        .filter(|v| v.get("type").and_then(Value::as_str) == Some("assay.tool.decision"))
+        .count()
+}
+
 #[test]
 fn wrap_unique_key_control_authorized_equals_forwarded() {
     let dir = tempfile::tempdir().unwrap();
@@ -130,6 +140,96 @@ fn wrap_unique_key_control_authorized_equals_forwarded() {
     assert_eq!(seen["name"], "echo");
     assert_eq!(seen["arguments"], serde_json::json!({"msg": "ok"}));
     assert_eq!(last_decision_tool(&decisions).as_deref(), Some("echo"));
+}
+
+const INIT_LINE: &str = r#"{"jsonrpc":"2.0","id":21,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}"#;
+const LIST_LINE: &str = r#"{"jsonrpc":"2.0","id":22,"method":"tools/list"}"#;
+const NOTE_LINE: &str = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+const NON_REQUEST_LINE: &str = r#"{"jsonrpc":"2.0","id":23,"result":{"passthrough":true}}"#;
+const PING_LINE: &str = r#"{"jsonrpc":"2.0","id":24,"method":"ping"}"#;
+
+#[test]
+fn wrap_protocol_control_is_forwarded_without_tool_decision() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mut conn, raw, _, decisions) = spawn_wrap(dir.path(), "last");
+
+    conn.send_line(INIT_LINE);
+    let init = conn.read_response_for_id(21);
+    assert!(
+        init.get("error").is_none(),
+        "initialize must be forwarded, not policy-denied: {init}"
+    );
+    assert_eq!(
+        init["result"]["protocolVersion"], "2024-11-05",
+        "initialize must reach the oracle: {init}"
+    );
+    assert_eq!(
+        tool_decision_count(&decisions),
+        0,
+        "initialize must not mint assay.tool.decision: {}",
+        std::fs::read_to_string(&decisions).unwrap_or_default()
+    );
+
+    conn.send_line(LIST_LINE);
+    let listed = conn.read_response_for_id(22);
+    assert!(
+        listed.get("error").is_none(),
+        "tools/list must be forwarded, not policy-denied: {listed}"
+    );
+    assert_eq!(
+        tool_decision_count(&decisions),
+        0,
+        "tools/list must not mint assay.tool.decision: {}",
+        std::fs::read_to_string(&decisions).unwrap_or_default()
+    );
+
+    conn.send_line(NOTE_LINE);
+    conn.send_line(NON_REQUEST_LINE);
+    conn.send_line(PING_LINE);
+    let ping = conn.read_response_for_id(24);
+    assert!(
+        ping.get("error").is_none(),
+        "ping must be forwarded, not policy-denied: {ping}"
+    );
+    assert_eq!(
+        tool_decision_count(&decisions),
+        0,
+        "non-tools/call unique objects must not mint assay.tool.decision: {}",
+        std::fs::read_to_string(&decisions).unwrap_or_default()
+    );
+
+    conn.send_line(
+        r#"{"jsonrpc":"2.0","id":25,"method":"tools/call","params":{"name":"echo","arguments":{"msg":"ok"}}}"#,
+    );
+    let call = conn.read_response_for_id(25);
+    assert!(
+        call.get("error").is_none(),
+        "tools/call must still authorize the exact parsed value: {call}"
+    );
+    let _ = conn.shutdown();
+
+    let body = std::fs::read_to_string(&raw).unwrap_or_default();
+    for line in [INIT_LINE, LIST_LINE, NOTE_LINE, NON_REQUEST_LINE, PING_LINE] {
+        assert!(
+            body.contains(line),
+            "protocol-control line must be forwarded byte-identically: missing {line} in {body}"
+        );
+    }
+    assert!(
+        body.contains("\"method\":\"tools/call\""),
+        "tools/call must still reach upstream: {body}"
+    );
+    assert_eq!(
+        last_decision_tool(&decisions).as_deref(),
+        Some("echo"),
+        "only the tools/call is authorized"
+    );
+    assert_eq!(
+        tool_decision_count(&decisions),
+        1,
+        "exactly one assay.tool.decision, for the tools/call: {}",
+        std::fs::read_to_string(&decisions).unwrap_or_default()
+    );
 }
 
 #[test]

--- a/crates/assay-cli/tests/mcp_wrap_authorize_forward.rs
+++ b/crates/assay-cli/tests/mcp_wrap_authorize_forward.rs
@@ -187,6 +187,54 @@ fn wrap_duplicate_argument_member_is_not_forwarded() {
     }
 }
 
+/// Abstract duplicate-member fixture whose keys are JSON-escaped. It contains
+/// no literal `"method"` / `"params"` / `"tool"` token, so the raw
+/// method-bearing heuristic does not see it.
+const ESCAPED_DUPLICATE_OBJECT: &str = r#"{"jsonrpc":"2.0","id":1,"\u006dethod":"tools/list","\u006dethod":"tools/call","\u0070arams":{"name":"danger","arguments":{}}}"#;
+
+#[test]
+fn wrap_escaped_duplicate_object_is_not_forwarded() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mut conn, raw, interpret, decisions) = spawn_wrap(dir.path(), "last");
+    conn.send_line(ESCAPED_DUPLICATE_OBJECT);
+    let r = conn.read_json();
+    assert_eq!(
+        r["error"]["code"], -32700,
+        "object-shaped unique-parse fail must be a parse error, not a forwarded result: {r}"
+    );
+    conn.send_line(
+        r#"{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"echo","arguments":{}}}"#,
+    );
+    let follow = conn.read_response_for_id(11);
+    assert!(
+        follow.get("error").is_none(),
+        "follow-up unique call must still work: {follow}"
+    );
+    let _ = conn.shutdown();
+
+    let body = std::fs::read_to_string(&raw).unwrap_or_default();
+    assert!(
+        !body.contains(ESCAPED_DUPLICATE_OBJECT),
+        "escaped duplicate object must not reach the oracle: {body}"
+    );
+    assert!(
+        !body.contains(r#"\u006dethod"#),
+        "escaped duplicate object must not reach the oracle: {body}"
+    );
+    if let Some(seen) = last_interpret(&interpret) {
+        assert_ne!(
+            seen["name"], "danger",
+            "first/last oracle must not see a forwarded escaped duplicate: {seen}"
+        );
+    }
+    if let Some(tool) = last_decision_tool(&decisions) {
+        assert_ne!(
+            tool, "danger",
+            "must not authorize a collapsed tree, got tool={tool}"
+        );
+    }
+}
+
 #[test]
 fn wrap_unparsable_method_bearing_frame_is_not_forwarded() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/assay-cli/tests/mcp_wrap_authorize_forward.rs
+++ b/crates/assay-cli/tests/mcp_wrap_authorize_forward.rs
@@ -1,0 +1,211 @@
+//! README-facing `assay mcp wrap`: the value authorized must be the value forwarded.
+//!
+//! Abstract member / malformed-frame fixtures only. Not a named-upstream bypass recipe.
+
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+#[path = "../../assay-mcp-server/tests/jsonrpc_conn/mod.rs"]
+mod jsonrpc_conn;
+
+use jsonrpc_conn::Conn;
+
+fn assay_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_assay"))
+}
+
+fn python() -> &'static str {
+    if cfg!(windows) {
+        "python"
+    } else {
+        "python3"
+    }
+}
+
+fn oracle_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../assay-mcp-server/tests/fixtures/proxy/member_oracles.py")
+}
+
+fn write_policy(dir: &Path) -> PathBuf {
+    let p = dir.join("wrap-policy.yaml");
+    std::fs::write(
+        &p,
+        r#"
+version: "2.0"
+name: "authorize-forward"
+tools:
+  allow: ["echo"]
+enforcement:
+  unconstrained_tools: allow
+"#,
+    )
+    .expect("write policy");
+    p
+}
+
+fn spawn_wrap(dir: &Path, mode: &str) -> (Conn, PathBuf, PathBuf, PathBuf) {
+    let policy = write_policy(dir);
+    let raw = dir.join("raw.log");
+    let interpret = dir.join("interpret.ndjson");
+    let decisions = dir.join("decisions.ndjson");
+    let child = Command::new(assay_bin())
+        .args([
+            "mcp",
+            "wrap",
+            "--policy",
+            policy.to_str().unwrap(),
+            "--decision-log",
+            decisions.to_str().unwrap(),
+            "--event-source",
+            "assay://tests/authorize-forward",
+            "--",
+            python(),
+            "-u",
+            oracle_path().to_str().unwrap(),
+            "serve",
+            mode,
+        ])
+        .env("ORACLE_RAW_LOG", &raw)
+        .env("ORACLE_INTERPRET_LOG", &interpret)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn assay mcp wrap");
+    (Conn::attach(child), raw, interpret, decisions)
+}
+
+fn last_interpret(path: &Path) -> Option<Value> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("interpret json"))
+        .next_back()
+}
+
+fn last_decision_tool(path: &Path) -> Option<String> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<Value>(l).ok())
+        .filter_map(|v| {
+            v.pointer("/data/tool")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .next_back()
+}
+
+fn raw_contains_tools_call(path: &Path) -> bool {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .contains("tools/call")
+}
+
+#[test]
+fn wrap_unique_key_control_authorized_equals_forwarded() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mut conn, raw, interpret, decisions) = spawn_wrap(dir.path(), "last");
+    let line = r#"{"jsonrpc":"2.0","id":1e2,"method":"tools/call","params":{"name":"echo","arguments":{"msg":"ok"}}}"#;
+    conn.send_line(line);
+    let r = conn.read_response();
+    assert!(r.get("error").is_none(), "unique-key wrap denied: {r}");
+    let _ = conn.shutdown();
+
+    assert!(
+        raw_contains_tools_call(&raw),
+        "unique-key control must reach upstream"
+    );
+    assert!(
+        std::fs::read_to_string(&raw).unwrap().contains("1e2"),
+        "wrap must preserve the written numeric id"
+    );
+    let seen = last_interpret(&interpret).expect("oracle interpretation");
+    assert_eq!(seen["accepted"], true);
+    assert_eq!(seen["name"], "echo");
+    assert_eq!(seen["arguments"], serde_json::json!({"msg": "ok"}));
+    assert_eq!(last_decision_tool(&decisions).as_deref(), Some("echo"));
+}
+
+#[test]
+fn wrap_noop_control_unique_ping_is_not_a_tools_call() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mut conn, raw, _, _) = spawn_wrap(dir.path(), "last");
+    conn.send_line(r#"{"jsonrpc":"2.0","id":7,"method":"ping"}"#);
+    let r = conn.read_response();
+    assert_eq!(r["id"], 7);
+    let _ = conn.shutdown();
+    assert!(!raw_contains_tools_call(&raw));
+}
+
+#[test]
+fn wrap_duplicate_params_name_is_not_forwarded() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mut conn, raw, interpret, decisions) = spawn_wrap(dir.path(), "first");
+    conn.send_line(
+        r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"other","name":"echo","arguments":{}}}"#,
+    );
+    let _ = conn.read_json();
+    let _ = conn.shutdown();
+    assert!(
+        !raw_contains_tools_call(&raw),
+        "duplicate params.name must not be forwarded: {}",
+        std::fs::read_to_string(&raw).unwrap_or_default()
+    );
+    if let Some(seen) = last_interpret(&interpret) {
+        assert_ne!(
+            seen["accepted"], true,
+            "first-member oracle must not see a forwarded call"
+        );
+    }
+    if let Some(tool) = last_decision_tool(&decisions) {
+        panic!("must not authorize a collapsed tree, got tool={tool}");
+    }
+}
+
+#[test]
+fn wrap_duplicate_argument_member_is_not_forwarded() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mut conn, raw, _, decisions) = spawn_wrap(dir.path(), "first");
+    conn.send_line(
+        r#"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"echo","arguments":{"msg":"other","msg":"ok"}}}"#,
+    );
+    let _ = conn.read_json();
+    let _ = conn.shutdown();
+    assert!(
+        !raw_contains_tools_call(&raw),
+        "duplicate argument members must not be forwarded: {}",
+        std::fs::read_to_string(&raw).unwrap_or_default()
+    );
+    if let Some(tool) = last_decision_tool(&decisions) {
+        panic!("must not authorize a collapsed tree, got tool={tool}");
+    }
+}
+
+#[test]
+fn wrap_unparsable_method_bearing_frame_is_not_forwarded() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mut conn, raw, _, _) = spawn_wrap(dir.path(), "reject");
+    let broken = r#"{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"echo""#;
+    conn.send_line(broken);
+    conn.send_line(r#"{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"echo","arguments":{}}}"#);
+    let r = conn.read_response_for_id(10);
+    assert!(
+        r.get("error").is_none(),
+        "follow-up unique call must still work: {r}"
+    );
+    let _ = conn.shutdown();
+    let body = std::fs::read_to_string(&raw).unwrap_or_default();
+    assert!(
+        !body.contains(broken),
+        "unparsable method-bearing frame must not be forwarded: {body}"
+    );
+    assert!(
+        body.contains("\"id\":10"),
+        "follow-up unique call is the no-op control that the stream stayed intact"
+    );
+}

--- a/crates/assay-cli/tests/mcp_wrap_authorize_forward.rs
+++ b/crates/assay-cli/tests/mcp_wrap_authorize_forward.rs
@@ -67,8 +67,9 @@ fn spawn_wrap(dir: &Path, mode: &str) -> (Conn, PathBuf, PathBuf, PathBuf) {
             "serve",
             mode,
         ])
-        .env("ORACLE_RAW_LOG", &raw)
-        .env("ORACLE_INTERPRET_LOG", &interpret)
+        .current_dir(dir)
+        .env("ORACLE_RAW_LOG", "raw.log")
+        .env("ORACLE_INTERPRET_LOG", "interpret.ndjson")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())

--- a/crates/assay-core/src/mcp/jsonrpc.rs
+++ b/crates/assay-core/src/mcp/jsonrpc.rs
@@ -18,6 +18,15 @@ pub fn is_tools_call_method(method: &str) -> bool {
     method == "tools/call"
 }
 
+/// Whether a uniquely-parsed object carries a `method` member.
+///
+/// Presence on the parsed tree (not a raw-byte scan) distinguishes
+/// request-shaped frames from unique responses. A present `method` that
+/// cannot type as [`JsonRpcRequest`] is INVALID_REQUEST, not a pass-through.
+pub(crate) fn unique_value_has_method_member(value: &Value) -> bool {
+    value.get("method").is_some()
+}
+
 impl JsonRpcRequest {
     pub fn is_tool_call(&self) -> bool {
         is_tools_call_method(&self.method)

--- a/crates/assay-core/src/mcp/jsonrpc.rs
+++ b/crates/assay-core/src/mcp/jsonrpc.rs
@@ -10,9 +10,17 @@ pub struct JsonRpcRequest {
     pub params: Value,
 }
 
+/// Whether a uniquely-parsed JSON-RPC method is a `tools/call`.
+///
+/// Protocol-control methods (`initialize`, `tools/list`, notifications, `ping`)
+/// are not. One function so wrap and proxy-enforce cannot drift.
+pub fn is_tools_call_method(method: &str) -> bool {
+    method == "tools/call"
+}
+
 impl JsonRpcRequest {
     pub fn is_tool_call(&self) -> bool {
-        self.method == "tools/call"
+        is_tools_call_method(&self.method)
     }
 
     pub fn tool_params(&self) -> Option<CallToolParams> {

--- a/crates/assay-core/src/mcp/mod.rs
+++ b/crates/assay-core/src/mcp/mod.rs
@@ -14,6 +14,8 @@ pub mod ingest;
 pub mod jcs;
 pub(crate) mod json_depth;
 pub mod jsonrpc;
+pub mod unique_json;
+pub use unique_json::{is_method_bearing_frame, parse_unique_json, UniqueJsonError};
 pub mod lifecycle;
 pub mod mapper_v2;
 pub mod obligations;

--- a/crates/assay-core/src/mcp/mod.rs
+++ b/crates/assay-core/src/mcp/mod.rs
@@ -15,6 +15,7 @@ pub mod jcs;
 pub(crate) mod json_depth;
 pub mod jsonrpc;
 pub mod unique_json;
+pub use jsonrpc::is_tools_call_method;
 pub use unique_json::{is_method_bearing_frame, parse_unique_json, UniqueJsonError};
 pub mod lifecycle;
 pub mod mapper_v2;

--- a/crates/assay-core/src/mcp/proxy/client.rs
+++ b/crates/assay-core/src/mcp/proxy/client.rs
@@ -10,7 +10,7 @@ use crate::mcp::jsonrpc::{error_codes, JsonRpcRequest};
 use crate::mcp::policy::{McpPolicy, PolicyState};
 use crate::mcp::tool_decision_truth as tdt;
 use crate::mcp::tool_definition::ToolDefinitionBinding;
-use crate::mcp::unique_json::{is_method_bearing_frame, parse_unique_json};
+use crate::mcp::unique_json::parse_unique_json;
 use std::{
     collections::HashMap,
     io::{self, BufRead, Write},
@@ -131,7 +131,9 @@ pub(super) fn run_client_to_server(
                 }
             },
             Err(_) => {
-                if is_method_bearing_frame(&line) {
+                // Object-shaped lines that fail unique parse cannot be authorized.
+                // A raw token scan for "method"/"params"/"tool" misses JSON-escaped keys.
+                if line.trim().starts_with('{') {
                     let mut out = stdout.lock().map_err(|e| io::Error::other(e.to_string()))?;
                     let response = serde_json::json!({
                         "jsonrpc": "2.0",

--- a/crates/assay-core/src/mcp/proxy/client.rs
+++ b/crates/assay-core/src/mcp/proxy/client.rs
@@ -6,7 +6,7 @@ use super::{ProxyConfig, TdtProducer};
 use crate::mcp::audit::AuditLog;
 use crate::mcp::decision::DecisionEmitter;
 use crate::mcp::identity::ToolIdentity;
-use crate::mcp::jsonrpc::{error_codes, JsonRpcRequest};
+use crate::mcp::jsonrpc::{error_codes, unique_value_has_method_member, JsonRpcRequest};
 use crate::mcp::policy::{McpPolicy, PolicyState};
 use crate::mcp::tool_decision_truth as tdt;
 use crate::mcp::tool_definition::ToolDefinitionBinding;
@@ -43,97 +43,117 @@ pub(super) fn run_client_to_server(
         // 1. Try Parse as MCP Request. Unique-member parse first so the tree the
         // policy sees cannot diverge from a later read of the same bytes.
         match parse_unique_json(line.trim_end()) {
-            Ok(value) => match serde_json::from_value::<JsonRpcRequest>(value) {
-                Ok(req) if !req.is_tool_call() => {
-                    // Unique non-tools/call objects (initialize, tools/list,
-                    // notifications, ping) pass through byte-identically.
-                }
-                Ok(req) => {
-                    let tool_params = req.tool_params();
-                    let tool_name = tool_params
-                        .as_ref()
-                        .map(|params| params.name.as_str())
-                        .unwrap_or_default();
+            Ok(value) => {
+                let request_id = value.get("id").cloned().unwrap_or(serde_json::Value::Null);
+                let method_present = unique_value_has_method_member(&value);
+                match serde_json::from_value::<JsonRpcRequest>(value) {
+                    Ok(req) if !req.is_tool_call() => {
+                        // Unique non-tools/call objects (initialize, tools/list,
+                        // notifications, ping) pass through byte-identically.
+                    }
+                    Ok(req) => {
+                        let tool_params = req.tool_params();
+                        let tool_name = tool_params
+                            .as_ref()
+                            .map(|params| params.name.as_str())
+                            .unwrap_or_default();
 
-                    // 2. Check Policy with Identity (Phase 9)
-                    let (runtime_id, tool_definition_binding) = if req.is_tool_call() {
-                        let runtime_id = {
-                            let cache = identity_cache.lock().unwrap();
-                            cache.get(tool_name).cloned()
+                        // 2. Check Policy with Identity (Phase 9)
+                        let (runtime_id, tool_definition_binding) = if req.is_tool_call() {
+                            let runtime_id = {
+                                let cache = identity_cache.lock().unwrap();
+                                cache.get(tool_name).cloned()
+                            };
+                            let tool_definition_binding = {
+                                let cache = tool_definition_cache.lock().unwrap();
+                                cache.get(tool_name).cloned()
+                            };
+                            (runtime_id, tool_definition_binding)
+                        } else {
+                            (None, None)
                         };
-                        let tool_definition_binding = {
-                            let cache = tool_definition_cache.lock().unwrap();
-                            cache.get(tool_name).cloned()
-                        };
-                        (runtime_id, tool_definition_binding)
-                    } else {
-                        (None, None)
-                    };
 
-                    let tool_call_id = extract_tool_call_id(&req, tool_params.as_ref());
-                    let null_arguments = serde_json::Value::Null;
-                    let tool_arguments = tool_params
-                        .as_ref()
-                        .map(|params| &params.arguments)
-                        .unwrap_or(&null_arguments);
+                        let tool_call_id = extract_tool_call_id(&req, tool_params.as_ref());
+                        let null_arguments = serde_json::Value::Null;
+                        let tool_arguments = tool_params
+                            .as_ref()
+                            .map(|params| &params.arguments)
+                            .unwrap_or(&null_arguments);
 
-                    let policy_eval = policy.evaluate_with_metadata(
-                        tool_name,
-                        tool_arguments,
-                        &mut state,
-                        runtime_id.as_ref(),
-                    );
+                        let policy_eval = policy.evaluate_with_metadata(
+                            tool_name,
+                            tool_arguments,
+                            &mut state,
+                            runtime_id.as_ref(),
+                        );
 
-                    // EXPERIMENTAL opt-in: mint a tool-decision-truth carrier for this evaluated tool call,
-                    // appended to its own NDJSON sink (separate from the decision log). Evidence-only — this
-                    // never alters the decision below and never blocks the call, including when the call is
-                    // about to be blocked: the carrier records that the decision was observed and classified.
-                    if req.is_tool_call() {
-                        if let Some(producer) = config.tdt_producer.as_ref() {
-                            emit_tdt_carrier(
-                                producer,
-                                &policy,
+                        // EXPERIMENTAL opt-in: mint a tool-decision-truth carrier for this evaluated tool call,
+                        // appended to its own NDJSON sink (separate from the decision log). Evidence-only — this
+                        // never alters the decision below and never blocks the call, including when the call is
+                        // about to be blocked: the carrier records that the decision was observed and classified.
+                        if req.is_tool_call() {
+                            if let Some(producer) = config.tdt_producer.as_ref() {
+                                emit_tdt_carrier(
+                                    producer,
+                                    &policy,
+                                    tool_name,
+                                    tool_arguments,
+                                    tdt_order,
+                                    &tool_call_id,
+                                    runtime_id.is_some(),
+                                );
+                                tdt_order += 1;
+                            }
+                        }
+
+                        let branch_outcome = handle_policy_decision(
+                            policy_eval.decision,
+                            PolicyBranchContext {
+                                req: &req,
+                                tool_params: tool_params.as_ref(),
                                 tool_name,
-                                tool_arguments,
-                                tdt_order,
-                                &tool_call_id,
-                                runtime_id.is_some(),
-                            );
-                            tdt_order += 1;
+                                tool_call_id: &tool_call_id,
+                                metadata: &policy_eval.metadata,
+                                tool_definition_binding: tool_definition_binding.as_ref(),
+                                config: &config,
+                                emitter: &emitter,
+                                event_source: &event_source,
+                                audit_log: &mut audit_log,
+                            },
+                            |response_json| {
+                                let mut out =
+                                    stdout.lock().map_err(|e| io::Error::other(e.to_string()))?;
+                                out.write_all(response_json.as_bytes())?;
+                                out.flush()
+                            },
+                        )?;
+
+                        if branch_outcome == BranchOutcome::Blocked {
+                            line.clear();
+                            continue;
                         }
                     }
-
-                    let branch_outcome = handle_policy_decision(
-                        policy_eval.decision,
-                        PolicyBranchContext {
-                            req: &req,
-                            tool_params: tool_params.as_ref(),
-                            tool_name,
-                            tool_call_id: &tool_call_id,
-                            metadata: &policy_eval.metadata,
-                            tool_definition_binding: tool_definition_binding.as_ref(),
-                            config: &config,
-                            emitter: &emitter,
-                            event_source: &event_source,
-                            audit_log: &mut audit_log,
-                        },
-                        |response_json| {
-                            let mut out =
-                                stdout.lock().map_err(|e| io::Error::other(e.to_string()))?;
-                            out.write_all(response_json.as_bytes())?;
-                            out.flush()
-                        },
-                    )?;
-
-                    if branch_outcome == BranchOutcome::Blocked {
+                    Err(_) if method_present => {
+                        let mut out = stdout.lock().map_err(|e| io::Error::other(e.to_string()))?;
+                        let response = serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": request_id,
+                            "error": {
+                                "code": error_codes::INVALID_REQUEST,
+                                "message": "Invalid Request"
+                            }
+                        });
+                        out.write_all(response.to_string().as_bytes())?;
+                        out.write_all(b"\n")?;
+                        out.flush()?;
                         line.clear();
                         continue;
                     }
+                    Err(_) => {
+                        // Unique JSON with no method member: response / non-request, forward.
+                    }
                 }
-                Err(_) => {
-                    // Unique JSON that is not a request: forward as before.
-                }
-            },
+            }
             Err(_) => {
                 // Object-shaped lines that fail unique parse cannot be authorized.
                 // A raw token scan for "method"/"params"/"tool" misses JSON-escaped keys.

--- a/crates/assay-core/src/mcp/proxy/client.rs
+++ b/crates/assay-core/src/mcp/proxy/client.rs
@@ -6,10 +6,11 @@ use super::{ProxyConfig, TdtProducer};
 use crate::mcp::audit::AuditLog;
 use crate::mcp::decision::DecisionEmitter;
 use crate::mcp::identity::ToolIdentity;
-use crate::mcp::jsonrpc::JsonRpcRequest;
+use crate::mcp::jsonrpc::{error_codes, JsonRpcRequest};
 use crate::mcp::policy::{McpPolicy, PolicyState};
 use crate::mcp::tool_decision_truth as tdt;
 use crate::mcp::tool_definition::ToolDefinitionBinding;
+use crate::mcp::unique_json::{is_method_bearing_frame, parse_unique_json};
 use std::{
     collections::HashMap,
     io::{self, BufRead, Write},
@@ -39,98 +40,112 @@ pub(super) fn run_client_to_server(
     let mut tdt_order: i64 = 0;
 
     while reader.read_line(&mut line)? > 0 {
-        // 1. Try Parse as MCP Request
-        match serde_json::from_str::<JsonRpcRequest>(&line) {
-            Ok(req) => {
-                let tool_params = req.tool_params();
-                let tool_name = tool_params
-                    .as_ref()
-                    .map(|params| params.name.as_str())
-                    .unwrap_or_default();
+        // 1. Try Parse as MCP Request. Unique-member parse first so the tree the
+        // policy sees cannot diverge from a later read of the same bytes.
+        match parse_unique_json(line.trim_end()) {
+            Ok(value) => match serde_json::from_value::<JsonRpcRequest>(value) {
+                Ok(req) => {
+                    let tool_params = req.tool_params();
+                    let tool_name = tool_params
+                        .as_ref()
+                        .map(|params| params.name.as_str())
+                        .unwrap_or_default();
 
-                // 2. Check Policy with Identity (Phase 9)
-                let (runtime_id, tool_definition_binding) = if req.is_tool_call() {
-                    let runtime_id = {
-                        let cache = identity_cache.lock().unwrap();
-                        cache.get(tool_name).cloned()
+                    // 2. Check Policy with Identity (Phase 9)
+                    let (runtime_id, tool_definition_binding) = if req.is_tool_call() {
+                        let runtime_id = {
+                            let cache = identity_cache.lock().unwrap();
+                            cache.get(tool_name).cloned()
+                        };
+                        let tool_definition_binding = {
+                            let cache = tool_definition_cache.lock().unwrap();
+                            cache.get(tool_name).cloned()
+                        };
+                        (runtime_id, tool_definition_binding)
+                    } else {
+                        (None, None)
                     };
-                    let tool_definition_binding = {
-                        let cache = tool_definition_cache.lock().unwrap();
-                        cache.get(tool_name).cloned()
-                    };
-                    (runtime_id, tool_definition_binding)
-                } else {
-                    (None, None)
-                };
 
-                let tool_call_id = extract_tool_call_id(&req, tool_params.as_ref());
-                let null_arguments = serde_json::Value::Null;
-                let tool_arguments = tool_params
-                    .as_ref()
-                    .map(|params| &params.arguments)
-                    .unwrap_or(&null_arguments);
+                    let tool_call_id = extract_tool_call_id(&req, tool_params.as_ref());
+                    let null_arguments = serde_json::Value::Null;
+                    let tool_arguments = tool_params
+                        .as_ref()
+                        .map(|params| &params.arguments)
+                        .unwrap_or(&null_arguments);
 
-                let policy_eval = policy.evaluate_with_metadata(
-                    tool_name,
-                    tool_arguments,
-                    &mut state,
-                    runtime_id.as_ref(),
-                );
+                    let policy_eval = policy.evaluate_with_metadata(
+                        tool_name,
+                        tool_arguments,
+                        &mut state,
+                        runtime_id.as_ref(),
+                    );
 
-                // EXPERIMENTAL opt-in: mint a tool-decision-truth carrier for this evaluated tool call,
-                // appended to its own NDJSON sink (separate from the decision log). Evidence-only — this
-                // never alters the decision below and never blocks the call, including when the call is
-                // about to be blocked: the carrier records that the decision was observed and classified.
-                if req.is_tool_call() {
-                    if let Some(producer) = config.tdt_producer.as_ref() {
-                        emit_tdt_carrier(
-                            producer,
-                            &policy,
+                    // EXPERIMENTAL opt-in: mint a tool-decision-truth carrier for this evaluated tool call,
+                    // appended to its own NDJSON sink (separate from the decision log). Evidence-only — this
+                    // never alters the decision below and never blocks the call, including when the call is
+                    // about to be blocked: the carrier records that the decision was observed and classified.
+                    if req.is_tool_call() {
+                        if let Some(producer) = config.tdt_producer.as_ref() {
+                            emit_tdt_carrier(
+                                producer,
+                                &policy,
+                                tool_name,
+                                tool_arguments,
+                                tdt_order,
+                                &tool_call_id,
+                                runtime_id.is_some(),
+                            );
+                            tdt_order += 1;
+                        }
+                    }
+
+                    let branch_outcome = handle_policy_decision(
+                        policy_eval.decision,
+                        PolicyBranchContext {
+                            req: &req,
+                            tool_params: tool_params.as_ref(),
                             tool_name,
-                            tool_arguments,
-                            tdt_order,
-                            &tool_call_id,
-                            runtime_id.is_some(),
-                        );
-                        tdt_order += 1;
+                            tool_call_id: &tool_call_id,
+                            metadata: &policy_eval.metadata,
+                            tool_definition_binding: tool_definition_binding.as_ref(),
+                            config: &config,
+                            emitter: &emitter,
+                            event_source: &event_source,
+                            audit_log: &mut audit_log,
+                        },
+                        |response_json| {
+                            let mut out =
+                                stdout.lock().map_err(|e| io::Error::other(e.to_string()))?;
+                            out.write_all(response_json.as_bytes())?;
+                            out.flush()
+                        },
+                    )?;
+
+                    if branch_outcome == BranchOutcome::Blocked {
+                        line.clear();
+                        continue;
                     }
                 }
-
-                let branch_outcome = handle_policy_decision(
-                    policy_eval.decision,
-                    PolicyBranchContext {
-                        req: &req,
-                        tool_params: tool_params.as_ref(),
-                        tool_name,
-                        tool_call_id: &tool_call_id,
-                        metadata: &policy_eval.metadata,
-                        tool_definition_binding: tool_definition_binding.as_ref(),
-                        config: &config,
-                        emitter: &emitter,
-                        event_source: &event_source,
-                        audit_log: &mut audit_log,
-                    },
-                    |response_json| {
-                        let mut out = stdout.lock().map_err(|e| io::Error::other(e.to_string()))?;
-                        out.write_all(response_json.as_bytes())?;
-                        out.flush()
-                    },
-                )?;
-
-                if branch_outcome == BranchOutcome::Blocked {
+                Err(_) => {
+                    // Unique JSON that is not a request: forward as before.
+                }
+            },
+            Err(_) => {
+                if is_method_bearing_frame(&line) {
+                    let mut out = stdout.lock().map_err(|e| io::Error::other(e.to_string()))?;
+                    let response = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": serde_json::Value::Null,
+                        "error": {
+                            "code": error_codes::PARSE_ERROR,
+                            "message": "Parse error"
+                        }
+                    });
+                    out.write_all(response.to_string().as_bytes())?;
+                    out.write_all(b"\n")?;
+                    out.flush()?;
                     line.clear();
                     continue;
-                }
-            }
-            Err(_) => {
-                // Hardening: Suspicious Unparsable JSON
-                let trimmed = line.trim();
-                if trimmed.starts_with('{')
-                    && (trimmed.contains("\"method\"")
-                        || trimmed.contains("\"params\"")
-                        || trimmed.contains("\"tool\""))
-                {
-                    eprintln!("[assay] WARNING: Suspicious unparsable JSON, forwarding anyway (potential bypass attempt?): {:.60}...", trimmed);
                 }
             }
         }

--- a/crates/assay-core/src/mcp/proxy/client.rs
+++ b/crates/assay-core/src/mcp/proxy/client.rs
@@ -44,6 +44,10 @@ pub(super) fn run_client_to_server(
         // policy sees cannot diverge from a later read of the same bytes.
         match parse_unique_json(line.trim_end()) {
             Ok(value) => match serde_json::from_value::<JsonRpcRequest>(value) {
+                Ok(req) if !req.is_tool_call() => {
+                    // Unique non-tools/call objects (initialize, tools/list,
+                    // notifications, ping) pass through byte-identically.
+                }
                 Ok(req) => {
                     let tool_params = req.tool_params();
                     let tool_name = tool_params

--- a/crates/assay-core/src/mcp/unique_json.rs
+++ b/crates/assay-core/src/mcp/unique_json.rs
@@ -1,0 +1,111 @@
+//! Unique-member JSON ingress for live MCP proxy lines.
+//!
+//! `serde_json::Value` collapses duplicate object members last-value-wins, so a
+//! later parse of the same bytes can disagree with the tree a policy decision
+//! already used. This boundary refuses duplicates in one pass and applies the
+//! transcript line-byte ceiling before building a tree.
+
+use super::era::UniqueValue;
+use super::ingest::McpTranscriptLimits;
+use serde_json::Value;
+
+/// Why a client line cannot be authorized.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UniqueJsonError {
+    DuplicateMember,
+    Malformed,
+    LineTooLong { limit: u64 },
+}
+
+impl std::fmt::Display for UniqueJsonError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DuplicateMember => f.write_str("JSON object contains a duplicate member"),
+            Self::Malformed => f.write_str("malformed JSON"),
+            Self::LineTooLong { limit } => {
+                write!(f, "JSON line exceeded byte limit of {limit}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for UniqueJsonError {}
+
+/// Parse one client line, refusing duplicate members and oversized lines.
+///
+/// The line-byte ceiling is [`McpTranscriptLimits::max_line_bytes`] so live
+/// proxy ingest and transcript ingest share one number.
+pub fn parse_unique_json(line: &str) -> Result<Value, UniqueJsonError> {
+    let limit = McpTranscriptLimits::default().max_line_bytes;
+    if (line.len() as u64) > limit {
+        return Err(UniqueJsonError::LineTooLong { limit });
+    }
+    match serde_json::from_str::<UniqueValue>(line) {
+        Ok(UniqueValue(value)) => Ok(value),
+        Err(error) => {
+            if error.to_string().contains("duplicate member") {
+                Err(UniqueJsonError::DuplicateMember)
+            } else {
+                Err(UniqueJsonError::Malformed)
+            }
+        }
+    }
+}
+
+/// Whether an unparsable line still looks like a JSON-RPC method frame.
+///
+/// Matches the wrap path's existing method-bearing check so only that class of
+/// opaque line changes from "warn and forward" to refuse.
+pub fn is_method_bearing_frame(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with('{')
+        && (trimmed.contains("\"method\"")
+            || trimmed.contains("\"params\"")
+            || trimmed.contains("\"tool\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn unique_members_parse() {
+        let v = parse_unique_json(r#"{"name":"echo","arguments":{"x":1}}"#).unwrap();
+        assert_eq!(v["name"], "echo");
+        assert_eq!(v["arguments"]["x"], 1);
+    }
+
+    #[test]
+    fn duplicate_members_are_refused() {
+        let err = parse_unique_json(r#"{"name":"alpha","name":"bravo"}"#).unwrap_err();
+        assert_eq!(err, UniqueJsonError::DuplicateMember);
+        let rendered = format!("{err}");
+        assert!(!rendered.contains("alpha") && !rendered.contains("bravo"));
+    }
+
+    #[test]
+    fn malformed_is_refused() {
+        let err = parse_unique_json(r#"{"name":"echo""#).unwrap_err();
+        assert_eq!(err, UniqueJsonError::Malformed);
+    }
+
+    #[test]
+    fn oversized_line_is_refused_before_a_second_parse() {
+        let limit = McpTranscriptLimits::default().max_line_bytes;
+        let line = "x".repeat((limit as usize) + 1);
+        assert_eq!(
+            parse_unique_json(&line),
+            Err(UniqueJsonError::LineTooLong { limit })
+        );
+    }
+
+    #[test]
+    fn method_bearing_detects_the_wrap_heuristic() {
+        assert!(is_method_bearing_frame(
+            r#"{"jsonrpc":"2.0","method":"tools/call""#
+        ));
+        assert!(!is_method_bearing_frame("not-json"));
+        assert_eq!(json!({"name": "echo"})["name"], "echo");
+    }
+}

--- a/crates/assay-core/src/mcp/unique_json.rs
+++ b/crates/assay-core/src/mcp/unique_json.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 
 /// Why a client line cannot be authorized.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum UniqueJsonError {
     DuplicateMember,
     Malformed,

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -29,6 +29,7 @@ mod io;
 mod observer;
 
 use anyhow::{Context, Result};
+use assay_core::mcp::parse_unique_json;
 use assay_mcp_server::manifest_observed::{self, Completeness};
 use serde_json::Value;
 use std::path::PathBuf;
@@ -204,7 +205,7 @@ pub async fn run(
         if line.trim().is_empty() {
             continue;
         }
-        let v: Value = match serde_json::from_str(&line) {
+        let v: Value = match parse_unique_json(&line) {
             Ok(v) => v,
             Err(_) => {
                 let _ = tx.send(io::proxy_error_line(

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -29,7 +29,7 @@ mod io;
 mod observer;
 
 use anyhow::{Context, Result};
-use assay_core::mcp::parse_unique_json;
+use assay_core::mcp::{is_tools_call_method, parse_unique_json};
 use assay_mcp_server::manifest_observed::{self, Completeness};
 use serde_json::Value;
 use std::path::PathBuf;
@@ -229,22 +229,7 @@ pub async fn run(
         }
 
         match v.get("method").and_then(|m| m.as_str()) {
-            Some(method) if ALLOWLIST.contains(&method) => {
-                if method == "tools/list" {
-                    let had_cursor = v
-                        .pointer("/params/cursor")
-                        .map(|c| !c.is_null())
-                        .unwrap_or(false);
-                    observer
-                        .lock()
-                        .await
-                        .on_client_tools_list(v.get("id"), had_cursor);
-                }
-                if io::forward_line(&mut child_stdin, &line).await.is_err() {
-                    break;
-                }
-            }
-            Some(method) if mode == Mode::Enforce && method == "tools/call" => {
+            Some(method) if mode == Mode::Enforce && is_tools_call_method(method) => {
                 let policy = policy
                     .as_ref()
                     .expect("enforce mode without a loaded policy is a startup bug");
@@ -268,6 +253,21 @@ pub async fn run(
                     .await
                     .is_err()
                 {
+                    break;
+                }
+            }
+            Some(method) if ALLOWLIST.contains(&method) => {
+                if method == "tools/list" {
+                    let had_cursor = v
+                        .pointer("/params/cursor")
+                        .map(|c| !c.is_null())
+                        .unwrap_or(false);
+                    observer
+                        .lock()
+                        .await
+                        .on_client_tools_list(v.get("id"), had_cursor);
+                }
+                if io::forward_line(&mut child_stdin, &line).await.is_err() {
                     break;
                 }
             }

--- a/crates/assay-mcp-server/tests/fixtures/proxy/member_oracles.py
+++ b/crates/assay-mcp-server/tests/fixtures/proxy/member_oracles.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Controlled JSON object-member oracles for authorize/forward tests.
+
+Modes are abstract test doubles (first-member, last-member, strict-reject).
+They are not a named-upstream bypass recipe.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def first_member(pairs):
+    out = {}
+    for key, value in pairs:
+        if key not in out:
+            out[key] = value
+    return out
+
+
+def last_member(pairs):
+    return dict(pairs)
+
+
+def strict_reject(pairs):
+    out = {}
+    for key, value in pairs:
+        if key in out:
+            raise ValueError("duplicate member")
+        out[key] = value
+    return out
+
+
+HOOKS = {
+    "first": first_member,
+    "last": last_member,
+    "reject": strict_reject,
+}
+
+
+def interpret(line: str, mode: str) -> dict:
+    hook = HOOKS[mode]
+    try:
+        msg = json.loads(line, object_pairs_hook=hook)
+    except (json.JSONDecodeError, ValueError):
+        return {"accepted": False}
+    params = msg.get("params") if isinstance(msg, dict) else None
+    if not isinstance(params, dict):
+        params = {}
+    arguments = params.get("arguments")
+    if not isinstance(arguments, dict):
+        arguments = {}
+    return {
+        "accepted": True,
+        "method": msg.get("method") if isinstance(msg, dict) else None,
+        "name": params.get("name"),
+        "arguments": arguments,
+        "id": msg.get("id") if isinstance(msg, dict) else None,
+    }
+
+
+def _append(path: str | None, text: str) -> None:
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(text + "\n")
+        handle.flush()
+
+
+def _send(obj: dict) -> None:
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def serve(mode: str) -> None:
+    raw_log = os.environ.get("ORACLE_RAW_LOG")
+    interpret_log = os.environ.get("ORACLE_INTERPRET_LOG")
+    while True:
+        raw = sys.stdin.readline()
+        if not raw:
+            break
+        line = raw.strip()
+        if not line:
+            continue
+        _append(raw_log, line)
+        seen = interpret(line, mode)
+        _append(interpret_log, json.dumps(seen, separators=(",", ":")))
+        if not seen.get("accepted"):
+            continue
+        mid = seen.get("id")
+        method = seen.get("method")
+        if method == "initialize":
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": mid,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "member-oracle", "version": "0"},
+                    },
+                }
+            )
+        elif method == "ping":
+            _send({"jsonrpc": "2.0", "id": mid, "result": {}})
+        elif method == "tools/list":
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": mid,
+                    "result": {
+                        "tools": [
+                            {
+                                "name": "echo",
+                                "description": "echo",
+                                "inputSchema": {"type": "object"},
+                            }
+                        ]
+                    },
+                }
+            )
+        elif method == "tools/call":
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": mid,
+                    "result": {
+                        "content": [{"type": "text", "text": "oracle-ok"}],
+                        "isError": False,
+                    },
+                }
+            )
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        sys.stderr.write("usage: member_oracles.py interpret|serve [first|last|reject]\n")
+        sys.exit(2)
+    action = sys.argv[1]
+    mode = sys.argv[2] if len(sys.argv) > 2 else os.environ.get("ORACLE_MODE", "last")
+    if mode not in HOOKS:
+        sys.stderr.write(f"unknown mode {mode}\n")
+        sys.exit(2)
+    if action == "interpret":
+        line = sys.stdin.read().strip()
+        sys.stdout.write(json.dumps(interpret(line, mode), separators=(",", ":")) + "\n")
+        return
+    if action == "serve":
+        serve(mode)
+        return
+    sys.stderr.write(f"unknown action {action}\n")
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/assay-mcp-server/tests/fixtures/proxy/member_oracles.py
+++ b/crates/assay-mcp-server/tests/fixtures/proxy/member_oracles.py
@@ -39,6 +39,13 @@ HOOKS = {
     "reject": strict_reject,
 }
 
+# Closed set of log basenames. Env values are admitted only as these names;
+# `open` uses the dict value, never the raw env string.
+ALLOWED_LOG_NAMES = {
+    "raw.log": "raw.log",
+    "interpret.ndjson": "interpret.ndjson",
+}
+
 
 def interpret(line: str, mode: str) -> dict:
     hook = HOOKS[mode]
@@ -61,10 +68,29 @@ def interpret(line: str, mode: str) -> dict:
     }
 
 
-def _append(path: str | None, text: str) -> None:
-    if not path:
+def allowed_log_name(name: str | None) -> str | None:
+    """Admit a single allowed basename, or refuse before any open.
+
+    Separators, `.`, `..`, and unknown names fail. A successful return is a
+    value from ALLOWED_LOG_NAMES, not the raw env string.
+    """
+    if not name:
+        return None
+    if any(sep in name for sep in ("/", "\\", os.sep)):
+        raise ValueError("log name must be a single path component")
+    if name in {".", ".."}:
+        raise ValueError("log name must be a single path component")
+    admitted = ALLOWED_LOG_NAMES.get(name)
+    if admitted is None:
+        raise ValueError("unknown log name")
+    return admitted
+
+
+def _append(name: str | None, text: str) -> None:
+    admitted = allowed_log_name(name)
+    if not admitted:
         return
-    with open(path, "a", encoding="utf-8") as handle:
+    with open(admitted, "a", encoding="utf-8") as handle:
         handle.write(text + "\n")
         handle.flush()
 
@@ -75,8 +101,12 @@ def _send(obj: dict) -> None:
 
 
 def serve(mode: str) -> None:
-    raw_log = os.environ.get("ORACLE_RAW_LOG")
-    interpret_log = os.environ.get("ORACLE_INTERPRET_LOG")
+    try:
+        raw_log = allowed_log_name(os.environ.get("ORACLE_RAW_LOG"))
+        interpret_log = allowed_log_name(os.environ.get("ORACLE_INTERPRET_LOG"))
+    except ValueError as err:
+        sys.stderr.write(f"{err}\n")
+        sys.exit(2)
     while True:
         raw = sys.stdin.readline()
         if not raw:
@@ -136,9 +166,24 @@ def serve(mode: str) -> None:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        sys.stderr.write("usage: member_oracles.py interpret|serve [first|last|reject]\n")
+        sys.stderr.write(
+            "usage: member_oracles.py interpret|serve|check-log-name [arg]\n"
+        )
         sys.exit(2)
     action = sys.argv[1]
+    if action == "check-log-name":
+        if len(sys.argv) < 3:
+            sys.stderr.write("usage: member_oracles.py check-log-name NAME\n")
+            sys.exit(2)
+        try:
+            admitted = allowed_log_name(sys.argv[2])
+        except ValueError as err:
+            sys.stderr.write(f"{err}\n")
+            sys.exit(1)
+        if admitted is None:
+            sys.exit(1)
+        sys.stdout.write(admitted + "\n")
+        return
     mode = sys.argv[2] if len(sys.argv) > 2 else os.environ.get("ORACLE_MODE", "last")
     if mode not in HOOKS:
         sys.stderr.write(f"unknown mode {mode}\n")

--- a/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
+++ b/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
@@ -154,6 +154,16 @@ impl Conn {
         stdin.flush().expect("flush request");
     }
 
+    /// Write one already-serialized JSON-RPC line. Used for frames whose member
+    /// order or duplicate members cannot be produced by [`Value`] serialization.
+    pub fn send_line(&mut self, line: &str) {
+        let preview: String = line.chars().take(80).collect();
+        self.last_sent = Some(preview);
+        let stdin = self.stdin.as_mut().expect("stdin is still open");
+        writeln!(stdin, "{line}").expect("write request");
+        stdin.flush().expect("flush request");
+    }
+
     /// Send a request and read the response to it.
     ///
     /// Reads with [`Conn::read_response`] and not [`Conn::read_json`]: the name promises the

--- a/crates/assay-mcp-server/tests/member_oracle_log_allowlist.rs
+++ b/crates/assay-mcp-server/tests/member_oracle_log_allowlist.rs
@@ -1,0 +1,92 @@
+//! Bite tests for the member-oracle log-name allowlist.
+//!
+//! Env-controlled log paths must be closed basenames. A separator, `..`, or an
+//! unknown name is refused before `open`. Abstract fixture only.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn python() -> &'static str {
+    if cfg!(windows) {
+        "python"
+    } else {
+        "python3"
+    }
+}
+
+fn oracle_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/proxy/member_oracles.py")
+}
+
+fn check_log_name(name: &str) -> std::process::Output {
+    Command::new(python())
+        .args([oracle_path().to_str().unwrap(), "check-log-name", name])
+        .output()
+        .expect("spawn oracle check-log-name")
+}
+
+#[test]
+fn allowed_basenames_are_admitted() {
+    for name in ["raw.log", "interpret.ndjson"] {
+        let out = check_log_name(name);
+        assert!(
+            out.status.success(),
+            "{name} must be admitted: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
+#[test]
+fn separator_is_refused_before_open() {
+    for name in ["foo/bar", r"foo\bar", "/tmp/raw.log"] {
+        let out = check_log_name(name);
+        assert!(!out.status.success(), "{name:?} must fail before open");
+    }
+}
+
+#[test]
+fn parent_component_is_refused_before_open() {
+    let out = check_log_name("..");
+    assert!(!out.status.success(), ".. must fail before open");
+    let out = check_log_name("../escape.log");
+    assert!(!out.status.success(), "../escape.log must fail before open");
+}
+
+#[test]
+fn unknown_basename_is_refused_before_open() {
+    let out = check_log_name("unknown.log");
+    assert!(!out.status.success(), "unknown.log must fail before open");
+}
+
+#[test]
+fn serve_does_not_open_a_rejected_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let token = "oracle-allowlist-escape-must-not-exist.log";
+    let outside = dir.path().parent().expect("temp parent").join(token);
+    let _ = std::fs::remove_file(&outside);
+    let mut child = Command::new(python())
+        .args([oracle_path().to_str().unwrap(), "serve", "last"])
+        .current_dir(dir.path())
+        .env("ORACLE_RAW_LOG", format!("../{token}"))
+        .env("ORACLE_INTERPRET_LOG", "interpret.ndjson")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn oracle serve");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin");
+        let _ = stdin.write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n");
+    }
+    let output = child.wait_with_output().expect("oracle exit");
+    assert!(
+        !outside.exists(),
+        "rejected name must not be opened; {token} was created"
+    );
+    assert!(
+        !output.status.success(),
+        "serve must refuse a rejected log name at startup"
+    );
+}

--- a/crates/assay-mcp-server/tests/proxy_authorize_forward_parity.rs
+++ b/crates/assay-mcp-server/tests/proxy_authorize_forward_parity.rs
@@ -128,6 +128,14 @@ fn forwarded_calls(raw: &Path) -> Vec<String> {
         .collect()
 }
 
+fn enforcement_decision_count(path: &Path) -> usize {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .count()
+}
+
 fn last_decision(path: &Path) -> Option<Value> {
     std::fs::read_to_string(path)
         .unwrap_or_default()
@@ -154,6 +162,79 @@ fn assert_oracles_match_authorized(authorized_name: &str, authorized_args: &Valu
             "{mode} oracle arguments diverged from the authorized arguments"
         );
     }
+}
+
+const INIT_LINE: &str = r#"{"jsonrpc":"2.0","id":21,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}"#;
+const LIST_LINE: &str = r#"{"jsonrpc":"2.0","id":22,"method":"tools/list"}"#;
+const NOTE_LINE: &str = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+const NON_REQUEST_LINE: &str = r#"{"jsonrpc":"2.0","id":23,"result":{"passthrough":true}}"#;
+const PING_LINE: &str = r#"{"jsonrpc":"2.0","id":24,"method":"ping"}"#;
+
+#[test]
+fn protocol_control_is_forwarded_without_enforcement_decision() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let raw = dir.path().join("raw.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut out = Conn::attach(spawn_enforce(&log, &raw, &policy, &decisions));
+
+    out.send_line(INIT_LINE);
+    let init = out.read_response_for_id(21);
+    assert!(
+        init.get("error").is_none(),
+        "initialize must be forwarded, not policy-denied: {init}"
+    );
+    out.send_line(LIST_LINE);
+    let listed = out.read_response_for_id(22);
+    assert!(
+        listed.get("error").is_none(),
+        "tools/list must be forwarded, not policy-denied: {listed}"
+    );
+    out.send_line(NOTE_LINE);
+    out.send_line(NON_REQUEST_LINE);
+    out.send_line(PING_LINE);
+    let ping = out.read_response_for_id(24);
+    assert!(
+        ping.get("error").is_none(),
+        "ping must be forwarded, not policy-denied: {ping}"
+    );
+    assert_eq!(
+        enforcement_decision_count(&decisions),
+        0,
+        "non-tools/call unique objects must not mint an enforcement decision: {}",
+        std::fs::read_to_string(&decisions).unwrap_or_default()
+    );
+
+    let call = r#"{"jsonrpc":"2.0","id":25,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{"owner":"acme","repo":"prod-app"}}}"#;
+    out.send_line(call);
+    let r = out.read_response_for_id(25);
+    assert!(
+        r.get("error").is_none(),
+        "tools/call must still authorize the exact parsed value: {r}"
+    );
+    let _ = out.shutdown();
+
+    let body = std::fs::read_to_string(&raw).unwrap_or_default();
+    for line in [INIT_LINE, LIST_LINE, NOTE_LINE, NON_REQUEST_LINE, PING_LINE] {
+        assert!(
+            body.contains(line),
+            "protocol-control line must be forwarded byte-identically: missing {line} in {body}"
+        );
+    }
+    assert_eq!(
+        forwarded_calls(&raw).len(),
+        1,
+        "tools/call must still reach upstream once"
+    );
+    let rec = last_decision(&decisions).expect("tools/call decision");
+    assert_eq!(rec["decision"], "allow");
+    assert_eq!(rec["tool"]["name"], "github.add_deploy_key");
+    assert_eq!(
+        enforcement_decision_count(&decisions),
+        1,
+        "exactly one enforcement decision, for the tools/call"
+    );
 }
 
 #[test]

--- a/crates/assay-mcp-server/tests/proxy_authorize_forward_parity.rs
+++ b/crates/assay-mcp-server/tests/proxy_authorize_forward_parity.rs
@@ -1,0 +1,281 @@
+//! SECURITY-001: the value authorized must be the value forwarded.
+//!
+//! Drives a real `tools/call` through `proxy-enforce` and compares the PDP
+//! decision record against first-member / last-member / strict-reject oracles
+//! applied to the bytes actually written upstream. Abstract member fixtures
+//! only; not a named-upstream bypass recipe.
+
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+mod jsonrpc_conn;
+use jsonrpc_conn::Conn;
+
+const PROXY_FAILED: i64 = -31998;
+
+const ALLOW_ACME: &str = r#"
+caller:
+  id: "ci-agent"
+upstream_credential:
+  alias: "gh-deploy"
+  scopes: ["repo:deploy_key:write"]
+allowances:
+  - action_class: "github_deploy_key"
+    targets:
+      - { owner: "acme", repo: "prod-app" }
+"#;
+
+fn python() -> &'static str {
+    if cfg!(windows) {
+        "python"
+    } else {
+        "python3"
+    }
+}
+
+fn mock_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/proxy/mock_upstream.py")
+}
+
+fn oracle_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/proxy/member_oracles.py")
+}
+
+fn baseline_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/mcp_manifest_drift/declared_per_tool_baseline.json")
+}
+
+fn write_file(dir: &Path, name: &str, content: &str) -> PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, content).expect("write");
+    p
+}
+
+fn spawn_enforce(log: &Path, raw: &Path, policy: &Path, decisions: &Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args([
+            "proxy-enforce",
+            "--upstream-command",
+            python(),
+            "--upstream-arg",
+            "-u",
+            "--upstream-arg",
+            mock_path().to_str().unwrap(),
+            "--enforce-policy",
+            policy.to_str().unwrap(),
+            "--declared-mcp-manifest",
+            baseline_path().to_str().unwrap(),
+            "--enforcement-decision-out",
+            decisions.to_str().unwrap(),
+        ])
+        .env("MOCK_UPSTREAM_LOG", log)
+        .env("MOCK_UPSTREAM_RAW_LOG", raw)
+        .env("MOCK_UPSTREAM_MODE", "p60a")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn enforce proxy")
+}
+
+fn init() -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "t", "version": "1"}}
+    })
+}
+
+fn handshake(out: &mut Conn) {
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let _ = out.read_response();
+}
+
+fn oracle(mode: &str, line: &str) -> Value {
+    let out = Command::new(python())
+        .args([oracle_path().to_str().unwrap(), "interpret", mode])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn oracle");
+    let mut child = out;
+    {
+        use std::io::Write;
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(line.as_bytes())
+            .unwrap();
+    }
+    let output = child.wait_with_output().expect("oracle exit");
+    assert!(output.status.success(), "oracle {mode} failed");
+    serde_json::from_slice(&output.stdout).expect("oracle json")
+}
+
+fn forwarded_calls(raw: &Path) -> Vec<String> {
+    std::fs::read_to_string(raw)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| {
+            l.contains("\"method\":\"tools/call\"") || l.contains("\"method\": \"tools/call\"")
+        })
+        .map(str::to_string)
+        .collect()
+}
+
+fn last_decision(path: &Path) -> Option<Value> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("decision json"))
+        .next_back()
+}
+
+fn assert_oracles_match_authorized(authorized_name: &str, authorized_args: &Value, line: &str) {
+    for mode in ["first", "last", "reject"] {
+        let seen = oracle(mode, line);
+        assert_eq!(
+            seen["accepted"], true,
+            "{mode} oracle must accept a unique-member frame: {seen}"
+        );
+        assert_eq!(
+            seen["name"].as_str(),
+            Some(authorized_name),
+            "{mode} oracle name diverged from the authorized name"
+        );
+        assert_eq!(
+            &seen["arguments"], authorized_args,
+            "{mode} oracle arguments diverged from the authorized arguments"
+        );
+    }
+}
+
+#[test]
+fn unique_key_control_authorized_value_equals_forwarded_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let raw = dir.path().join("raw.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut out = Conn::attach(spawn_enforce(&log, &raw, &policy, &decisions));
+    handshake(&mut out);
+
+    // Numeric domain control: the id must survive as written, not a re-serialized Number.
+    let line = r#"{"jsonrpc":"2.0","id":1e2,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{"owner":"acme","repo":"prod-app"}}}"#;
+    out.send_line(line);
+    let r = out.read_response();
+    assert!(
+        r.get("error").is_none(),
+        "unique-key control was denied: {r}"
+    );
+    let _ = out.shutdown();
+
+    let calls = forwarded_calls(&raw);
+    assert_eq!(
+        calls.len(),
+        1,
+        "unique-key control must forward once: {calls:?}"
+    );
+    assert!(
+        calls[0].contains("1e2"),
+        "forwarded bytes must preserve the written numeric id: {}",
+        calls[0]
+    );
+    let rec = last_decision(&decisions).expect("decision record");
+    assert_eq!(rec["decision"], "allow");
+    assert_eq!(rec["tool"]["name"], "github.add_deploy_key");
+    assert_oracles_match_authorized(
+        "github.add_deploy_key",
+        &serde_json::json!({"owner": "acme", "repo": "prod-app"}),
+        &calls[0],
+    );
+}
+
+#[test]
+fn noop_control_ping_is_not_a_tools_call() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let raw = dir.path().join("raw.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut out = Conn::attach(spawn_enforce(&log, &raw, &policy, &decisions));
+    handshake(&mut out);
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 50, "method": "ping"}));
+    let r = out.read_response();
+    assert_eq!(r["id"], 50);
+    let _ = out.shutdown();
+    assert!(forwarded_calls(&raw).is_empty());
+    assert!(last_decision(&decisions).is_none());
+    let methods = std::fs::read_to_string(&log).unwrap_or_default();
+    assert!(methods.contains("ping"));
+}
+
+#[test]
+fn duplicate_params_name_is_not_forwarded_and_oracles_do_not_diverge() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let raw = dir.path().join("raw.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut out = Conn::attach(spawn_enforce(&log, &raw, &policy, &decisions));
+    handshake(&mut out);
+
+    let line = r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","name":"github.add_deploy_key","arguments":{"owner":"acme","repo":"prod-app"}}}"#;
+    out.send_line(line);
+    let r = out.read_response();
+    let _ = out.shutdown();
+
+    let calls = forwarded_calls(&raw);
+    assert!(
+        calls.is_empty(),
+        "duplicate params.name must not be forwarded: {calls:?}"
+    );
+    assert_eq!(
+        r["error"]["code"], PROXY_FAILED,
+        "duplicate members are an ingress refusal, not a silent last-member allow: {r}"
+    );
+    if let Some(rec) = last_decision(&decisions) {
+        assert_ne!(
+            rec["decision"], "allow",
+            "must not authorize a collapsed tree: {rec}"
+        );
+    }
+}
+
+#[test]
+fn duplicate_argument_member_is_not_forwarded_and_oracles_do_not_diverge() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let raw = dir.path().join("raw.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut out = Conn::attach(spawn_enforce(&log, &raw, &policy, &decisions));
+    handshake(&mut out);
+
+    let line = r#"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{"owner":"other","owner":"acme","repo":"prod-app"}}}"#;
+    out.send_line(line);
+    let r = out.read_response();
+    let _ = out.shutdown();
+
+    let calls = forwarded_calls(&raw);
+    assert!(
+        calls.is_empty(),
+        "duplicate argument members must not be forwarded: {calls:?}"
+    );
+    assert_eq!(
+        r["error"]["code"], PROXY_FAILED,
+        "duplicate arguments refused: {r}"
+    );
+    if let Some(rec) = last_decision(&decisions) {
+        assert_ne!(
+            rec["decision"], "allow",
+            "must not authorize a collapsed tree: {rec}"
+        );
+    }
+}

--- a/crates/assay-mcp-server/tests/proxy_authorize_forward_parity.rs
+++ b/crates/assay-mcp-server/tests/proxy_authorize_forward_parity.rs
@@ -248,6 +248,50 @@ fn duplicate_params_name_is_not_forwarded_and_oracles_do_not_diverge() {
     }
 }
 
+/// Abstract duplicate-member fixture whose keys are JSON-escaped. It contains
+/// no literal `"method"` / `"params"` / `"tool"` token, so a raw method-bearing
+/// heuristic does not see it.
+const ESCAPED_DUPLICATE_OBJECT: &str = r#"{"jsonrpc":"2.0","id":1,"\u006dethod":"tools/list","\u006dethod":"tools/call","\u0070arams":{"name":"danger","arguments":{}}}"#;
+
+#[test]
+fn escaped_duplicate_object_is_not_forwarded() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let raw = dir.path().join("raw.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut out = Conn::attach(spawn_enforce(&log, &raw, &policy, &decisions));
+    handshake(&mut out);
+
+    out.send_line(ESCAPED_DUPLICATE_OBJECT);
+    let r = out.read_response();
+    let _ = out.shutdown();
+
+    let body = std::fs::read_to_string(&raw).unwrap_or_default();
+    assert!(
+        !body.contains(ESCAPED_DUPLICATE_OBJECT),
+        "escaped duplicate object must not reach upstream: {body}"
+    );
+    assert!(
+        !body.contains(r#"\u006dethod"#),
+        "escaped duplicate object must not reach upstream: {body}"
+    );
+    assert!(
+        !body.contains("danger"),
+        "escaped duplicate object must not reach upstream: {body}"
+    );
+    assert_eq!(
+        r["error"]["code"], PROXY_FAILED,
+        "object-shaped unique-parse fail is an ingress refusal: {r}"
+    );
+    if let Some(rec) = last_decision(&decisions) {
+        assert_ne!(
+            rec["decision"], "allow",
+            "must not authorize a collapsed tree: {rec}"
+        );
+    }
+}
+
 #[test]
 fn duplicate_argument_member_is_not_forwarded_and_oracles_do_not_diverge() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: private `Rul1an/assay-tunnel-experiments#218` (no public programme is active)
- Slice: SECURITY-001 authorize/forward semantic equivalence
- Builder: Cursor (`cursor/218-authorize-forward-parity`)
- Reviewers: one independent non-building agent (builder self-review does not count)
- Final head SHA: `5af0dadd9f6b0722cecdda32191478a72b013540`
- Pin: public `origin/main` `822f5286b34abeb58f2317c392d4a069997e1309`
- Worktree: `/Users/roelschuurkes/wt-cursor-218-parse-forward` (standalone clone; `CARGO_TARGET_DIR` under the worktree)
- Toolchain: `rustc 1.96.0 (ac68faa20 2026-05-25)`
- ADR invariants affected: MCP authorization / live proxy ingest. Decision vs observation vs outcome stay separate. No new schema, score, or whole-action verdict.

## Behavior

**Reproduced** on the pin. `proxy-enforce` and `assay mcp wrap` parsed a client line into a last-member `Value`, authorized that tree, then forwarded the original bytes. Duplicate `params.name` / argument members and wrap's unparsable method-bearing frames could therefore be interpreted differently by first-member and strict-reject oracles than by the PDP.

The invariant is: the value authorized is the value forwarded. Ingress now refuses duplicate object members (reusing the existing unique-member parse). A unique JSON object that declares a request method but cannot be decoded as the typed JSON-RPC request fails closed as `-32600` without forwarding or producing a decision. Object-shaped malformed JSON remains `-32700`; unique non-request responses remain byte-identical pass-through. Unique-key allows still forward the original bytes, so JSON-RPC ids and the written numeric domain are preserved.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim
- No demonstrated bypass against a named released upstream server
- Deny paths are unchanged: a denied call is still not forwarded
- This is not a generic JCS / canonicalization requirement

## Test Evidence

### RED

On pin `822f5286b34abeb58f2317c392d4a069997e1309`, before the production change:

```
CARGO_TARGET_DIR=.../.cargo-target cargo test -p assay-mcp-server --test proxy_authorize_forward_parity
```

Failed: duplicate `params.name` and duplicate argument members were allowed last-member-wins and the raw duplicate line reached the upstream. Unique-key and ping no-op controls passed.

```
CARGO_TARGET_DIR=.../.cargo-target cargo test -p assay-cli --test mcp_wrap_authorize_forward
```

Failed: wrap forwarded duplicate `params.name` and warned-then-forwarded an unparsable method-bearing frame.

### GREEN

```
CARGO_TARGET_DIR=/Users/roelschuurkes/wt-cursor-218-parse-forward/.cargo-target \
  cargo test -p assay-mcp-server --test proxy_authorize_forward_parity
CARGO_TARGET_DIR=... cargo test -p assay-cli --test mcp_wrap_authorize_forward
CARGO_TARGET_DIR=... cargo test -p assay-core --lib unique_json
CARGO_TARGET_DIR=... cargo test -p assay-mcp-server --test proxy_enforce_e2e --test proxy_forwarding_e2e
CARGO_TARGET_DIR=... cargo test -p assay-cli --test e2e_mcp_wrap_assert_cmd
CARGO_TARGET_DIR=... cargo test -p assay-mcp-server --test proxy_enforce_pdp_e2e fully_allowed_call
cargo fmt --all -- --check
cargo clippy -p assay-core --lib -- -D warnings
cargo clippy -p assay-mcp-server --all-targets -- -D warnings
git diff --check
```

All focused suites and mutations passed on head `5af0dadd9f6b0722cecdda32191478a72b013540`; hosted integration checks are reported separately by GitHub Actions and are not substituted for the independent review.

### Must-bite (restored after each)

- Remove unique-member rejection (`serde_json::Value` last-wins): `duplicate_params_name_is_not_forwarded_and_oracles_do_not_diverge` failed (raw duplicate forwarded; PDP allowed last name).
- Restore wrap raw-forward of an unparsable method-bearing frame: `wrap_unparsable_method_bearing_frame_is_not_forwarded` failed (broken frame present in oracle raw log).
- Forward a unique method-bearing object that fails typed request decoding: the typed-invalid-request tests failed because the frame reached the upstream instead of returning `-32600`.
- Treat a unique response object without `method` as a request failure: the response pass-through controls failed because their original bytes were not forwarded.
- Forward a serialization of the parsed `Value` instead of the original unique-key line: `unique_key_control_authorized_value_equals_forwarded_value` failed (`1e2` became `100.0`).
- Unique-key and ping no-op controls passed on the real code.

## Review Quorum

- [ ] One non-building agent review
- [ ] Every actionable finding is fixed or has a technical disposition
- [ ] Any delegated proof targets this exact head SHA

Do not merge. Do not enable auto-merge. Public description stays at the invariant; the private ledger is #218.

Optional automated reviews can add evidence, but do not count toward or block quorum.

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP proxy handling of JSON-RPC messages with duplicate, malformed, or oversized JSON fields.
  * Prevented unsafe or ambiguous tool requests from being authorized or forwarded.
  * Preserved authorized tool-call values, numeric IDs, and protocol-control messages during forwarding.
  * Added clearer rejection behavior for invalid requests and parsing failures.
  * Ensured non-tool methods such as `ping` and `tools/list` continue to work correctly.

* **Chores**
  * Excluded workspace-only test files from published package contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->