### PR TITLE
fix(mcp): one strict truth for declared and observed manifest projection

### DIFF
--- a/crates/assay-mcp-server/src/declared_manifest.rs
+++ b/crates/assay-mcp-server/src/declared_manifest.rs
@@ -12,12 +12,12 @@
 //!   an approval. The known-optional members below are the ones the committed baselines already
 //!   carry; they are declared so they stay checkable, not so they stay ignorable.
 //! - **Exact canonicalization id.** A baseline must name
-//!   [`manifest_observed::CANONICALIZATION`]. A digest is only comparable to another digest computed
+//!   [`crate::manifest_observed::CANONICALIZATION`]. A digest is only comparable to another digest computed
 //!   the same way, so a baseline that will not say how it was computed cannot be compared.
 //! - **Full digest syntax.** `sha256:` plus exactly 64 lowercase hex. A prefix check accepts
 //!   `sha256:` alone, and the drift gate compares digests as exact bytes.
 //! - **Recomputed manifest digest.** `manifest_digest` must recompute from the declared
-//!   `(name, tool_digest)` pairs through [`manifest_observed::manifest_digest`] — the same function
+//!   `(name, tool_digest)` pairs through [`crate::manifest_observed::manifest_digest`] — the same function
 //!   the observed producer uses. This is what makes a per-tool digest un-editable in isolation.
 //! - **Order independence.** That shared function sorts its entries, so a baseline's validity does
 //!   not depend on the order tools appear in the file. The committed baselines are not name-sorted,

--- a/crates/assay-mcp-server/src/declared_manifest.rs
+++ b/crates/assay-mcp-server/src/declared_manifest.rs
@@ -1,0 +1,182 @@
+//! #2654 Slice A: the strict `assay.declared_mcp_manifest.v0` model.
+//!
+//! This is the ONE validator for an operator-declared approval baseline. It is deliberately in the
+//! library, not behind the binary's `proxy` module, so that production startup
+//! (`--declared-mcp-manifest`) and the fixture guard validate through the same code rather than
+//! through two descriptions of the same rule.
+//!
+//! Load-bearing rules, each of which used to be silently unenforced:
+//!
+//! - **Closed members.** `deny_unknown_fields` everywhere. A baseline carrying a member this model
+//!   does not know is refused, because an approval that contains something nobody validated is not
+//!   an approval. The known-optional members below are the ones the committed baselines already
+//!   carry; they are declared so they stay checkable, not so they stay ignorable.
+//! - **Exact canonicalization id.** A baseline must name
+//!   [`manifest_observed::CANONICALIZATION`]. A digest is only comparable to another digest computed
+//!   the same way, so a baseline that will not say how it was computed cannot be compared.
+//! - **Full digest syntax.** `sha256:` plus exactly 64 lowercase hex. A prefix check accepts
+//!   `sha256:` alone, and the drift gate compares digests as exact bytes.
+//! - **Recomputed manifest digest.** `manifest_digest` must recompute from the declared
+//!   `(name, tool_digest)` pairs through [`manifest_observed::manifest_digest`] — the same function
+//!   the observed producer uses. This is what makes a per-tool digest un-editable in isolation.
+//! - **Order independence.** That shared function sorts its entries, so a baseline's validity does
+//!   not depend on the order tools appear in the file. The committed baselines are not name-sorted,
+//!   and requiring them to be would break bytes an operator already approved.
+//!
+//! Non-claims: this validates the baseline's internal truth, never that the baseline is the *right*
+//! approval. It performs no candidate generation, no promotion, and no first-observation trust.
+
+use crate::manifest_observed::{manifest_digest, CANONICALIZATION};
+use anyhow::{bail, Result};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+pub const DECLARED_MANIFEST_SCHEMA: &str = "assay.declared_mcp_manifest.v0";
+
+/// The declaring server's identity. Carried for operator provenance; not part of any digest.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct DeclaredServer {
+    pub id: String,
+}
+
+/// One approved tool. `name` and `tool_digest` are the approval; the rest is attribution the
+/// producer also emits, declared here so it is validated rather than ignored.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct BaselineTool {
+    pub name: String,
+    pub tool_digest: String,
+    #[serde(default)]
+    pub privileged: Option<bool>,
+    #[serde(default)]
+    pub privilege_classification: Option<String>,
+    #[serde(default)]
+    pub action_class: Option<String>,
+    /// P60d-v2 attribution. Optional, and deliberately OUTSIDE the manifest-digest preimage, so its
+    /// presence moves no digest. Values are still syntax-checked: an unreadable digest is not
+    /// attribution.
+    #[serde(default)]
+    pub field_digests: Option<BTreeMap<String, String>>,
+}
+
+/// The operator-pinned approval-time baseline. The ONLY source of the approval baseline — never the
+/// first observed session manifest (spec §16-B).
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct DeclaredManifest {
+    pub schema: String,
+    pub canonicalization: String,
+    pub manifest_digest: String,
+    pub tools: Vec<BaselineTool>,
+    /// Free-text operator note. Declared so it is permitted and bounded, never interpreted.
+    #[serde(default)]
+    pub note: Option<String>,
+    #[serde(default)]
+    pub server: Option<DeclaredServer>,
+}
+
+impl DeclaredManifest {
+    /// The approved `tool_digest` for `name`, or `None` if this tool has no approved baseline.
+    pub fn tool_digest_for(&self, name: &str) -> Option<&str> {
+        self.tools
+            .iter()
+            .find(|t| t.name == name)
+            .map(|t| t.tool_digest.as_str())
+    }
+}
+
+/// `sha256:` + exactly 64 lowercase hex. Exact bytes, because the drift gate compares exact bytes.
+fn is_canonical_sha256(s: &str) -> bool {
+    match s.strip_prefix("sha256:") {
+        Some(hex) => {
+            hex.len() == 64
+                && hex
+                    .bytes()
+                    .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        }
+        None => false,
+    }
+}
+
+/// Parse and strictly validate a declared baseline from JSON text.
+///
+/// Every failure is a hard error for the caller to turn into a startup failure: in enforcing mode a
+/// proxy that would forward privileged calls without a valid baseline must not start.
+pub fn parse_declared_manifest(text: &str) -> Result<DeclaredManifest> {
+    let manifest: DeclaredManifest = serde_json::from_str(text)?;
+
+    if manifest.schema != DECLARED_MANIFEST_SCHEMA {
+        bail!(
+            "schema must be {DECLARED_MANIFEST_SCHEMA}, got {:?}",
+            manifest.schema
+        );
+    }
+    if manifest.canonicalization != CANONICALIZATION {
+        bail!(
+            "canonicalization must be {CANONICALIZATION}, got {:?}; a digest is only comparable to one computed the same way",
+            manifest.canonicalization
+        );
+    }
+    if !is_canonical_sha256(&manifest.manifest_digest) {
+        bail!(
+            "manifest_digest must be sha256: plus 64 lowercase hex, got {:?}",
+            manifest.manifest_digest
+        );
+    }
+    if manifest.tools.is_empty() {
+        bail!("tools must be a non-empty array");
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    for t in &manifest.tools {
+        if t.name.trim().is_empty() {
+            bail!("every tool must have a non-empty name");
+        }
+        if !is_canonical_sha256(&t.tool_digest) {
+            bail!(
+                "tool {:?} tool_digest must be sha256: plus 64 lowercase hex, got {:?}",
+                t.name,
+                t.tool_digest
+            );
+        }
+        if let Some(fields) = &t.field_digests {
+            for (field, digest) in fields {
+                if !is_canonical_sha256(digest) {
+                    bail!(
+                        "tool {:?} field_digest {:?} must be sha256: plus 64 lowercase hex, got {:?}",
+                        t.name,
+                        field,
+                        digest
+                    );
+                }
+            }
+        }
+        // Duplicate declared names are `declared_mcp_manifest_ambiguous` (manifest-drift contract): a
+        // first-match-wins lookup over an ambiguous approval baseline is unsafe, so fail startup.
+        if !seen.insert(t.name.as_str()) {
+            bail!(
+                "duplicate tool name {:?} (an approval baseline must be unambiguous)",
+                t.name
+            );
+        }
+    }
+
+    // The declared manifest_digest must recompute from the declared pairs, through the SAME rule the
+    // observed producer uses. This is what stops one tool_digest from being edited in isolation.
+    let pairs: Vec<(String, String)> = manifest
+        .tools
+        .iter()
+        .map(|t| (t.name.clone(), t.tool_digest.clone()))
+        .collect();
+    let recomputed = manifest_digest(&pairs);
+    if recomputed != manifest.manifest_digest {
+        bail!(
+            "manifest_digest does not recompute from the declared tools: file says {:?}, tools yield {:?}",
+            manifest.manifest_digest,
+            recomputed
+        );
+    }
+
+    Ok(manifest)
+}

--- a/crates/assay-mcp-server/src/lib.rs
+++ b/crates/assay-mcp-server/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod auth;
 pub mod cache;
 pub mod config;
+pub mod declared_manifest;
 pub mod enforcement_sarif;
 pub mod manifest_observed;
 pub mod modern_adapter;

--- a/crates/assay-mcp-server/src/manifest_observed.rs
+++ b/crates/assay-mcp-server/src/manifest_observed.rs
@@ -108,7 +108,12 @@ fn field_digest(field: &str, value: &Value) -> String {
 /// `manifest_digest` over the manifest projection, with the projection id INSIDE the hashed preimage
 /// and entries sorted by `(name, tool_digest)` — order-independent, shape-pinned. NOTE: the preimage
 /// is `{name, tool_digest}` only; P60d-v2 `field_digests` are deliberately NOT included here.
-fn manifest_digest(name_digests: &[(String, String)]) -> String {
+///
+/// PUBLIC because the declared-v0 validator (`crate::declared_manifest`) and the P60d fixture guard
+/// must recompute a manifest digest by the SAME rule the observed producer uses. A second
+/// implementation of this sort+preimage is how observed and declared silently drift apart, so there
+/// is exactly one.
+pub fn manifest_digest(name_digests: &[(String, String)]) -> String {
     let mut entries: Vec<(String, String)> = name_digests.to_vec();
     entries.sort();
     let tools: Vec<Value> = entries

--- a/crates/assay-mcp-server/src/proxy/enforce/manifest.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce/manifest.rs
@@ -1,35 +1,10 @@
-use anyhow::{bail, Context, Result};
-use serde::Deserialize;
+use anyhow::{Context, Result};
 use std::path::Path;
 
-const DECLARED_MANIFEST_SCHEMA: &str = "assay.declared_mcp_manifest.v0";
-
-/// The operator-pinned approval-time baseline (`assay.declared_mcp_manifest.v0`): the per-tool
-/// `tool_digest` the caller approved. The drift gate (c3) compares the current observed per-tool digest
-/// against this. It is the ONLY source of the approval baseline — never the first observed session
-/// manifest (spec §16-B).
-#[derive(Debug, Deserialize)]
-pub struct DeclaredManifest {
-    pub schema: String,
-    #[serde(default)]
-    pub tools: Vec<BaselineTool>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct BaselineTool {
-    pub name: String,
-    pub tool_digest: String,
-}
-
-impl DeclaredManifest {
-    /// The approved `tool_digest` for `name`, or `None` if this tool has no approved baseline.
-    pub fn tool_digest_for(&self, name: &str) -> Option<&str> {
-        self.tools
-            .iter()
-            .find(|t| t.name == name)
-            .map(|t| t.tool_digest.as_str())
-    }
-}
+// #2654 Slice A: the declared-v0 model and its strict validation live in the library
+// (`crate::declared_manifest`) so that startup and the fixture guard share one implementation
+// instead of two descriptions of the same rule. This module keeps the startup wiring only.
+pub use assay_mcp_server::declared_manifest::{BaselineTool, DeclaredManifest};
 
 /// The current observed per-tool digest for the invoked tool, computed by the proxy from its own
 /// observed `tools/list` (P61c). Distinguishes "no complete manifest observed this session" from
@@ -50,40 +25,12 @@ pub enum ObservedToolDigest {
 /// Load + STRICTLY validate the declared-manifest baseline. Like the enforce policy, any failure here
 /// is a STARTUP failure (non-zero exit), never a runtime deny: in enforcing mode an approval baseline
 /// is required, and a proxy that would forward privileged calls without a valid baseline must not start.
+///
+/// The validation itself is `crate::declared_manifest::parse_declared_manifest`; this function adds
+/// only the file read and the caller-facing flag name.
 pub fn load_declared_manifest(path: &Path) -> Result<DeclaredManifest> {
     let text = std::fs::read_to_string(path)
         .with_context(|| format!("reading --declared-mcp-manifest {}", path.display()))?;
-    let manifest: DeclaredManifest =
-        serde_json::from_str(&text).with_context(|| "parsing --declared-mcp-manifest JSON")?;
-    if manifest.schema != DECLARED_MANIFEST_SCHEMA {
-        bail!(
-            "--declared-mcp-manifest: schema must be {DECLARED_MANIFEST_SCHEMA}, got {:?}",
-            manifest.schema
-        );
-    }
-    if manifest.tools.is_empty() {
-        bail!("--declared-mcp-manifest: tools must be a non-empty array");
-    }
-    let mut seen = std::collections::HashSet::new();
-    for t in &manifest.tools {
-        if t.name.trim().is_empty() {
-            bail!("--declared-mcp-manifest: every tool must have a non-empty name");
-        }
-        if !t.tool_digest.starts_with("sha256:") {
-            bail!(
-                "--declared-mcp-manifest: tool {:?} tool_digest must be a sha256: digest, got {:?}",
-                t.name,
-                t.tool_digest
-            );
-        }
-        // Duplicate declared names are `declared_mcp_manifest_ambiguous` (manifest-drift contract): a
-        // first-match-wins lookup over an ambiguous approval baseline is unsafe, so fail startup.
-        if !seen.insert(t.name.as_str()) {
-            bail!(
-                "--declared-mcp-manifest: duplicate tool name {:?} (an approval baseline must be unambiguous)",
-                t.name
-            );
-        }
-    }
-    Ok(manifest)
+    assay_mcp_server::declared_manifest::parse_declared_manifest(&text)
+        .with_context(|| format!("--declared-mcp-manifest {}", path.display()))
 }

--- a/crates/assay-mcp-server/src/proxy/enforce/tests.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce/tests.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use serde_json::{json, Value};
 use std::io::Write;
 
+mod declared_manifest;
 mod drift;
 mod fixtures;
 mod pdp;

--- a/crates/assay-mcp-server/src/proxy/enforce/tests/declared_manifest.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce/tests/declared_manifest.rs
@@ -1,0 +1,232 @@
+//! #2654 Slice A: strict declared-v0 manifest truth at `--declared-mcp-manifest` startup.
+//!
+//! Two jobs. FREEZE: the committed declared fixtures that load today must keep loading, byte
+//! unchanged, so the strictness added here cannot be paid for by breaking a valid operator baseline.
+//! RED: the members the loader used to ignore — unknown members, a wrong or absent canonicalization
+//! id, a malformed `sha256:` digest, and a `manifest_digest` that does not recompute — must fail
+//! before the proxy starts, because a baseline that is not what it says it is cannot be an approval.
+use super::*;
+use serde_json::Value;
+
+/// Repository-root-relative fixture, resolved from this crate's manifest dir.
+fn repo_path(rel: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+/// Every committed declared baseline a reader could legitimately hand to `--declared-mcp-manifest`.
+fn committed_declared_fixtures() -> Vec<std::path::PathBuf> {
+    [
+        "crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/declared_per_tool_baseline.json",
+        "crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/declared_per_tool_baseline_readonly_annotation.json",
+        "examples/privileged-action-gate/baseline-approved.json",
+        "examples/privileged-action-gate/baseline-approved-readonly.json",
+    ]
+    .iter()
+    .map(|r| repo_path(r))
+    .collect()
+}
+
+/// Load a declared manifest from an in-memory value, through the production startup path.
+fn load_value(v: &Value) -> Result<DeclaredManifest> {
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(serde_json::to_string_pretty(v).unwrap().as_bytes())
+        .unwrap();
+    load_declared_manifest(f.path())
+}
+
+/// The canonical valid baseline every RED case below mutates exactly one thing away from.
+fn valid_declared() -> Value {
+    let p = repo_path(
+        "crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/declared_per_tool_baseline.json",
+    );
+    serde_json::from_str(&std::fs::read_to_string(&p).unwrap()).unwrap()
+}
+
+// ---------------------------------------------------------------- FREEZE
+
+#[test]
+fn committed_declared_fixtures_still_load_unchanged() {
+    for p in committed_declared_fixtures() {
+        let m = load_declared_manifest(&p)
+            .unwrap_or_else(|e| panic!("committed fixture {} must load: {e:#}", p.display()));
+        assert_eq!(m.schema, "assay.declared_mcp_manifest.v0");
+        assert!(
+            !m.tools.is_empty(),
+            "committed fixture {} must declare tools",
+            p.display()
+        );
+    }
+}
+
+#[test]
+fn valid_declared_control_loads() {
+    // The no-op control for every mutation below: unmutated, it loads.
+    load_value(&valid_declared()).expect("unmutated valid baseline must load");
+}
+
+// ------------------------------------------------------------------- RED
+
+#[test]
+fn unknown_top_level_member_fails_startup() {
+    let mut v = valid_declared();
+    v.as_object_mut()
+        .unwrap()
+        .insert("rogue_member".into(), Value::Bool(true));
+    assert!(
+        load_value(&v).is_err(),
+        "an unknown top-level member must fail startup, not be silently ignored"
+    );
+}
+
+#[test]
+fn unknown_tool_member_fails_startup() {
+    let mut v = valid_declared();
+    v["tools"][0]
+        .as_object_mut()
+        .unwrap()
+        .insert("rogue_member".into(), Value::Bool(true));
+    assert!(
+        load_value(&v).is_err(),
+        "an unknown per-tool member must fail startup, not be silently ignored"
+    );
+}
+
+#[test]
+fn absent_canonicalization_fails_startup() {
+    let mut v = valid_declared();
+    v.as_object_mut().unwrap().remove("canonicalization");
+    assert!(
+        load_value(&v).is_err(),
+        "a baseline without a canonicalization id must fail startup"
+    );
+}
+
+#[test]
+fn wrong_canonicalization_fails_startup() {
+    let mut v = valid_declared();
+    v["canonicalization"] = Value::String("assay.some_other_projection.v0".into());
+    assert!(
+        load_value(&v).is_err(),
+        "a baseline naming another canonicalization must fail startup"
+    );
+}
+
+#[test]
+fn short_tool_digest_fails_startup() {
+    let mut v = valid_declared();
+    v["tools"][0]["tool_digest"] = Value::String("sha256:abc".into());
+    assert!(
+        load_value(&v).is_err(),
+        "a sha256: prefix with the wrong length must fail startup"
+    );
+}
+
+#[test]
+fn non_hex_tool_digest_fails_startup() {
+    let mut v = valid_declared();
+    v["tools"][0]["tool_digest"] = Value::String(format!("sha256:{}", "z".repeat(64)));
+    assert!(
+        load_value(&v).is_err(),
+        "a sha256: digest that is not lowercase hex must fail startup"
+    );
+}
+
+#[test]
+fn uppercase_tool_digest_fails_startup() {
+    let mut v = valid_declared();
+    let d = v["tools"][0]["tool_digest"].as_str().unwrap().to_string();
+    v["tools"][0]["tool_digest"] = Value::String(d.to_uppercase().replace("SHA256:", "sha256:"));
+    assert!(
+        load_value(&v).is_err(),
+        "an uppercase-hex digest must fail startup; digests compare as exact bytes"
+    );
+}
+
+#[test]
+fn absent_manifest_digest_fails_startup() {
+    let mut v = valid_declared();
+    v.as_object_mut().unwrap().remove("manifest_digest");
+    assert!(
+        load_value(&v).is_err(),
+        "a baseline without a manifest_digest must fail startup"
+    );
+}
+
+#[test]
+fn tool_digest_mutated_without_manifest_digest_fails_startup() {
+    let mut v = valid_declared();
+    // Flip the last hex nibble of one tool digest, leaving manifest_digest stale.
+    let d = v["tools"][0]["tool_digest"].as_str().unwrap().to_string();
+    let flipped = if d.ends_with('0') {
+        format!("{}1", &d[..d.len() - 1])
+    } else {
+        format!("{}0", &d[..d.len() - 1])
+    };
+    v["tools"][0]["tool_digest"] = Value::String(flipped);
+    assert!(
+        load_value(&v).is_err(),
+        "a tool digest that moves without its manifest_digest must fail startup"
+    );
+}
+
+#[test]
+fn manifest_digest_mismatch_fails_startup() {
+    let mut v = valid_declared();
+    v["manifest_digest"] = Value::String(format!("sha256:{}", "0".repeat(64)));
+    assert!(
+        load_value(&v).is_err(),
+        "a manifest_digest that does not recompute must fail startup"
+    );
+}
+
+// ------------------------------------------- behaviour that must NOT regress
+
+#[test]
+fn duplicate_tool_name_still_fails_startup() {
+    // NEAR MISS: the duplicate is added AND the manifest_digest is recomputed over the duplicated
+    // entries, so this document violates exactly one rule — duplicate names. Without the
+    // recomputation the digest check would reject it first and the duplicate-name refusal would
+    // never be the reason, which is a guard that looks pinned and is not.
+    let mut v = valid_declared();
+    let first = v["tools"][0].clone();
+    v["tools"].as_array_mut().unwrap().push(first);
+    let pairs: Vec<(String, String)> = v["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| {
+            (
+                t["name"].as_str().unwrap().to_string(),
+                t["tool_digest"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    v["manifest_digest"] =
+        Value::String(assay_mcp_server::manifest_observed::manifest_digest(&pairs));
+    assert!(
+        load_value(&v).is_err(),
+        "duplicate declared names must remain a startup failure on their own"
+    );
+}
+
+#[test]
+fn wrong_schema_still_fails_startup() {
+    let mut v = valid_declared();
+    v["schema"] = Value::String("assay.declared_mcp_manifest.v1".into());
+    assert!(
+        load_value(&v).is_err(),
+        "a foreign schema id must remain a startup failure"
+    );
+}
+
+#[test]
+fn empty_tools_still_fails_startup() {
+    let mut v = valid_declared();
+    v["tools"] = Value::Array(vec![]);
+    assert!(
+        load_value(&v).is_err(),
+        "an empty tools array must remain a startup failure"
+    );
+}

--- a/crates/assay-mcp-server/src/proxy/enforce/tests/fixtures.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce/tests/fixtures.rs
@@ -32,15 +32,31 @@ pub(super) fn acme_call() -> Value {
 }
 
 pub(super) const TOOL: &str = "github.add_deploy_key";
-pub(super) const APPROVED: &str = "sha256:approved-digest";
+/// A well-formed approved digest. #2654: the declared model requires `sha256:` + 64 lowercase hex,
+/// so this fixture states a real digest shape. Its VALUE is arbitrary — the drift gate compares
+/// declared against observed as exact bytes, and these tests supply both sides.
+pub(super) const APPROVED: &str =
+    "sha256:1111111111111111111111111111111111111111111111111111111111111111";
 
 /// A single-tool declared baseline (loaded + strictly validated like at startup).
+///
+/// #2654: builds a COMPLETE declared-v0 document, with the manifest digest recomputed through the
+/// same shared rule production validates against — a helper that hand-wrote a digest would be the
+/// second implementation this slice exists to remove.
+pub(super) fn declared_json(name: &str, digest: &str) -> String {
+    let manifest_digest = assay_mcp_server::manifest_observed::manifest_digest(&[(
+        name.to_string(),
+        digest.to_string(),
+    )]);
+    format!(
+        r#"{{"schema":"assay.declared_mcp_manifest.v0","canonicalization":"{canon}","manifest_digest":"{manifest_digest}","tools":[{{"name":"{name}","tool_digest":"{digest}"}}]}}"#,
+        canon = assay_mcp_server::manifest_observed::CANONICALIZATION,
+    )
+}
+
 pub(super) fn baseline_with(name: &str, digest: &str) -> DeclaredManifest {
-    let j = format!(
-        r#"{{"schema":"assay.declared_mcp_manifest.v0","tools":[{{"name":"{name}","tool_digest":"{digest}"}}]}}"#
-    );
     let mut f = tempfile::NamedTempFile::new().unwrap();
-    f.write_all(j.as_bytes()).unwrap();
+    f.write_all(declared_json(name, digest).as_bytes()).unwrap();
     load_declared_manifest(f.path()).unwrap()
 }
 

--- a/crates/assay-mcp-server/src/proxy/enforce/tests/policy.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce/tests/policy.rs
@@ -30,13 +30,14 @@ fn manifest_from(json: &str) -> Result<DeclaredManifest> {
 
 #[test]
 fn valid_baseline_loads() {
-    let m = manifest_from(
-        r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[{"name":"github.add_deploy_key","tool_digest":"sha256:abc"}]}"#,
-    )
+    let m = manifest_from(&super::fixtures::declared_json(
+        "github.add_deploy_key",
+        super::fixtures::APPROVED,
+    ))
     .unwrap();
     assert_eq!(
         m.tool_digest_for("github.add_deploy_key"),
-        Some("sha256:abc")
+        Some(super::fixtures::APPROVED)
     );
     assert_eq!(m.tool_digest_for("nope"), None);
 }

--- a/crates/assay-mcp-server/tests/mcp_manifest_granular_fixtures.rs
+++ b/crates/assay-mcp-server/tests/mcp_manifest_granular_fixtures.rs
@@ -5,9 +5,7 @@
 //! documented per-tool finding matrix + validity checks are executable. P60d explains which tool digest
 //! drifted; it does not explain which field changed or whether the change is malicious.
 
-use assay_core::mcp::jcs;
-use serde_json::{json, Value};
-use sha2::{Digest, Sha256};
+use serde_json::Value;
 use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::path::PathBuf;
@@ -19,10 +17,13 @@ fn fx(name: &str) -> Value {
     serde_json::from_str(&fs::read_to_string(&p).unwrap()).unwrap()
 }
 
-/// Recompute a manifest_digest from per-tool {name, tool_digest} entries via the documented JCS
-/// canonicalization (projection id inside the hashed preimage, entries sorted by name then digest).
+/// Recompute a manifest_digest from per-tool {name, tool_digest} entries.
+///
+/// #2654: this delegates to the production rule instead of restating it. The previous local copy of
+/// the JCS preimage and the entry sort was a second implementation of the same rule, free to drift
+/// from the producer it was supposed to be anchored to.
 fn recompute_manifest_digest(tools: &[Value]) -> String {
-    let mut entries: Vec<(String, String)> = tools
+    let entries: Vec<(String, String)> = tools
         .iter()
         .map(|t| {
             (
@@ -31,17 +32,7 @@ fn recompute_manifest_digest(tools: &[Value]) -> String {
             )
         })
         .collect();
-    entries.sort();
-    let arr: Vec<Value> = entries
-        .into_iter()
-        .map(|(n, d)| json!({"name": n, "tool_digest": d}))
-        .collect();
-    let bytes = jcs::to_vec(&json!({
-        "projection": "assay.mcp_manifest_projection.v0",
-        "tools": arr,
-    }))
-    .unwrap();
-    format!("sha256:{}", hex::encode(Sha256::digest(&bytes)))
+    assay_mcp_server::manifest_observed::manifest_digest(&entries)
 }
 
 fn dup_names(tools: &[Value]) -> bool {

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/drift_allow.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/drift_allow.rs
@@ -24,7 +24,10 @@ fn tool_absent_from_baseline_denies_baseline_missing() {
     let baseline = write_file(
         dir.path(),
         "baseline.json",
-        r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[{"name":"search","tool_digest":"sha256:abc"}]}"#,
+        &declared_baseline_json(
+            "search",
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        ),
     );
     let mut out = Conn::attach(spawn_enforce(&log, &policy, &baseline, "p60a"));
 
@@ -52,7 +55,10 @@ fn observed_digest_differs_from_baseline_denies_drifted() {
     let baseline = write_file(
         dir.path(),
         "baseline.json",
-        r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[{"name":"github.add_deploy_key","tool_digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000"}]}"#,
+        &declared_baseline_json(
+            "github.add_deploy_key",
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        ),
     );
     let mut out = Conn::attach(spawn_enforce(&log, &policy, &baseline, "p60a"));
 

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/support.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/support.rs
@@ -338,3 +338,19 @@ pub(crate) fn run_startup_output(extra: &[&str]) -> std::process::Output {
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     startup_output(&arg_refs)
 }
+
+/// A COMPLETE, strictly-valid declared-v0 baseline for one tool.
+///
+/// #2654: the declared model requires a canonicalization id and a `manifest_digest` that recomputes,
+/// so an e2e baseline is built through the same shared rule production validates against rather than
+/// hand-written. A minimal two-key document is no longer a baseline the proxy will start on.
+pub fn declared_baseline_json(name: &str, tool_digest: &str) -> String {
+    let manifest_digest = assay_mcp_server::manifest_observed::manifest_digest(&[(
+        name.to_string(),
+        tool_digest.to_string(),
+    )]);
+    format!(
+        r#"{{"schema":"assay.declared_mcp_manifest.v0","canonicalization":"{canon}","manifest_digest":"{manifest_digest}","tools":[{{"name":"{name}","tool_digest":"{tool_digest}"}}]}}"#,
+        canon = assay_mcp_server::manifest_observed::CANONICALIZATION,
+    )
+}

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -99,6 +99,7 @@ revision, when this block was a bare list.
 <!-- machine-checked: not-cli-documents -->
 ```text
 assay.coding_agent.evidence_pack.v0 | declared in assay-evidence as a bundle pack schema; no CLI write opened
+assay.declared_mcp_manifest.v0 | operator-authored approval baseline read by assay-mcp-server at startup; no command writes it
 assay.mandate.v1 | mandate event carried in evidence, not written by a command
 assay.mcp_manifest_observed.v0 | assay-mcp-server observation event inside a bundle
 assay.mcp_manifest_projection.v0 | assay-mcp-server projection event inside a bundle


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: none — AGENTS.md records that no programme is active, and this slice does not invent or reopen one.
- Slice: #2654 (Slice A of #2647) — strict shared MCP manifest truth.
- Builder: Claude Code (sole writer, worktree `wt-claude-2654-manifest-truth`).
- Reviewer: Cursor, independent exact-head READY record on `4a4e937a8daeb9353a3a91d61ca35c63c3abc232`; reviewer authored neither the governing plan nor the change.
- Final head SHA: `4a4e937a8daeb9353a3a91d61ca35c63c3abc232` (base `c1cd7e600ff34f84e03cb7503687adb340d5ebf8`). Every number below is measured on that SHA in that worktree, `cargo` with `--locked`.
- ADR invariants affected: ADR-043 (declared-vs-observed distinction, hostile input, ceilings before use). ADR-042 stop list untouched.

## Behavior

`--declared-mcp-manifest` previously accepted a baseline it had not validated. It checked `schema`, non-empty `tools`, a non-empty name, a `sha256:` **prefix**, and duplicate names — and silently ignored every other member the committed baselines actually carry: `canonicalization`, `manifest_digest`, `server`, `note`, and per-tool `privileged` / `privilege_classification` / `action_class` / `field_digests`. A prefix check also accepts `sha256:` alone, while the drift gate compares digests as exact bytes.

Now: closed members everywhere (`deny_unknown_fields`), exact canonicalization id, `sha256:` plus exactly 64 lowercase hex, duplicate refusal, and a `manifest_digest` that must recompute from the declared pairs. Failure is a **startup** failure before the proxy serves anything — never a runtime deny.

One rule, one function: the recomputation calls `manifest_observed::manifest_digest` (now `pub`), the same function the observed producer uses, so declared and observed cannot be computed by two sorts or two preimages. `tests/mcp_manifest_granular_fixtures.rs` dropped its local copy of that JCS preimage + entry sort and calls the production rule instead. The validator lives in the **library**, not behind the binary's `proxy` module, so startup and the fixture guard share code rather than a parity test — no crate boundary forced a second implementation.

Order independence is deliberate: the shared rule sorts its entries, so validity does not depend on tool order in the file. The committed baselines are **not** name-sorted, and requiring them to be would break bytes an operator already approved. All four committed baselines load byte-unchanged (frozen by test).

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim

Also held: no candidate/promote CLI (#2655), no automatic approval or first-observation trust, no public schema rename, no forwarding change.

## Test Evidence

### RED

Written before any production edit, against the production loader `load_declared_manifest`:

`cargo test --locked -p assay-mcp-server --bins declared_manifest`
→ **`FAILED. 5 passed; 10 failed`**

The 5 passing were the freeze test (four committed baselines load), the no-op control, and the three pre-existing refusals (schema, empty tools, duplicate name). The 10 failing were exactly the new requirements.

### GREEN

| Check | Result |
|---|---|
| `cargo test --locked -p assay-mcp-server` | **485 passed, 0 failed** |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --locked -p assay-mcp-server --all-targets -- -D warnings` | clean |
| `git diff --check` | clean |
| pre-push: workspace clippy (deny warnings), linux compile gate | Passed |

### Required mutations (production code; each reverted, reverts byte-verified)

| Mutation | Result |
|---|---|
| no-op control | ok. 15 passed |
| remove canonicalization validation | **FAILED. 14 passed; 1 failed** |
| accept unknown member (`deny_unknown_fields` off) | **FAILED. 14 passed; 1 failed** |
| drop manifest-digest recomputation | **FAILED. 13 passed; 2 failed** |
| permit duplicate name | **FAILED. 14 passed; 1 failed** |
| diverge observed/declared sorting | **FAILED. 13 passed; 2 failed** |

Two notes a reviewer should check rather than take on trust:

1. **The duplicate-name mutation initially did not bite.** The first fixture appended a duplicate tool, which also changes the recomputed manifest digest — so the digest check rejected it and the duplicate-name refusal was never the reason. The fixture is now a near-miss that recomputes `manifest_digest` over the duplicated entries, so it violates exactly one rule. The mutation bites only against the corrected fixture.
2. **The literal "permit duplicate name" edit does not compile** (`HashSet<_>` loses inference when the only `insert` is removed), which is a non-measurement, not a pass. The measured variant keeps the insert and discards its result.

The sorting mutation biting on 2 tests is the evidence that observed and declared share one rule: changing the sort in `manifest_observed` moves the declared fixtures' digests.

## Review Quorum

- [x] One non-building agent review
- [x] Every actionable finding is fixed or has a technical disposition: no live defects; open map keys and input/note ceilings are follow-up hardening for #2655, not accepted-manifest bypasses in this slice.
- [ ] Any delegated proof targets this exact head SHA

Draft on purpose: not ready, not for merge.

Refs #2654. Parent #2647.

