### PR TITLE
fix(release): derive installability from one asset contract (#2648)

### DIFF
--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -87,6 +87,28 @@ This document outlines the canonical checklist for releasing new versions of Ass
   - Step: `Check release asset preflight` (fails before publication unless the `release/` directory exactly matches the expected asset contract, every `.sha256` verifies, and `server.json` points at the generated MCPB checksum).
   - Step: `Create GitHub Release` (uploads only the preflighted files from `release/`).
 
+### Published binary installability
+
+`installer` means `scripts/install.sh` installs the component for that target.
+`manual_step` means a release archive exists but the installer does not install
+that component. `unsupported` means this release publishes no matching binary;
+it is not an installer failure.
+
+<!-- release-installability-matrix:start -->
+| Component | Target | Install status | Release asset |
+| --- | --- | --- | --- |
+| `assay` | `x86_64-unknown-linux-gnu` | `installer` | `assay-v5.4.0-x86_64-unknown-linux-gnu.tar.gz` |
+| `assay` | `aarch64-unknown-linux-gnu` | `installer` | `assay-v5.4.0-aarch64-unknown-linux-gnu.tar.gz` |
+| `assay` | `x86_64-apple-darwin` | `installer` | `assay-v5.4.0-x86_64-apple-darwin.tar.gz` |
+| `assay` | `aarch64-apple-darwin` | `installer` | `assay-v5.4.0-aarch64-apple-darwin.tar.gz` |
+| `assay` | `x86_64-pc-windows-msvc` | `installer` | `assay-v5.4.0-x86_64-pc-windows-msvc.zip` |
+| `assay-mcp-server` | `x86_64-unknown-linux-gnu` | `manual_step` | `assay-mcp-server-v5.4.0-x86_64-unknown-linux-gnu.tar.gz` |
+| `assay-mcp-server` | `aarch64-unknown-linux-gnu` | `manual_step` | `assay-mcp-server-v5.4.0-aarch64-unknown-linux-gnu.tar.gz` |
+| `assay-mcp-server` | `x86_64-apple-darwin` | `unsupported` | `-` |
+| `assay-mcp-server` | `aarch64-apple-darwin` | `unsupported` | `-` |
+| `assay-mcp-server` | `x86_64-pc-windows-msvc` | `unsupported` | `-` |
+<!-- release-installability-matrix:end -->
+
 ### 4. Verification
 - [ ] **Published MSRV Install Check**: use a fresh install root so Cargo cannot reuse an existing
   installation, then execute the resulting binary:

--- a/scripts/ci/check-release-assets.sh
+++ b/scripts/ci/check-release-assets.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./scripts/ci/release_asset_contract.sh
+source "$SCRIPT_DIR/release_asset_contract.sh"
+
 VERSION="${VERSION:?VERSION is required, for example v3.10.0}"
 ASSETS_DIR="${ASSETS_DIR:-release}"
 JQ_BIN="${JQ_BIN:-jq}"
@@ -42,23 +46,15 @@ if [[ -n "$non_files" ]]; then
   exit 1
 fi
 
-checksum_targets=(
-  "assay-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-  "assay-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
-  "assay-${VERSION}-x86_64-apple-darwin.tar.gz"
-  "assay-${VERSION}-aarch64-apple-darwin.tar.gz"
-  "assay-${VERSION}-x86_64-pc-windows-msvc.zip"
-  "assay-mcp-server-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-  "assay-mcp-server-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
-  "assay-mcp-server-${VERSION}-linux.mcpb"
-  "assay-${VERSION}-sbom-cyclonedx.tar.gz"
-  "assay-${VERSION}-release-provenance.json"
-  "assay-${VERSION}-release-proof-kit.tar.gz"
-)
+checksum_targets=()
+while IFS= read -r asset; do
+  checksum_targets+=("$asset")
+done < <(release_checksum_targets "$VERSION")
 
-plain_assets=(
-  "server.json"
-)
+plain_assets=()
+while IFS= read -r asset; do
+  plain_assets+=("$asset")
+done < <(release_plain_assets)
 
 scratch_dir="$(mktemp -d)"
 trap 'rm -rf "$scratch_dir"' EXIT

--- a/scripts/ci/release_asset_contract.sh
+++ b/scripts/ci/release_asset_contract.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Shared release asset and installability truth. Callers may source this file;
+# it must not mutate shell options or global state.
+
+release_normalize_version() {
+  local version="${1#v}"
+  [[ "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-.+][0-9A-Za-z.-]+)?$ ]] || return 1
+  printf 'v%s\n' "$version"
+}
+
+release_installability_matrix() {
+  local tag
+  tag="$(release_normalize_version "$1")" || return 1
+
+  printf '%s\t%s\t%s\t%s\n' \
+    assay x86_64-unknown-linux-gnu installer "assay-${tag}-x86_64-unknown-linux-gnu.tar.gz" \
+    assay aarch64-unknown-linux-gnu installer "assay-${tag}-aarch64-unknown-linux-gnu.tar.gz" \
+    assay x86_64-apple-darwin installer "assay-${tag}-x86_64-apple-darwin.tar.gz" \
+    assay aarch64-apple-darwin installer "assay-${tag}-aarch64-apple-darwin.tar.gz" \
+    assay x86_64-pc-windows-msvc installer "assay-${tag}-x86_64-pc-windows-msvc.zip" \
+    assay-mcp-server x86_64-unknown-linux-gnu manual_step "assay-mcp-server-${tag}-x86_64-unknown-linux-gnu.tar.gz" \
+    assay-mcp-server aarch64-unknown-linux-gnu manual_step "assay-mcp-server-${tag}-aarch64-unknown-linux-gnu.tar.gz" \
+    assay-mcp-server x86_64-apple-darwin unsupported - \
+    assay-mcp-server aarch64-apple-darwin unsupported - \
+    assay-mcp-server x86_64-pc-windows-msvc unsupported -
+}
+
+release_checksum_targets() {
+  local tag
+  tag="$(release_normalize_version "$1")" || return 1
+
+  release_installability_matrix "$tag" | while IFS=$'\t' read -r _product _target status asset; do
+    if [[ "$status" != unsupported ]]; then
+      printf '%s\n' "$asset"
+    fi
+  done
+  printf '%s\n' \
+    "assay-mcp-server-${tag}-linux.mcpb" \
+    "assay-${tag}-sbom-cyclonedx.tar.gz" \
+    "assay-${tag}-release-provenance.json" \
+    "assay-${tag}-release-proof-kit.tar.gz"
+}
+
+release_plain_assets() {
+  printf '%s\n' server.json
+}
+
+release_expected_assets() {
+  local asset
+  while IFS= read -r asset; do
+    printf '%s\n%s.sha256\n' "$asset" "$asset"
+  done < <(release_checksum_targets "$1")
+  release_plain_assets
+}
+
+release_installability_markdown() {
+  local product target status asset
+  printf '%s\n' \
+    '| Component | Target | Install status | Release asset |' \
+    '| --- | --- | --- | --- |'
+  while IFS=$'\t' read -r product target status asset; do
+    # shellcheck disable=SC2016
+    printf '| `%s` | `%s` | `%s` | `%s` |\n' "$product" "$target" "$status" "$asset"
+  done < <(release_installability_matrix "$1")
+}

--- a/scripts/ci/test-release-assets.sh
+++ b/scripts/ci/test-release-assets.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 CHECK_SCRIPT="${REPO_ROOT}/scripts/ci/check-release-assets.sh"
+ASSET_CONTRACT="${REPO_ROOT}/scripts/ci/release_asset_contract.sh"
 CHECKSUM_WRITER="${REPO_ROOT}/scripts/ci/write_sha256_sidecar.sh"
 VERSION="v9.9.9"
 SEMVER="${VERSION#v}"
@@ -15,6 +16,25 @@ compute_sha256() {
   else
     shasum -a 256 "$file" | awk '{print $1}'
   fi
+}
+
+[[ -f "$ASSET_CONTRACT" ]] || {
+  echo "shared release asset contract is missing: $ASSET_CONTRACT" >&2
+  exit 1
+}
+# shellcheck disable=SC2016
+grep -Fq 'source "$SCRIPT_DIR/release_asset_contract.sh"' "$CHECK_SCRIPT" || {
+  echo "release preflight does not source the shared asset contract" >&2
+  exit 1
+}
+# shellcheck disable=SC2016
+grep -Fq 'done < <(release_checksum_targets "$VERSION")' "$CHECK_SCRIPT" || {
+  echo "release preflight does not consume shared checksum targets" >&2
+  exit 1
+}
+grep -Fq 'done < <(release_plain_assets)' "$CHECK_SCRIPT" || {
+  echo "release preflight does not consume shared plain assets" >&2
+  exit 1
 }
 
 write_asset() {

--- a/scripts/ci/test-verify-release.sh
+++ b/scripts/ci/test-verify-release.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ORACLE="${ROOT}/scripts/ci/verify-release.sh"
+ASSET_CONTRACT="${ROOT}/scripts/ci/release_asset_contract.sh"
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -20,6 +21,7 @@ expect_status() {
 }
 
 [[ -f "$ORACLE" ]] || fail "release oracle is missing: $ORACLE"
+[[ -f "$ASSET_CONTRACT" ]] || fail "shared release asset contract is missing: $ASSET_CONTRACT"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
@@ -30,6 +32,32 @@ printf '%s\n' "$expected_assets" | grep -qxF 'assay-v5.3.0-release-proof-kit.tar
   || fail "asset generator omitted proof kit"
 if printf '%s\n' "$expected_assets" | grep -qxF 'latest.json'; then
   fail "asset generator must not accept latest.json"
+fi
+
+expected_mcp_installability=$(cat <<'EOF'
+assay-mcp-server	x86_64-unknown-linux-gnu	manual_step	assay-mcp-server-v5.4.0-x86_64-unknown-linux-gnu.tar.gz
+assay-mcp-server	aarch64-unknown-linux-gnu	manual_step	assay-mcp-server-v5.4.0-aarch64-unknown-linux-gnu.tar.gz
+assay-mcp-server	x86_64-apple-darwin	unsupported	-
+assay-mcp-server	aarch64-apple-darwin	unsupported	-
+assay-mcp-server	x86_64-pc-windows-msvc	unsupported	-
+EOF
+)
+actual_mcp_installability="$($ORACLE --unit-installability-matrix 5.4.0 | grep '^assay-mcp-server')"
+[[ "$actual_mcp_installability" == "$expected_mcp_installability" ]] \
+  || fail "MCP server installability matrix is not the measured release surface"
+
+release_doc="$ROOT/docs/reference/release.md"
+documented_matrix="$(sed -n \
+  '/<!-- release-installability-matrix:start -->/,/<!-- release-installability-matrix:end -->/p' \
+  "$release_doc" | sed '1d;$d')"
+generated_matrix="$($ORACLE --unit-installability-markdown 5.4.0)"
+[[ -n "$documented_matrix" && "$documented_matrix" == "$generated_matrix" ]] \
+  || fail "release documentation did not come from the installability contract"
+
+# Both release consumers must call the shared contract. Reintroducing a local
+# expected_assets function would create a second release truth.
+if grep -Eq '^expected_assets\(\)' "$ORACLE"; then
+  fail "release verifier carries a local expected_assets implementation"
 fi
 
 # Abbreviated identifiers are never resolved or expanded.

--- a/scripts/ci/test-verify-release.sh
+++ b/scripts/ci/test-verify-release.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ORACLE="${ROOT}/scripts/ci/verify-release.sh"
 ASSET_CONTRACT="${ROOT}/scripts/ci/release_asset_contract.sh"
+RELEASE_TAG_READER="${ROOT}/scripts/ci/read-assay-release-tag.sh"
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -22,8 +23,11 @@ expect_status() {
 
 [[ -f "$ORACLE" ]] || fail "release oracle is missing: $ORACLE"
 [[ -f "$ASSET_CONTRACT" ]] || fail "shared release asset contract is missing: $ASSET_CONTRACT"
+[[ -f "$RELEASE_TAG_READER" ]] || fail "release tag reader is missing: $RELEASE_TAG_READER"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
+
+release_tag="$(bash "$RELEASE_TAG_READER")"
 
 expected_assets="$("$ORACLE" --unit-expected-assets 5.3.0)"
 [[ "$(printf '%s\n' "$expected_assets" | wc -l | tr -d ' ')" -eq 23 ]] \
@@ -34,15 +38,15 @@ if printf '%s\n' "$expected_assets" | grep -qxF 'latest.json'; then
   fail "asset generator must not accept latest.json"
 fi
 
-expected_mcp_installability=$(cat <<'EOF'
-assay-mcp-server	x86_64-unknown-linux-gnu	manual_step	assay-mcp-server-v5.4.0-x86_64-unknown-linux-gnu.tar.gz
-assay-mcp-server	aarch64-unknown-linux-gnu	manual_step	assay-mcp-server-v5.4.0-aarch64-unknown-linux-gnu.tar.gz
+expected_mcp_installability=$(cat <<EOF
+assay-mcp-server	x86_64-unknown-linux-gnu	manual_step	assay-mcp-server-${release_tag}-x86_64-unknown-linux-gnu.tar.gz
+assay-mcp-server	aarch64-unknown-linux-gnu	manual_step	assay-mcp-server-${release_tag}-aarch64-unknown-linux-gnu.tar.gz
 assay-mcp-server	x86_64-apple-darwin	unsupported	-
 assay-mcp-server	aarch64-apple-darwin	unsupported	-
 assay-mcp-server	x86_64-pc-windows-msvc	unsupported	-
 EOF
 )
-actual_mcp_installability="$($ORACLE --unit-installability-matrix 5.4.0 | grep '^assay-mcp-server')"
+actual_mcp_installability="$($ORACLE --unit-installability-matrix "$release_tag" | grep '^assay-mcp-server')"
 [[ "$actual_mcp_installability" == "$expected_mcp_installability" ]] \
   || fail "MCP server installability matrix is not the measured release surface"
 
@@ -50,7 +54,7 @@ release_doc="$ROOT/docs/reference/release.md"
 documented_matrix="$(sed -n \
   '/<!-- release-installability-matrix:start -->/,/<!-- release-installability-matrix:end -->/p' \
   "$release_doc" | sed '1d;$d')"
-generated_matrix="$($ORACLE --unit-installability-markdown 5.4.0)"
+generated_matrix="$($ORACLE --unit-installability-markdown "$release_tag")"
 [[ -n "$documented_matrix" && "$documented_matrix" == "$generated_matrix" ]] \
   || fail "release documentation did not come from the installability contract"
 

--- a/scripts/ci/verify-release.sh
+++ b/scripts/ci/verify-release.sh
@@ -3,6 +3,10 @@
 # 2=infra (missing tools, API/network failure, timeout, or unreadable input).
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./scripts/ci/release_asset_contract.sh
+source "$SCRIPT_DIR/release_asset_contract.sh"
+
 REPO="${REPO:-Rul1an/assay}"
 GH="${GH:-$(command -v gh)}"
 PYTHON="${PYTHON:-$(command -v python3)}"
@@ -20,34 +24,6 @@ finding() { printf 'FINDING: %s\n' "$*" >&2; exit 1; }
 infra() { printf 'INFRA: %s\n' "$*" >&2; exit 2; }
 
 valid_sha() { [[ "${1:-}" =~ ^[0-9a-f]{40}$ ]]; }
-
-expected_assets() {
-  local version="$1"
-  printf '%s\n' \
-    "assay-mcp-server-v${version}-aarch64-unknown-linux-gnu.tar.gz" \
-    "assay-mcp-server-v${version}-aarch64-unknown-linux-gnu.tar.gz.sha256" \
-    "assay-mcp-server-v${version}-linux.mcpb" \
-    "assay-mcp-server-v${version}-linux.mcpb.sha256" \
-    "assay-mcp-server-v${version}-x86_64-unknown-linux-gnu.tar.gz" \
-    "assay-mcp-server-v${version}-x86_64-unknown-linux-gnu.tar.gz.sha256" \
-    "assay-v${version}-aarch64-apple-darwin.tar.gz" \
-    "assay-v${version}-aarch64-apple-darwin.tar.gz.sha256" \
-    "assay-v${version}-aarch64-unknown-linux-gnu.tar.gz" \
-    "assay-v${version}-aarch64-unknown-linux-gnu.tar.gz.sha256" \
-    "assay-v${version}-release-proof-kit.tar.gz" \
-    "assay-v${version}-release-proof-kit.tar.gz.sha256" \
-    "assay-v${version}-release-provenance.json" \
-    "assay-v${version}-release-provenance.json.sha256" \
-    "assay-v${version}-sbom-cyclonedx.tar.gz" \
-    "assay-v${version}-sbom-cyclonedx.tar.gz.sha256" \
-    "assay-v${version}-x86_64-apple-darwin.tar.gz" \
-    "assay-v${version}-x86_64-apple-darwin.tar.gz.sha256" \
-    "assay-v${version}-x86_64-pc-windows-msvc.zip" \
-    "assay-v${version}-x86_64-pc-windows-msvc.zip.sha256" \
-    "assay-v${version}-x86_64-unknown-linux-gnu.tar.gz" \
-    "assay-v${version}-x86_64-unknown-linux-gnu.tar.gz.sha256" \
-    "server.json"
-}
 
 expected_absent_attestation() {
   case "$1" in
@@ -346,7 +322,7 @@ post_publish() {
     || infra "could not fetch release JSON"
   parse_release "$release" >"$WORK/assets.tsv" || finding "release JSON is malformed"
   awk -F '\t' '$1 != "TARGET" { print $1 }' "$WORK/assets.tsv" | LC_ALL=C sort >"$WORK/actual"
-  expected_assets "$VERSION" | LC_ALL=C sort >"$WORK/expected"
+  release_expected_assets "$VERSION" | LC_ALL=C sort >"$WORK/expected"
   cmp -s "$WORK/actual" "$WORK/expected" || finding "release asset names do not exactly match the expected set"
 
   mkdir -p "$WORK/assets"
@@ -430,7 +406,9 @@ PY
 
 usage() { printf 'usage: verify-release.sh [--pre-tag [PIN_SHA]|--self-test]\n' >&2; exit 2; }
 case "${1:-}" in
-  --unit-expected-assets) [[ $# -eq 2 ]] || usage; expected_assets "$2"; exit 0 ;;
+  --unit-expected-assets) [[ $# -eq 2 ]] || usage; release_expected_assets "$2"; exit 0 ;;
+  --unit-installability-matrix) [[ $# -eq 2 ]] || usage; release_installability_matrix "$2"; exit 0 ;;
+  --unit-installability-markdown) [[ $# -eq 2 ]] || usage; release_installability_markdown "$2"; exit 0 ;;
   --unit-validate-sha) [[ $# -eq 2 ]] || usage; valid_sha "$2" || exit 1; exit 0 ;;
   --unit-verify-attestation-json) [[ $# -eq 2 ]] || usage; verify_attestation_json "$2"; exit $? ;;
   --unit-classify-attestation)


### PR DESCRIPTION
## Summary
- derive the exact 23-file release set from one shared asset contract
- expose a generated installability matrix that distinguishes installer, manual step, and unsupported
- make both pre-publish and post-publish release verification consume the same contract
- document the current v5.4.0 CLI and MCP-server target matrix from that source

## Why
The release already publishes Linux MCP-server archives, but the installer installs only the CLI and no Darwin/Windows MCP-server binaries exist. Asset presence and one-command installability must not be conflated.

## TDD
- RED: both existing release tests failed because the shared contract and matrix did not exist
- GREEN: release verifier, asset preflight, installer normalization, SHA sidecar, and outward release-surface suites pass

## Mutations
- Linux MCP server mislabeled as installer: red
- invented Darwin MCP server asset: red
- preflight disconnected from shared contract: red
- online verifier disconnected from shared contract: red
- no-op and post-mutation controls: green

## Verification
- PASS: verify-release offline contract tests
- release asset preflight tests passed
- sha256 sidecar writer tests passed
- ok   unprefixed derives /download/v5.2.0/assay-v5.2.0- (exit 1)
ok   prefixed derives /download/v5.2.0/assay-v5.2.0- (exit 1)
ok   literal-latest resolves via the latest API (exit 1)
ok   unset resolves via the latest API (exit 1)
ok   latest-multiline-tags fails closed with no asset curl (exit 1)
ok   empty fails closed before network (exit 1)
ok   bare-v fails closed before network (exit 1)
ok   dotdot fails closed before network (exit 1)
ok   url fails closed before network (exit 1)
ok   trailing-space fails closed before network (exit 1)
ok   leading-space fails closed before network (exit 1)
ok   latest-foo fails closed before network (exit 1)
ok   double-v fails closed before network (exit 1)
ok   two-part fails closed before network (exit 1)
ok   prerelease fails closed before network (exit 1)
ok   percent fails closed before network (exit 1)
ok   semicolon fails closed before network (exit 1)
ok   newline fails closed before network (exit 1)
ok   cmdsubst fails closed and does not create a sentinel (exit 1)
ok   install.sh defines normalize_install_version()
ok   install.sh defines is_stable_release_tag()
ok   stable-tag regex remains the latest-channel literal
ok   install.sh has no source-only production escape
== mutations must make this contract fail ==
ok   mutation unprefixed-archive bites
ok   mutation malformed-as-latest bites
ok   mutation latest-v-prefix bites
ok   mutation drop-tag-prefilter bites
install-version-normalization contract: all cases passed
- PASS: wrong-python-package
PASS: wrong-python-package-installation
PASS: wrong-python-package-sdk
PASS: wrong-python-package-flow
PASS: wrong-python-package-migration
PASS: wrong-python-package-upgrade
PASS: wrong-python-package-short-upgrade
PASS: homebrew-channel
PASS: scoop-channel
PASS: ghcr-channel
PASS: ghcr-installation
PASS: ghcr-air-gapped
PASS: stale-windows-asset
PASS: unsupported-codex-config-path
PASS: unsupported-codex-literal
PASS: unsupported-codex-guide
PASS: broad-rge-claim
PASS: broad-rge-claim-both
PASS: duplicate-broad-rge-claim-both
PASS: wrong-rust-package-ci
PASS: wrong-rust-package-ci-gate
PASS: stale-air-gap-version
PASS: obsolete-air-gap-asset
PASS: unsupported-runtime-image
PASS: stale-air-gap-checksum
PASS: wrong-air-gap-extraction
PASS: mutable-action-ci
PASS: mutable-action-ci-gate
PASS: mutable-action-quickstart
PASS: mutable-action-user-flow
PASS: missing-air-gap-archive
PASS: release-surface selector covers ci-gate
PASS: stale-version-readme
PASS: stale-version-getting-started
PASS: stale-version-installation
PASS: stale-version-quickstart
PASS: stale-version-cli-reference
PASS: stale-version-user-flow
PASS: wrong-workspace-binary
PASS: wrong-published-version-output
PASS: stale-release-readme
PASS: stale-release-doc-index
PASS: duplicate-release
PASS: stale-cli-version
release-surface mutations: 44 observed
- 
- 

## Non-claims
- no new MCP-server binaries
- no installer expansion
- no registry or host-discovery proof
- no change to the 23 published asset names

Closes #2648
