### PR TITLE
fix(python): declare assay-it as CPython 3.12 on the three published wheels

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -50,6 +50,7 @@ on:
       - "llms.txt"
       - "docs/python-sdk/**"
       - "docs/getting-started/**"
+      - "docs/migration-v1.2.md"
       # S1b coverage-gate hook runs under Lint (pre-commit) in this workflow.
       - ".github/workflows/monitor-attach-smoke.yml"
       # The lane self-test pins guards inside this workflow file; run the

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -51,6 +51,8 @@ on:
       - "docs/python-sdk/**"
       - "docs/getting-started/**"
       - "docs/migration-v1.2.md"
+      - "docs/guides/troubleshooting.md"
+      - "docs/AIcontext/user-flows.md"
       # S1b coverage-gate hook runs under Lint (pre-commit) in this workflow.
       - ".github/workflows/monitor-attach-smoke.yml"
       # The lane self-test pins guards inside this workflow file; run the

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -44,6 +44,12 @@ on:
       - "docs/contributing/REFACTOR-WAVE-STATUS.md"
       - ".github/rulesets/main-required-ci-contexts.json"
       - ".github/workflows/kernel-matrix.yml"
+      # python-artifact-truth hook runs under Lint (pre-commit) here. scripts/**
+      # covers a guard change; a metadata/docs-only PR never starts this workflow.
+      - "assay-python-sdk/**"
+      - "llms.txt"
+      - "docs/python-sdk/**"
+      - "docs/getting-started/**"
       # S1b coverage-gate hook runs under Lint (pre-commit) in this workflow.
       - ".github/workflows/monitor-attach-smoke.yml"
       # The lane self-test pins guards inside this workflow file; run the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -809,23 +809,38 @@ jobs:
           bash scripts/ci/record-mcp-registry-result.sh
 
   # ============================================================
+  # Plan Python wheels from the artifact matrix (sole authority)
+  # ============================================================
+  plan-python-artifact:
+    name: Plan Python artifact matrix
+    needs: release-contract
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      python: ${{ steps.plan.outputs.python }}
+      abi: ${{ steps.plan.outputs.abi }}
+      wheels: ${{ steps.plan.outputs.wheels }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+      - name: Plan wheels from the artifact matrix
+        id: plan
+        run: python3 scripts/ci/plan-python-artifact-matrix.py >> "$GITHUB_OUTPUT"
+
+  # ============================================================
   # Build and Publish Python Wheels (PyPI)
   # ============================================================
   wheels:
     name: Build Wheels
-    needs: release-contract
+    needs: [release-contract, plan-python-artifact]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-          - os: macos-15
-            target: aarch64-apple-darwin
+        include: ${{ fromJSON(needs.plan-python-artifact.outputs.wheels) }}
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -833,17 +848,16 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: '3.12'
+          python-version: ${{ needs.plan-python-artifact.outputs.python }}
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           working-directory: assay-python-sdk
           target: ${{ matrix.target }}
-          # Keep the interpreter explicit for all wheel targets. This is
-          # required inside the manylinux container and harmless on macOS,
-          # where setup-python provides the same Python version.
-          args: --release --out dist --locked -i python3.12 --compatibility pypi
+          # Interpreter comes from the artifact-matrix plan (==X.Y.* -> X.Y).
+          # Required inside the manylinux container; setup-python provides it on macOS.
+          args: --release --out dist --locked -i python${{ needs.plan-python-artifact.outputs.python }} --compatibility pypi
           sccache: 'false'
           manylinux: auto
 
@@ -851,7 +865,7 @@ jobs:
         shell: bash
         env:
           ASSAY_WHEEL_TARGET: ${{ matrix.target }}
-        run: python3 scripts/ci/smoke-python-wheel.py --dist-dir assay-python-sdk/dist
+        run: python3 scripts/ci/smoke-python-wheel.py --dist-dir assay-python-sdk/dist --python "python${{ needs.plan-python-artifact.outputs.python }}"
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -822,7 +822,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-15
+          - os: macos-15-intel
             target: x86_64-apple-darwin
           - os: macos-15
             target: aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -847,6 +847,12 @@ jobs:
           sccache: 'false'
           manylinux: auto
 
+      - name: Smoke the produced wheel
+        shell: bash
+        env:
+          ASSAY_WHEEL_TARGET: ${{ matrix.target }}
+        run: python3 scripts/ci/smoke-python-wheel.py --dist-dir assay-python-sdk/dist
+
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -381,7 +381,7 @@ repos:
         entry: bash -c 'bash scripts/ci/test-check-python-artifact-truth.sh && python3 scripts/ci/check-python-artifact-truth.py && bash scripts/ci/test-check-python-wheel-smoke-contract.sh && python3 scripts/ci/check-python-wheel-smoke-contract.py'
         language: system
         pass_filenames: false
-        files: ^(assay-python-sdk/(python-artifact-matrix\.v0\.json|pyproject\.toml|Cargo\.toml|README\.md)|scripts/ci/(check-python-artifact-truth\.py|test-check-python-artifact-truth\.sh|check-python-wheel-smoke-contract\.py|test-check-python-wheel-smoke-contract\.sh|smoke-python-wheel\.py)|\.github/workflows/release\.yml|docs/(python-sdk/index\.md|getting-started/(index|installation|python-quickstart)\.md|guides/troubleshooting\.md|AIcontext/user-flows\.md)|llms\.txt|CHANGELOG\.md|\.pre-commit-config\.yaml)$
+        files: ^(assay-python-sdk/(python-artifact-matrix\.v0\.json|pyproject\.toml|Cargo\.toml|README\.md)|scripts/ci/(check-python-artifact-truth\.py|test-check-python-artifact-truth\.sh|check-python-wheel-smoke-contract\.py|test-check-python-wheel-smoke-contract\.sh|smoke-python-wheel\.py|plan-python-artifact-matrix\.py)|\.github/workflows/(release|kernel-matrix)\.yml|docs/(python-sdk/index\.md|getting-started/(index|installation|python-quickstart)\.md|guides/troubleshooting\.md|AIcontext/user-flows\.md|migration-v1\.2\.md)|llms\.txt|CHANGELOG\.md|\.pre-commit-config\.yaml)$
 
       - id: osv-scanner-scheduled-lockstep
         name: OSV scanner/reporter lockstep and count bind

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -363,7 +363,7 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
-        files: ^scripts/ci/(lib/clear-git-repository-env|test-(check-release-surface|git-fixture-env-isolation|perf-pr-event-provenance-contract))\.sh$
+        files: ^scripts/ci/(lib/clear-git-repository-env|test-(check-release-surface|check-python-artifact-truth|git-fixture-env-isolation|perf-pr-event-provenance-contract))\.sh$
 
       - id: release-surface
         name: Release surface matches source and published versions
@@ -374,6 +374,14 @@ repos:
         # no `target/` build it still verifies source and published-release truth independently.
         files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag)\.sh|\.github/assay-release-tag|Cargo\.toml|README\.md|llms\.txt|docs/(index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.pre-commit-config\.yaml)$
 
+
+
+      - id: python-artifact-truth
+        name: assay-it metadata matches the published wheel matrix
+        entry: bash -c 'bash scripts/ci/test-check-python-artifact-truth.sh && python3 scripts/ci/check-python-artifact-truth.py'
+        language: system
+        pass_filenames: false
+        files: ^(assay-python-sdk/(python-artifact-matrix\.v0\.json|pyproject\.toml|Cargo\.toml|README\.md)|scripts/ci/(check-python-artifact-truth\.py|test-check-python-artifact-truth\.sh)|\.github/workflows/release\.yml|docs/(python-sdk/index\.md|getting-started/(index|installation|python-quickstart)\.md|guides/troubleshooting\.md|AIcontext/user-flows\.md)|llms\.txt|CHANGELOG\.md|\.pre-commit-config\.yaml)$
 
       - id: osv-scanner-scheduled-lockstep
         name: OSV scanner/reporter lockstep and count bind

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -363,7 +363,7 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
-        files: ^scripts/ci/(lib/clear-git-repository-env|test-(check-release-surface|check-python-artifact-truth|git-fixture-env-isolation|perf-pr-event-provenance-contract))\.sh$
+        files: ^scripts/ci/(lib/clear-git-repository-env|test-(check-release-surface|check-python-artifact-truth|check-python-wheel-smoke-contract|git-fixture-env-isolation|perf-pr-event-provenance-contract))\.sh$
 
       - id: release-surface
         name: Release surface matches source and published versions
@@ -378,10 +378,10 @@ repos:
 
       - id: python-artifact-truth
         name: assay-it metadata matches the published wheel matrix
-        entry: bash -c 'bash scripts/ci/test-check-python-artifact-truth.sh && python3 scripts/ci/check-python-artifact-truth.py'
+        entry: bash -c 'bash scripts/ci/test-check-python-artifact-truth.sh && python3 scripts/ci/check-python-artifact-truth.py && bash scripts/ci/test-check-python-wheel-smoke-contract.sh && python3 scripts/ci/check-python-wheel-smoke-contract.py'
         language: system
         pass_filenames: false
-        files: ^(assay-python-sdk/(python-artifact-matrix\.v0\.json|pyproject\.toml|Cargo\.toml|README\.md)|scripts/ci/(check-python-artifact-truth\.py|test-check-python-artifact-truth\.sh)|\.github/workflows/release\.yml|docs/(python-sdk/index\.md|getting-started/(index|installation|python-quickstart)\.md|guides/troubleshooting\.md|AIcontext/user-flows\.md)|llms\.txt|CHANGELOG\.md|\.pre-commit-config\.yaml)$
+        files: ^(assay-python-sdk/(python-artifact-matrix\.v0\.json|pyproject\.toml|Cargo\.toml|README\.md)|scripts/ci/(check-python-artifact-truth\.py|test-check-python-artifact-truth\.sh|check-python-wheel-smoke-contract\.py|test-check-python-wheel-smoke-contract\.sh|smoke-python-wheel\.py)|\.github/workflows/release\.yml|docs/(python-sdk/index\.md|getting-started/(index|installation|python-quickstart)\.md|guides/troubleshooting\.md|AIcontext/user-flows\.md)|llms\.txt|CHANGELOG\.md|\.pre-commit-config\.yaml)$
 
       - id: osv-scanner-scheduled-lockstep
         name: OSV scanner/reporter lockstep and count bind

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ All notable changes to this project will be documented in this file.
   `.github/workflows/release.yml` was regenerated through the manifest
   owner refresh after that wheels-job change. This does not change
   published 5.4.0 files. The smoke contract now witnesses the production
-  `install_and_import` invocation; install_docs includes
+  `install_and_import` invocation; the smoke self-test now spies that
+  production call (importlib + monkeypatch); install_docs includes
   `docs/migration-v1.2.md` and active pip-install pages cannot be omitted
   (#2649).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ All notable changes to this project will be documented in this file.
   the expected `{dist}-{version}-{tag}.whl`, no-index only-binary install,
   version + `assay._native`). Both macOS cells are native: x86_64 on
   macos-15-intel, arm64 on macos-15. There is no unsupported escape for a
-  declared pair. This does not change published 5.4.0 files (#2649).
+  declared pair. The published-release golden-path harness digest for
+  `.github/workflows/release.yml` was regenerated through the manifest
+  owner refresh after that wheels-job change. This does not change
+  published 5.4.0 files (#2649).
 
 ### Added
 - `assay policy resolve --input PATH --format json` emits one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - `assay-it` metadata, release wheel targets, and install docs now share one
-  `assay.python_artifact_matrix.v0`. Declared support is CPython 3.12 on the
-  three existing wheel targets. This does not change published 5.4.0 files
-  (#2649).
+  `assay.python_artifact_matrix.v0` that pins/parity-checks those surfaces.
+  Each wheels-job cell smokes the locally produced wheel (exact one file,
+  no-index only-binary install, version + `assay._native` on native runners;
+  macos x86_64 is unsupported for import). This does not change published
+  5.4.0 files (#2649).
 
 ### Added
 - `assay policy resolve --input PATH --format json` emits one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,31 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- `assay-it` metadata, release wheel targets, and install docs now share one
-  `assay.python_artifact_matrix.v0` that pins/parity-checks those surfaces.
-  Metadata is anchored to the declared wheel tags (`==3.12.*` requires every
-  tag ABI `cp312`; cp312-only tags require `==3.12.*` in the matrix and
-  pyproject; PyPy is forbidden without a `pp*` tag). kernel-matrix
-  `pull_request.paths` cover the SDK and install docs so the
-  python-artifact-truth hook runs on metadata-only PRs. Each wheels-job
-  cell smokes the locally produced wheel (exactly one `.whl` whose name is
-  the expected `{dist}-{version}-{tag}.whl`, no-index only-binary install,
-  version + `assay._native`). Both macOS cells are native: x86_64 on
+- `assay-it` metadata, release wheel targets, and install docs share one
+  `assay.python_artifact_matrix.v0`. That matrix is the sole mutable
+  authority for CPython version, package, target, and tag. A plan job
+  reads it and emits the wheels JSON plus `==X.Y.*` → X.Y / cpXY;
+  release.yml and smoke consume those outputs (no hardcoded interpreter).
+  Requires-Python is exact `==X.Y.*` bound to `cpXY` and to
+  `Programming Language :: Python :: X.Y`. `support_bound` is derived
+  from the declared wheels and that X.Y, not free prose. Requires-Python
+  changed from `>=3.9` to `==3.12.*`. This does not break any previously
+  working 3.9–3.11 install: those wheels never existed. Only the error
+  becomes explicitly unsupported. The remedy is CPython 3.12. Pinning
+  5.4.0 does not restore support. kernel-matrix `pull_request.paths` now
+  include the remaining install-doc pages
+  (`docs/guides/troubleshooting.md`, `docs/AIcontext/user-flows.md`) so
+  those docs-only PRs start the hook; this does not claim every
+  install-doc PR was already covered. Each wheels-job cell smokes the
+  locally produced wheel (exactly one `.whl` whose name is the expected
+  `{dist}-{version}-{tag}.whl`, no-index only-binary install, version +
+  `assay._native`). Both macOS cells are native: x86_64 on
   macos-15-intel, arm64 on macos-15. There is no unsupported escape for a
   declared pair. The published-release golden-path harness digest for
   `.github/workflows/release.yml` was regenerated through the manifest
   owner refresh after that wheels-job change. This does not change
-  published 5.4.0 files. The smoke contract now witnesses the production
-  `install_and_import` invocation; the smoke self-test now spies that
+  published 5.4.0 files. The smoke contract witnesses the production
+  `install_and_import` invocation; the smoke self-test spies that
   production call (importlib + monkeypatch); install_docs includes
   `docs/migration-v1.2.md` and active pip-install pages cannot be omitted
   (#2649).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ All notable changes to this project will be documented in this file.
   declared pair. The published-release golden-path harness digest for
   `.github/workflows/release.yml` was regenerated through the manifest
   owner refresh after that wheels-job change. This does not change
-  published 5.4.0 files (#2649).
+  published 5.4.0 files. The smoke contract now witnesses the production
+  `install_and_import` invocation; install_docs includes
+  `docs/migration-v1.2.md` and active pip-install pages cannot be omitted
+  (#2649).
 
 ### Added
 - `assay policy resolve --input PATH --format json` emits one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ All notable changes to this project will be documented in this file.
 - `assay-it` metadata, release wheel targets, and install docs now share one
   `assay.python_artifact_matrix.v0` that pins/parity-checks those surfaces.
   Each wheels-job cell smokes the locally produced wheel (exact one file,
-  no-index only-binary install, version + `assay._native` on native runners;
-  macos x86_64 is unsupported for import). This does not change published
+  no-index only-binary install, version + `assay._native`). Both macOS cells
+  are native: x86_64 on macos-15-intel, arm64 on macos-15. There is no
+  unsupported escape for a declared pair. This does not change published
   5.4.0 files (#2649).
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- `assay-it` metadata, release wheel targets, and install docs now share one
+  `assay.python_artifact_matrix.v0`. Declared support is CPython 3.12 on the
+  three existing wheel targets. This does not change published 5.4.0 files
+  (#2649).
+
 ### Added
 - `assay policy resolve --input PATH --format json` emits one
   `assay.policy.resolved.v0` document after the same load and schema-compile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - `assay-it` metadata, release wheel targets, and install docs now share one
   `assay.python_artifact_matrix.v0` that pins/parity-checks those surfaces.
-  Each wheels-job cell smokes the locally produced wheel (exact one file,
-  no-index only-binary install, version + `assay._native`). Both macOS cells
-  are native: x86_64 on macos-15-intel, arm64 on macos-15. There is no
-  unsupported escape for a declared pair. This does not change published
-  5.4.0 files (#2649).
+  Metadata is anchored to the declared wheel tags (`==3.12.*` requires every
+  tag ABI `cp312`; cp312-only tags require `==3.12.*` in the matrix and
+  pyproject; PyPy is forbidden without a `pp*` tag). kernel-matrix
+  `pull_request.paths` cover the SDK and install docs so the
+  python-artifact-truth hook runs on metadata-only PRs. Each wheels-job
+  cell smokes the locally produced wheel (exactly one `.whl` whose name is
+  the expected `{dist}-{version}-{tag}.whl`, no-index only-binary install,
+  version + `assay._native`). Both macOS cells are native: x86_64 on
+  macos-15-intel, arm64 on macos-15. There is no unsupported escape for a
+  declared pair. This does not change published 5.4.0 files (#2649).
 
 ### Added
 - `assay policy resolve --input PATH --format json` emits one

--- a/assay-python-sdk/README.md
+++ b/assay-python-sdk/README.md
@@ -15,6 +15,8 @@ It currently provides a small, bounded surface on top of Assay core:
 pip install assay-it
 ```
 
+CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.
+
 Import path:
 
 ```python

--- a/assay-python-sdk/pyproject.toml
+++ b/assay-python-sdk/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "assay-it"
 description = "Python bindings for Assay trace capture, policy coverage, and explanation helpers."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = "==3.12.*"
 license = { text = "MIT" }
 authors = [{ name = "Assay" }]
 classifiers = [
@@ -15,8 +15,8 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Rust",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Quality Assurance",
 ]
 keywords = ["assay", "policy", "testing", "coverage", "tracing", "mcp", "ai-agents", "agent-security", "evidence"]

--- a/assay-python-sdk/python-artifact-matrix.v0.json
+++ b/assay-python-sdk/python-artifact-matrix.v0.json
@@ -16,17 +16,20 @@
     {
       "os": "ubuntu-latest",
       "target": "x86_64-unknown-linux-gnu",
-      "tag": "cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64"
+      "tag": "cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64",
+      "import_smoke": "native"
     },
     {
       "os": "macos-15",
       "target": "x86_64-apple-darwin",
-      "tag": "cp312-cp312-macosx_10_12_x86_64"
+      "tag": "cp312-cp312-macosx_10_12_x86_64",
+      "import_smoke": "unsupported"
     },
     {
       "os": "macos-15",
       "target": "aarch64-apple-darwin",
-      "tag": "cp312-cp312-macosx_11_0_arm64"
+      "tag": "cp312-cp312-macosx_11_0_arm64",
+      "import_smoke": "native"
     }
   ],
   "install_docs": [

--- a/assay-python-sdk/python-artifact-matrix.v0.json
+++ b/assay-python-sdk/python-artifact-matrix.v0.json
@@ -1,0 +1,42 @@
+{
+  "schema": "assay.python_artifact_matrix.v0",
+  "package": "assay-it",
+  "requires_python": "==3.12.*",
+  "required_classifiers": [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: Implementation :: CPython"
+  ],
+  "forbidden_classifiers": [
+    "Programming Language :: Python :: Implementation :: PyPy"
+  ],
+  "publish_sdist": false,
+  "support_bound": "CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.",
+  "wheels": [
+    {
+      "os": "ubuntu-latest",
+      "target": "x86_64-unknown-linux-gnu",
+      "tag": "cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64"
+    },
+    {
+      "os": "macos-15",
+      "target": "x86_64-apple-darwin",
+      "tag": "cp312-cp312-macosx_10_12_x86_64"
+    },
+    {
+      "os": "macos-15",
+      "target": "aarch64-apple-darwin",
+      "tag": "cp312-cp312-macosx_11_0_arm64"
+    }
+  ],
+  "install_docs": [
+    "assay-python-sdk/README.md",
+    "docs/python-sdk/index.md",
+    "docs/getting-started/python-quickstart.md",
+    "docs/getting-started/installation.md",
+    "docs/getting-started/index.md",
+    "docs/guides/troubleshooting.md",
+    "docs/AIcontext/user-flows.md",
+    "llms.txt"
+  ]
+}

--- a/assay-python-sdk/python-artifact-matrix.v0.json
+++ b/assay-python-sdk/python-artifact-matrix.v0.json
@@ -20,10 +20,10 @@
       "import_smoke": "native"
     },
     {
-      "os": "macos-15",
+      "os": "macos-15-intel",
       "target": "x86_64-apple-darwin",
       "tag": "cp312-cp312-macosx_10_12_x86_64",
-      "import_smoke": "unsupported"
+      "import_smoke": "native"
     },
     {
       "os": "macos-15",

--- a/assay-python-sdk/python-artifact-matrix.v0.json
+++ b/assay-python-sdk/python-artifact-matrix.v0.json
@@ -40,6 +40,7 @@
     "docs/getting-started/index.md",
     "docs/guides/troubleshooting.md",
     "docs/AIcontext/user-flows.md",
+    "docs/migration-v1.2.md",
     "llms.txt"
   ]
 }

--- a/docs/AIcontext/user-flows.md
+++ b/docs/AIcontext/user-flows.md
@@ -27,7 +27,7 @@ flowchart TD
 ```
 
 **Steps:**
-1. **Install**: `cargo install assay-cli --version 5.4.0 --locked` or use a verified release asset; install the Python SDK separately with `pip install assay-it`
+1. **Install**: `cargo install assay-cli --version 5.4.0 --locked` or use a verified release asset; install the Python SDK separately with `pip install assay-it`. CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.
 2. **Initialize**: `assay init` - auto-detects project, generates secure defaults
 3. **Capture traces**: Use `AssayClient` or `assay import` to record tool calls
 4. **Validate**: `assay validate --config eval.yaml --trace-file traces.jsonl`
@@ -254,7 +254,7 @@ flowchart TD
 
 **Python SDK Flow:**
 
-1. **Installation**: `pip install assay-it` (the Python SDK; install the Rust CLI separately when the workflow invokes `assay` commands)
+1. **Installation**: `pip install assay-it` (the Python SDK; install the Rust CLI separately when the workflow invokes `assay` commands). CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.
 2. **Recording**:
 ```python
 from assay import AssayClient

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -19,8 +19,8 @@ This guide covers:
 ## Prerequisites
 
 - **Rust 1.96** for repository development, **Rust 1.89+** for public-crate
-  source installs, or **Python 3.9+** for Python SDK use (**Python 3.10+** for
-  SDK development)
+  source installs, or CPython 3.12 for Python SDK use
+- CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.
 - An MCP session log (or use our example)
 - 5 minutes ☕
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -36,6 +36,8 @@ Assay does not currently document Homebrew, Scoop, or a public GHCR image as ver
 python -m pip install assay-it
 ```
 
+CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.
+
 `assay-it` installs the Python SDK and pytest plugin. It does not install the `assay` CLI. The package named `assay` on PyPI is unrelated to this project.
 
 ## Verify the CLI

--- a/docs/getting-started/python-quickstart.md
+++ b/docs/getting-started/python-quickstart.md
@@ -8,6 +8,8 @@ Integrate **Assay** into your Python test suite to enforce agent compliance. We 
 pip install assay-it
 ```
 
+CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.
+
 ## Usage
 
 ### 1. Stateless Validation

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -287,6 +287,8 @@ pip uninstall assay
 pip install assay-it
 ```
 
+CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.
+
 ### Module Not Found
 ```
 ModuleNotFoundError: No module named 'assay'
@@ -296,6 +298,8 @@ ModuleNotFoundError: No module named 'assay'
 ```bash
 pip install assay-it
 ```
+
+CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.
 
 ### Trace Recording Empty
 If your trace file is created but has no events:

--- a/docs/migration-v1.2.md
+++ b/docs/migration-v1.2.md
@@ -43,6 +43,12 @@ pip install assay-it
 
 CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.
 
+`Requires-Python` changed from `>=3.9` to `==3.12.*`. This does not break
+any previously working 3.9–3.11 install: those wheels never existed. Only
+the error becomes explicitly unsupported. The remedy is CPython 3.12.
+Pinning 5.4.0 does not restore support.
+
+
 See [Python Quickstart](getting-started/python-quickstart.md) for details.
 
 ### Baseline Management

--- a/docs/migration-v1.2.md
+++ b/docs/migration-v1.2.md
@@ -41,6 +41,8 @@ Install the SDK and pytest plugin:
 pip install assay-it
 ```
 
+CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.
+
 See [Python Quickstart](getting-started/python-quickstart.md) for details.
 
 ### Baseline Management

--- a/docs/python-sdk/index.md
+++ b/docs/python-sdk/index.md
@@ -8,6 +8,8 @@ The `assay-it` distribution provides trace recording, validation, and coverage a
 pip install assay-it
 ```
 
+CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.
+
 ## Quick Start
 
 ### Record Traces

--- a/llms.txt
+++ b/llms.txt
@@ -14,7 +14,7 @@ Assay answers two questions: how do I deny a risky MCP tool call before it runs,
 ## Install
 
 - Rust CLI: `cargo install assay-cli` (the crate is assay-cli; the unrelated crate named assay is a test macro by another author)
-- Python SDK: `pip install assay-it`
+- Python SDK: `pip install assay-it`. CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.
 - GitHub Action: https://github.com/marketplace/actions/assay-ai-agent-security
 - MCP registry: io.github.Rul1an/assay-mcp-server
 

--- a/scripts/ci/check-python-artifact-truth.py
+++ b/scripts/ci/check-python-artifact-truth.py
@@ -100,6 +100,8 @@ def check_release_workflow(root: Path, matrix: dict, errors: list[str]) -> None:
     expected = [wheel["target"] for wheel in matrix["wheels"]]
     if targets != expected:
         fail(errors, f"{RELEASE_REL}: wheel targets {targets} != matrix {expected}")
+    if "Smoke the produced wheel" not in job or "scripts/ci/smoke-python-wheel.py" not in job:
+        fail(errors, f"{RELEASE_REL}: wheels job must bind the produced-wheel smoke")
 
 
 def check_docs(root: Path, matrix: dict, errors: list[str]) -> None:
@@ -143,8 +145,10 @@ def evaluate_published_files(matrix: dict, version: str, filenames: list[str]) -
 def check_pip_download_contract(
     matrix: dict, version: str, errors: list[str], published: list[str] | None
 ) -> None:
-    names = published if published is not None else expected_wheel_names(matrix, version)
-    errors.extend(evaluate_published_files(matrix, version, names))
+    if published is None:
+        # Existence is the producer smoke, not a matrix-vs-itself compare.
+        return
+    errors.extend(evaluate_published_files(matrix, version, published))
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -158,6 +162,9 @@ def main(argv: list[str] | None = None) -> int:
     if matrix is None:
         print("\n".join(errors), file=sys.stderr)
         return 1
+    for wheel in matrix.get("wheels") or []:
+        if wheel.get("import_smoke") not in {"native", "unsupported"}:
+            fail(errors, f"{MATRIX_REL}: {wheel.get('target')}: import_smoke must be native or unsupported")
     version = workspace_version(root, errors)
     check_pyproject(root, matrix, errors)
     check_cargo(root, errors)

--- a/scripts/ci/check-python-artifact-truth.py
+++ b/scripts/ci/check-python-artifact-truth.py
@@ -14,7 +14,21 @@ PYPROJECT_REL = "assay-python-sdk/pyproject.toml"
 CARGO_REL = "assay-python-sdk/Cargo.toml"
 RELEASE_REL = ".github/workflows/release.yml"
 WORKSPACE_REL = "Cargo.toml"
+KERNEL_MATRIX_REL = ".github/workflows/kernel-matrix.yml"
 SCHEMA = "assay.python_artifact_matrix.v0"
+PYPY_CLASSIFIER = "Programming Language :: Python :: Implementation :: PyPy"
+REQUIRES_CPYTHON_312 = "==3.12.*"
+CP312_ABI = "cp312"
+PP_ABI_RE = re.compile(r"^pp\d+$")
+# python-artifact-truth runs under kernel-matrix Lint. scripts/** already
+# fires; these remaining surfaces must stay listed or a metadata/docs-only
+# PR never starts the workflow.
+ARTIFACT_TRUTH_PR_PATHS = (
+    "assay-python-sdk/**",
+    "llms.txt",
+    "docs/python-sdk/**",
+    "docs/getting-started/**",
+)
 PIP_INSTALL_RE = re.compile(
     r"""(?:python(?:3(?:\.\d+)?)?\s+-m\s+)?pip(?:3|x)?\s+install(?:\s+(?:-U|--upgrade|--user))*\s+["']?assay-it\b""",
     re.IGNORECASE,
@@ -126,6 +140,91 @@ def check_docs(root: Path, matrix: dict, errors: list[str]) -> None:
             fail(errors, f"{rel}: abi3 claim is out of scope")
 
 
+def tag_abi(tag: str) -> str:
+    """Wheel ABI/impl is the first '-' separated tag component."""
+    return tag.split("-", 1)[0]
+
+
+def check_tag_anchor(root: Path, matrix: dict, errors: list[str]) -> None:
+    """Anchor Requires-Python / PyPy metadata to declared wheel tags."""
+    wheels = matrix.get("wheels") or []
+    tags = [str(wheel.get("tag") or "") for wheel in wheels]
+    abis = [tag_abi(tag) for tag in tags]
+    requires = matrix.get("requires_python")
+    pyproject = (root / PYPROJECT_REL).read_text(encoding="utf-8")
+    py_req = re.search(r'(?m)^requires-python\s*=\s*"([^"]+)"', pyproject)
+    py_requires = py_req.group(1) if py_req else None
+
+    if requires == REQUIRES_CPYTHON_312:
+        for tag, abi in zip(tags, abis, strict=False):
+            if abi != CP312_ABI:
+                fail(
+                    errors,
+                    f"{MATRIX_REL}: requires_python {REQUIRES_CPYTHON_312!r} "
+                    f"requires every declared tag ABI to be {CP312_ABI}, got {tag!r}",
+                )
+
+    # Inverse: every declared tag is cp312-... (no other CPython ABI, no pp*).
+    if tags and all(abi == CP312_ABI for abi in abis):
+        if requires != REQUIRES_CPYTHON_312:
+            fail(
+                errors,
+                f"{MATRIX_REL}: all declared tags are {CP312_ABI}-only; "
+                f"requires_python must be {REQUIRES_CPYTHON_312!r}, got {requires!r}",
+            )
+        if py_requires != REQUIRES_CPYTHON_312:
+            fail(
+                errors,
+                f"{PYPROJECT_REL}: all declared tags are {CP312_ABI}-only; "
+                f"requires-python must be {REQUIRES_CPYTHON_312!r}, got {py_requires!r}",
+            )
+
+    required = matrix.get("required_classifiers") or []
+    has_pypy = PYPY_CLASSIFIER in pyproject or PYPY_CLASSIFIER in required
+    has_pp_tag = any(PP_ABI_RE.fullmatch(abi) for abi in abis)
+    if has_pypy and not has_pp_tag:
+        fail(
+            errors,
+            f"{MATRIX_REL}: {PYPY_CLASSIFIER!r} is forbidden unless a "
+            f"declared tag ABI matches pp\\d+",
+        )
+
+
+def pull_request_paths(text: str) -> list[str]:
+    in_pr = in_paths = False
+    paths: list[str] = []
+    for line in text.splitlines():
+        if re.match(r"^  pull_request:\s*$", line):
+            in_pr, in_paths = True, False
+            continue
+        if in_pr and re.match(r"^  \S", line):
+            in_pr = in_paths = False
+        if in_pr and re.match(r"^    paths:\s*$", line):
+            in_paths = True
+            continue
+        if in_pr and in_paths and re.match(r"^    \S", line):
+            in_paths = False
+        if in_paths:
+            match = re.match(r'^      - "([^"]+)"\s*(?:#.*)?$', line)
+            if match:
+                paths.append(match.group(1))
+    return paths
+
+
+def check_kernel_matrix_paths(root: Path, errors: list[str]) -> None:
+    path = root / KERNEL_MATRIX_REL
+    if not path.is_file():
+        return
+    paths = pull_request_paths(path.read_text(encoding="utf-8"))
+    for required in ARTIFACT_TRUTH_PR_PATHS:
+        if required not in paths:
+            fail(
+                errors,
+                f"{KERNEL_MATRIX_REL}: pull_request.paths must include {required!r} "
+                f"(python-artifact-truth hook runs here)",
+            )
+
+
 def expected_wheel_names(matrix: dict, version: str) -> list[str]:
     dist = matrix["package"].replace("-", "_")
     return [f"{dist}-{version}-{wheel['tag']}.whl" for wheel in matrix["wheels"]]
@@ -175,9 +274,11 @@ def main(argv: list[str] | None = None) -> int:
             fail(errors, f"{MATRIX_REL}: {target}: import_smoke must be native")
     version = workspace_version(root, errors)
     check_pyproject(root, matrix, errors)
+    check_tag_anchor(root, matrix, errors)
     check_cargo(root, errors)
     check_release_workflow(root, matrix, errors)
     check_docs(root, matrix, errors)
+    check_kernel_matrix_paths(root, errors)
     published = None
     if args.published_files:
         published = json.loads(Path(args.published_files).read_text(encoding="utf-8"))

--- a/scripts/ci/check-python-artifact-truth.py
+++ b/scripts/ci/check-python-artifact-truth.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import re
 import sys
@@ -15,10 +16,10 @@ CARGO_REL = "assay-python-sdk/Cargo.toml"
 RELEASE_REL = ".github/workflows/release.yml"
 WORKSPACE_REL = "Cargo.toml"
 KERNEL_MATRIX_REL = ".github/workflows/kernel-matrix.yml"
+PRECOMMIT_REL = ".pre-commit-config.yaml"
+PLANNER_REL = "scripts/ci/plan-python-artifact-matrix.py"
 SCHEMA = "assay.python_artifact_matrix.v0"
 PYPY_CLASSIFIER = "Programming Language :: Python :: Implementation :: PyPy"
-REQUIRES_CPYTHON_312 = "==3.12.*"
-CP312_ABI = "cp312"
 PP_ABI_RE = re.compile(r"^pp\d+$")
 # python-artifact-truth runs under kernel-matrix Lint. scripts/** already
 # fires; these remaining surfaces must stay listed or a metadata/docs-only
@@ -29,18 +30,47 @@ ARTIFACT_TRUTH_PR_PATHS = (
     "docs/python-sdk/**",
     "docs/getting-started/**",
     "docs/migration-v1.2.md",
+    "docs/guides/troubleshooting.md",
+    "docs/AIcontext/user-flows.md",
+)
+PRECOMMIT_REQUIRED_PATHS = (
+    "docs/migration-v1.2.md",
+    ".github/workflows/kernel-matrix.yml",
 )
 PIP_INSTALL_RE = re.compile(
     r"""(?:python(?:3(?:\.\d+)?)?\s+-m\s+)?pip(?:3|x)?\s+install(?:\s+(?:-U|--upgrade|--user))*\s+["']?assay-it\b""",
     re.IGNORECASE,
 )
-BROADER_PYTHON_RE = re.compile(r"Python\s+3\.(?:[0-9]|1[01])\+|PyPy", re.IGNORECASE)
+BROADER_PYTHON_RE = re.compile(
+    r"(?:(?:CPython|Python)\s+)?3\.\d+\+|3\.\d+\s+(?:and|or)\s+later|PyPy",
+    re.IGNORECASE,
+)
 SDIST_CLAIM_RE = re.compile(r"\bsdist\b|source distribution", re.IGNORECASE)
 ABI3_CLAIM_RE = re.compile(r"\babi3(?:-py\d+)?\b", re.IGNORECASE)
+STRAY_PYTHON_VERSION_RE = re.compile(
+    r"""python-version:\s*['\"]?\d+\.\d+['\"]?"""
+)
+STRAY_MATURIN_INTERPRETER_RE = re.compile(r"-i\s+python\d+\.\d+")
+FAMILY_ORDER = ("macOS", "Linux")
+TARGET_FAMILY_ARCH = {
+    "x86_64-apple-darwin": ("macOS", "x86_64"),
+    "aarch64-apple-darwin": ("macOS", "arm64"),
+    "x86_64-unknown-linux-gnu": ("Linux", "x86_64"),
+}
 
 
 def fail(errors: list[str], msg: str) -> None:
     errors.append(msg)
+
+
+def load_planner():
+    path = Path(__file__).resolve().parent / "plan-python-artifact-matrix.py"
+    spec = importlib.util.spec_from_file_location("plan_python_artifact_matrix", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {PLANNER_REL}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 def load_matrix(root: Path, errors: list[str]) -> dict | None:
@@ -65,6 +95,9 @@ def workspace_version(root: Path, errors: list[str]) -> str | None:
 
 def check_pyproject(root: Path, matrix: dict, errors: list[str]) -> None:
     text = (root / PYPROJECT_REL).read_text(encoding="utf-8")
+    name = re.search(r'(?m)^name\s*=\s*"([^"]+)"', text)
+    if not name or name.group(1) != matrix["package"]:
+        fail(errors, f"{PYPROJECT_REL}: name must be {matrix['package']!r}")
     req = re.search(r'(?m)^requires-python\s*=\s*"([^"]+)"', text)
     if not req or req.group(1) != matrix["requires_python"]:
         fail(errors, f"{PYPROJECT_REL}: requires-python must be {matrix['requires_python']!r}")
@@ -96,31 +129,75 @@ def wheels_job(text: str) -> str:
     return text[start:end]
 
 
-def check_release_workflow(root: Path, matrix: dict, errors: list[str]) -> None:
+def plan_job(text: str) -> str:
+    start = text.find("\n  plan-python-artifact:")
+    if start < 0:
+        raise ValueError("plan-python-artifact job missing")
+    end = text.find("\n  wheels:", start)
+    if end < 0:
+        end = len(text)
+    return text[start:end]
+
+
+def check_release_workflow(root: Path, matrix: dict, plan: dict, errors: list[str]) -> None:
     text = (root / RELEASE_REL).read_text(encoding="utf-8")
     try:
+        planned = plan_job(text)
         job = wheels_job(text)
     except ValueError as exc:
         fail(errors, f"{RELEASE_REL}: {exc}")
         return
-    if "python-version: '3.12'" not in job and 'python-version: "3.12"' not in job:
-        fail(errors, f"{RELEASE_REL}: wheels job must pin Python 3.12")
-    if "-i python3.12" not in job:
-        fail(errors, f"{RELEASE_REL}: maturin must use -i python3.12")
+    if PLANNER_REL not in planned:
+        fail(errors, f"{RELEASE_REL}: plan job must invoke {PLANNER_REL}")
+    if "fromJSON(needs.plan-python-artifact.outputs.wheels)" not in job:
+        fail(
+            errors,
+            f"{RELEASE_REL}: wheels include must consume needs.plan-python-artifact.outputs.wheels",
+        )
+    if "needs.plan-python-artifact.outputs.python" not in job:
+        fail(errors, f"{RELEASE_REL}: setup-python and maturin -i must consume needs.plan-python-artifact.outputs.python")
+    if STRAY_PYTHON_VERSION_RE.search(job):
+        fail(errors, f"{RELEASE_REL}: wheels job must not pin a literal python-version")
+    if STRAY_MATURIN_INTERPRETER_RE.search(job):
+        fail(errors, f"{RELEASE_REL}: maturin must not use a literal -i pythonX.Y")
     if "*.tar.gz" in job or "sdist" in job.lower():
         fail(errors, f"{RELEASE_REL}: sdist publish is out of scope")
     if "dist/*.whl" not in job:
         fail(errors, f"{RELEASE_REL}: upload glob must stay wheel-only")
-    targets = re.findall(r"(?m)^\s+target:\s+(\S+)$", job)
-    expected = [wheel["target"] for wheel in matrix["wheels"]]
-    if targets != expected:
-        fail(errors, f"{RELEASE_REL}: wheel targets {targets} != matrix {expected}")
-    os_labels = re.findall(r"(?m)^\s+-\s+os:\s+(\S+)$", job)
-    expected_os = [wheel["os"] for wheel in matrix["wheels"]]
-    if os_labels != expected_os:
-        fail(errors, f"{RELEASE_REL}: wheel os labels {os_labels} != matrix {expected_os}")
     if "Smoke the produced wheel" not in job or "scripts/ci/smoke-python-wheel.py" not in job:
         fail(errors, f"{RELEASE_REL}: wheels job must bind the produced-wheel smoke")
+    if not re.search(r"--python\b|PYTHON_BIN", job):
+        fail(errors, f"{RELEASE_REL}: smoke must pass --python or PYTHON_BIN explicitly")
+    if "plan-python-artifact" not in job:
+        fail(errors, f"{RELEASE_REL}: wheels job must need the plan job")
+    del matrix, plan
+
+
+def expected_support_bound(python: str, wheels: list) -> str:
+    """Bind support_bound to parsed X.Y and the declared os/target/tag set."""
+    families: dict[str, list[str]] = {}
+    for wheel in wheels:
+        target = wheel.get("target")
+        mapped = TARGET_FAMILY_ARCH.get(target)
+        if mapped is None:
+            raise ValueError(f"cannot derive support_bound from target {target!r}")
+        family, arch = mapped
+        families.setdefault(family, [])
+        if arch not in families[family]:
+            families[family].append(arch)
+    parts: list[str] = []
+    for family in FAMILY_ORDER:
+        if family in families:
+            parts.append(f"{family} {'/'.join(families[family])}")
+    for family, archs in families.items():
+        if family not in FAMILY_ORDER:
+            parts.append(f"{family} {'/'.join(archs)}")
+    if not parts:
+        raise ValueError("cannot derive support_bound from an empty wheels list")
+    return (
+        f"CPython {python} on {' and '.join(parts)}; "
+        "other interpreters and platforms are not claimed."
+    )
 
 
 def check_docs(root: Path, matrix: dict, errors: list[str]) -> None:
@@ -194,46 +271,37 @@ def check_install_docs_inventory(root: Path, matrix: dict, errors: list[str]) ->
             )
 
 
-def tag_abi(tag: str) -> str:
-    """Wheel ABI/impl is the first '-' separated tag component."""
-    return tag.split("-", 1)[0]
+def check_tag_anchor(root: Path, matrix: dict, planner, errors: list[str]) -> dict | None:
+    """Anchor Requires-Python / classifiers / tag ABI to the planner."""
+    try:
+        plan = planner.build_plan(matrix)
+    except ValueError as exc:
+        fail(errors, f"{MATRIX_REL}: {exc}")
+        return None
 
-
-def check_tag_anchor(root: Path, matrix: dict, errors: list[str]) -> None:
-    """Anchor Requires-Python / PyPy metadata to declared wheel tags."""
-    wheels = matrix.get("wheels") or []
-    tags = [str(wheel.get("tag") or "") for wheel in wheels]
-    abis = [tag_abi(tag) for tag in tags]
-    requires = matrix.get("requires_python")
-    pyproject = (root / PYPROJECT_REL).read_text(encoding="utf-8")
-    py_req = re.search(r'(?m)^requires-python\s*=\s*"([^"]+)"', pyproject)
-    py_requires = py_req.group(1) if py_req else None
-
-    if requires == REQUIRES_CPYTHON_312:
-        for tag, abi in zip(tags, abis, strict=False):
-            if abi != CP312_ABI:
-                fail(
-                    errors,
-                    f"{MATRIX_REL}: requires_python {REQUIRES_CPYTHON_312!r} "
-                    f"requires every declared tag ABI to be {CP312_ABI}, got {tag!r}",
-                )
-
-    # Inverse: every declared tag is cp312-... (no other CPython ABI, no pp*).
-    if tags and all(abi == CP312_ABI for abi in abis):
-        if requires != REQUIRES_CPYTHON_312:
-            fail(
-                errors,
-                f"{MATRIX_REL}: all declared tags are {CP312_ABI}-only; "
-                f"requires_python must be {REQUIRES_CPYTHON_312!r}, got {requires!r}",
-            )
-        if py_requires != REQUIRES_CPYTHON_312:
-            fail(
-                errors,
-                f"{PYPROJECT_REL}: all declared tags are {CP312_ABI}-only; "
-                f"requires-python must be {REQUIRES_CPYTHON_312!r}, got {py_requires!r}",
-            )
-
+    classifier = f"Programming Language :: Python :: {plan['python']}"
     required = matrix.get("required_classifiers") or []
+    if classifier not in required:
+        fail(
+            errors,
+            f"{MATRIX_REL}: required_classifiers must include {classifier!r}",
+        )
+    pyproject = (root / PYPROJECT_REL).read_text(encoding="utf-8")
+    if classifier not in pyproject:
+        fail(errors, f"{PYPROJECT_REL}: missing classifier {classifier!r}")
+    try:
+        expected_bound = expected_support_bound(plan["python"], matrix.get("wheels") or [])
+    except ValueError as exc:
+        fail(errors, f"{MATRIX_REL}: {exc}")
+    else:
+        if matrix.get("support_bound") != expected_bound:
+            fail(
+                errors,
+                f"{MATRIX_REL}: support_bound must match declared wheels and "
+                f"CPython {plan['python']}, expected {expected_bound!r}",
+            )
+
+    abis = [planner.tag_abi(str(wheel.get("tag") or "")) for wheel in matrix.get("wheels") or []]
     has_pypy = PYPY_CLASSIFIER in pyproject or PYPY_CLASSIFIER in required
     has_pp_tag = any(PP_ABI_RE.fullmatch(abi) for abi in abis)
     if has_pypy and not has_pp_tag:
@@ -242,6 +310,7 @@ def check_tag_anchor(root: Path, matrix: dict, errors: list[str]) -> None:
             f"{MATRIX_REL}: {PYPY_CLASSIFIER!r} is forbidden unless a "
             f"declared tag ABI matches pp\\d+",
         )
+    return plan
 
 
 def pull_request_paths(text: str) -> list[str]:
@@ -276,6 +345,42 @@ def check_kernel_matrix_paths(root: Path, errors: list[str]) -> None:
                 errors,
                 f"{KERNEL_MATRIX_REL}: pull_request.paths must include {required!r} "
                 f"(python-artifact-truth hook runs here)",
+            )
+
+
+def hook_files_regex(text: str, hook_id: str) -> str | None:
+    in_hook = False
+    for line in text.splitlines():
+        if re.match(rf"^\s+- id: {re.escape(hook_id)}\s*$", line):
+            in_hook = True
+            continue
+        if in_hook and re.match(r"^\s+- id:", line):
+            break
+        if in_hook:
+            match = re.match(r"^\s+files:\s+(\S+)\s*$", line)
+            if match:
+                return match.group(1)
+    return None
+
+
+def check_precommit_selector(root: Path, errors: list[str]) -> None:
+    path = root / PRECOMMIT_REL
+    if not path.is_file():
+        return
+    regex = hook_files_regex(path.read_text(encoding="utf-8"), "python-artifact-truth")
+    if not regex:
+        fail(errors, f"{PRECOMMIT_REL}: python-artifact-truth files: selector missing")
+        return
+    try:
+        compiled = re.compile(regex)
+    except re.error as exc:
+        fail(errors, f"{PRECOMMIT_REL}: python-artifact-truth files: invalid regex: {exc}")
+        return
+    for required in PRECOMMIT_REQUIRED_PATHS:
+        if compiled.search(required) is None:
+            fail(
+                errors,
+                f"{PRECOMMIT_REL}: python-artifact-truth files: must match {required!r}",
             )
 
 
@@ -315,6 +420,11 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     root = Path(args.root).resolve()
     errors: list[str] = []
+    try:
+        planner = load_planner()
+    except RuntimeError as exc:
+        print(f"python-artifact-truth FAIL\n  {exc}", file=sys.stderr)
+        return 1
     matrix = load_matrix(root, errors)
     if matrix is None:
         print("\n".join(errors), file=sys.stderr)
@@ -328,12 +438,14 @@ def main(argv: list[str] | None = None) -> int:
             fail(errors, f"{MATRIX_REL}: {target}: import_smoke must be native")
     version = workspace_version(root, errors)
     check_pyproject(root, matrix, errors)
-    check_tag_anchor(root, matrix, errors)
+    plan = check_tag_anchor(root, matrix, planner, errors)
     check_cargo(root, errors)
-    check_release_workflow(root, matrix, errors)
+    if plan is not None:
+        check_release_workflow(root, matrix, plan, errors)
     check_docs(root, matrix, errors)
     check_install_docs_inventory(root, matrix, errors)
     check_kernel_matrix_paths(root, errors)
+    check_precommit_selector(root, errors)
     published = None
     if args.published_files:
         published = json.loads(Path(args.published_files).read_text(encoding="utf-8"))

--- a/scripts/ci/check-python-artifact-truth.py
+++ b/scripts/ci/check-python-artifact-truth.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Fail-closed gate: assay-it metadata, wheel targets, docs, and pip-download contract share one matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+MATRIX_REL = "assay-python-sdk/python-artifact-matrix.v0.json"
+PYPROJECT_REL = "assay-python-sdk/pyproject.toml"
+CARGO_REL = "assay-python-sdk/Cargo.toml"
+RELEASE_REL = ".github/workflows/release.yml"
+WORKSPACE_REL = "Cargo.toml"
+SCHEMA = "assay.python_artifact_matrix.v0"
+PIP_INSTALL_RE = re.compile(
+    r"""(?:python(?:3(?:\.\d+)?)?\s+-m\s+)?pip(?:3|x)?\s+install(?:\s+(?:-U|--upgrade|--user))*\s+["']?assay-it\b""",
+    re.IGNORECASE,
+)
+BROADER_PYTHON_RE = re.compile(r"Python\s+3\.(?:[0-9]|1[01])\+|PyPy", re.IGNORECASE)
+SDIST_CLAIM_RE = re.compile(r"\bsdist\b|source distribution", re.IGNORECASE)
+ABI3_CLAIM_RE = re.compile(r"\babi3(?:-py\d+)?\b", re.IGNORECASE)
+
+
+def fail(errors: list[str], msg: str) -> None:
+    errors.append(msg)
+
+
+def load_matrix(root: Path, errors: list[str]) -> dict | None:
+    path = root / MATRIX_REL
+    if not path.is_file():
+        fail(errors, f"missing {MATRIX_REL}")
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema") != SCHEMA:
+        fail(errors, f"{MATRIX_REL}: schema must be {SCHEMA}")
+    return data
+
+
+def workspace_version(root: Path, errors: list[str]) -> str | None:
+    text = (root / WORKSPACE_REL).read_text(encoding="utf-8")
+    match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', text)
+    if not match:
+        fail(errors, "Cargo.toml: missing workspace version")
+        return None
+    return match.group(1)
+
+
+def check_pyproject(root: Path, matrix: dict, errors: list[str]) -> None:
+    text = (root / PYPROJECT_REL).read_text(encoding="utf-8")
+    req = re.search(r'(?m)^requires-python\s*=\s*"([^"]+)"', text)
+    if not req or req.group(1) != matrix["requires_python"]:
+        fail(errors, f"{PYPROJECT_REL}: requires-python must be {matrix['requires_python']!r}")
+    for required in matrix["required_classifiers"]:
+        if required not in text:
+            fail(errors, f"{PYPROJECT_REL}: missing classifier {required!r}")
+    for forbidden in matrix["forbidden_classifiers"]:
+        if forbidden in text:
+            fail(errors, f"{PYPROJECT_REL}: forbidden classifier {forbidden!r}")
+    if "pyo3/abi3" in text or "abi3-py" in text:
+        fail(errors, f"{PYPROJECT_REL}: abi3 is out of scope")
+
+
+def check_cargo(root: Path, errors: list[str]) -> None:
+    text = (root / CARGO_REL).read_text(encoding="utf-8")
+    if "abi3" in text:
+        fail(errors, f"{CARGO_REL}: abi3 is out of scope")
+    if "extension-module" not in text:
+        fail(errors, f"{CARGO_REL}: expected pyo3 extension-module only")
+
+
+def wheels_job(text: str) -> str:
+    start = text.find("\n  wheels:")
+    if start < 0:
+        raise ValueError("wheels job missing")
+    end = text.find("\n  publish-pypi:", start)
+    if end < 0:
+        end = len(text)
+    return text[start:end]
+
+
+def check_release_workflow(root: Path, matrix: dict, errors: list[str]) -> None:
+    text = (root / RELEASE_REL).read_text(encoding="utf-8")
+    try:
+        job = wheels_job(text)
+    except ValueError as exc:
+        fail(errors, f"{RELEASE_REL}: {exc}")
+        return
+    if "python-version: '3.12'" not in job and 'python-version: "3.12"' not in job:
+        fail(errors, f"{RELEASE_REL}: wheels job must pin Python 3.12")
+    if "-i python3.12" not in job:
+        fail(errors, f"{RELEASE_REL}: maturin must use -i python3.12")
+    if "*.tar.gz" in job or "sdist" in job.lower():
+        fail(errors, f"{RELEASE_REL}: sdist publish is out of scope")
+    if "dist/*.whl" not in job:
+        fail(errors, f"{RELEASE_REL}: upload glob must stay wheel-only")
+    targets = re.findall(r"(?m)^\s+target:\s+(\S+)$", job)
+    expected = [wheel["target"] for wheel in matrix["wheels"]]
+    if targets != expected:
+        fail(errors, f"{RELEASE_REL}: wheel targets {targets} != matrix {expected}")
+
+
+def check_docs(root: Path, matrix: dict, errors: list[str]) -> None:
+    bound = matrix["support_bound"]
+    for rel in matrix["install_docs"]:
+        path = root / rel
+        if not path.is_file():
+            fail(errors, f"{rel}: install-doc is missing")
+            continue
+        text = path.read_text(encoding="utf-8")
+        if PIP_INSTALL_RE.search(text) and bound not in text:
+            fail(errors, f"{rel}: pip install assay-it without support bound")
+        if BROADER_PYTHON_RE.search(text):
+            fail(errors, f"{rel}: broader Python/PyPy claim than the matrix")
+        if SDIST_CLAIM_RE.search(text) and "assay-it" in text.lower():
+            fail(errors, f"{rel}: sdist claim is out of scope")
+        if ABI3_CLAIM_RE.search(text):
+            fail(errors, f"{rel}: abi3 claim is out of scope")
+
+
+def expected_wheel_names(matrix: dict, version: str) -> list[str]:
+    dist = matrix["package"].replace("-", "_")
+    return [f"{dist}-{version}-{wheel['tag']}.whl" for wheel in matrix["wheels"]]
+
+
+def evaluate_published_files(matrix: dict, version: str, filenames: list[str]) -> list[str]:
+    errors: list[str] = []
+    expected = set(expected_wheel_names(matrix, version))
+    actual = set(filenames)
+    missing = sorted(expected - actual)
+    extra_sdist = sorted(
+        name for name in actual if name.endswith(".tar.gz") or ".tar.gz" in name
+    )
+    if missing:
+        errors.append(f"declared wheel missing from published set: {missing}")
+    if extra_sdist and not matrix.get("publish_sdist"):
+        errors.append(f"sdist published while publish_sdist is false: {extra_sdist}")
+    return errors
+
+
+def check_pip_download_contract(
+    matrix: dict, version: str, errors: list[str], published: list[str] | None
+) -> None:
+    names = published if published is not None else expected_wheel_names(matrix, version)
+    errors.extend(evaluate_published_files(matrix, version, names))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--published-files", help="path to a JSON list of published filenames")
+    args = parser.parse_args(argv)
+    root = Path(args.root).resolve()
+    errors: list[str] = []
+    matrix = load_matrix(root, errors)
+    if matrix is None:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    version = workspace_version(root, errors)
+    check_pyproject(root, matrix, errors)
+    check_cargo(root, errors)
+    check_release_workflow(root, matrix, errors)
+    check_docs(root, matrix, errors)
+    published = None
+    if args.published_files:
+        published = json.loads(Path(args.published_files).read_text(encoding="utf-8"))
+    if version:
+        check_pip_download_contract(matrix, version, errors, published)
+    if errors:
+        print("python-artifact-truth FAIL", file=sys.stderr)
+        for item in errors:
+            print(f"  {item}", file=sys.stderr)
+        return 1
+    print("python-artifact-truth PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check-python-artifact-truth.py
+++ b/scripts/ci/check-python-artifact-truth.py
@@ -100,6 +100,10 @@ def check_release_workflow(root: Path, matrix: dict, errors: list[str]) -> None:
     expected = [wheel["target"] for wheel in matrix["wheels"]]
     if targets != expected:
         fail(errors, f"{RELEASE_REL}: wheel targets {targets} != matrix {expected}")
+    os_labels = re.findall(r"(?m)^\s+-\s+os:\s+(\S+)$", job)
+    expected_os = [wheel["os"] for wheel in matrix["wheels"]]
+    if os_labels != expected_os:
+        fail(errors, f"{RELEASE_REL}: wheel os labels {os_labels} != matrix {expected_os}")
     if "Smoke the produced wheel" not in job or "scripts/ci/smoke-python-wheel.py" not in job:
         fail(errors, f"{RELEASE_REL}: wheels job must bind the produced-wheel smoke")
 
@@ -163,8 +167,12 @@ def main(argv: list[str] | None = None) -> int:
         print("\n".join(errors), file=sys.stderr)
         return 1
     for wheel in matrix.get("wheels") or []:
-        if wheel.get("import_smoke") not in {"native", "unsupported"}:
-            fail(errors, f"{MATRIX_REL}: {wheel.get('target')}: import_smoke must be native or unsupported")
+        mode = wheel.get("import_smoke")
+        target = wheel.get("target")
+        if mode == "unsupported":
+            fail(errors, f"{MATRIX_REL}: {target}: declared pair cannot be unsupported")
+        elif mode != "native":
+            fail(errors, f"{MATRIX_REL}: {target}: import_smoke must be native")
     version = workspace_version(root, errors)
     check_pyproject(root, matrix, errors)
     check_cargo(root, errors)

--- a/scripts/ci/check-python-artifact-truth.py
+++ b/scripts/ci/check-python-artifact-truth.py
@@ -28,6 +28,7 @@ ARTIFACT_TRUTH_PR_PATHS = (
     "llms.txt",
     "docs/python-sdk/**",
     "docs/getting-started/**",
+    "docs/migration-v1.2.md",
 )
 PIP_INSTALL_RE = re.compile(
     r"""(?:python(?:3(?:\.\d+)?)?\s+-m\s+)?pip(?:3|x)?\s+install(?:\s+(?:-U|--upgrade|--user))*\s+["']?assay-it\b""",
@@ -138,6 +139,59 @@ def check_docs(root: Path, matrix: dict, errors: list[str]) -> None:
             fail(errors, f"{rel}: sdist claim is out of scope")
         if ABI3_CLAIM_RE.search(text):
             fail(errors, f"{rel}: abi3 claim is out of scope")
+
+
+DOC_SUFFIXES = {".md", ".txt"}
+# Live install-doc surfaces (current inventory dirs + top-level docs/*.md).
+# Do not crawl tests/, CHANGELOG, archive, plans, or architecture specs.
+INSTALL_DOC_SCAN_DIRS = (
+    "docs/python-sdk",
+    "docs/getting-started",
+    "docs/guides",
+    "docs/AIcontext",
+    "assay-python-sdk",
+)
+
+
+def iter_install_doc_candidates(root: Path) -> list[str]:
+    rels: list[str] = []
+    docs = root / "docs"
+    if docs.is_dir():
+        for child in sorted(docs.iterdir()):
+            if child.is_file() and child.suffix in DOC_SUFFIXES:
+                rels.append(child.relative_to(root).as_posix())
+    for rel_dir in INSTALL_DOC_SCAN_DIRS:
+        base = root / rel_dir
+        if not base.is_dir():
+            continue
+        for child in sorted(base.rglob("*")):
+            if child.is_file() and child.suffix in DOC_SUFFIXES:
+                rels.append(child.relative_to(root).as_posix())
+    llms = root / "llms.txt"
+    if llms.is_file():
+        rels.append("llms.txt")
+    seen: set[str] = set()
+    out: list[str] = []
+    for rel in rels:
+        if rel not in seen:
+            seen.add(rel)
+            out.append(rel)
+    return out
+
+
+def check_install_docs_inventory(root: Path, matrix: dict, errors: list[str]) -> None:
+    listed = set(matrix.get("install_docs") or [])
+    for rel in iter_install_doc_candidates(root):
+        path = root / rel
+        try:
+            page = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if PIP_INSTALL_RE.search(page) and rel not in listed:
+            fail(
+                errors,
+                f"{rel}: active pip install assay-it is omitted from install_docs",
+            )
 
 
 def tag_abi(tag: str) -> str:
@@ -278,6 +332,7 @@ def main(argv: list[str] | None = None) -> int:
     check_cargo(root, errors)
     check_release_workflow(root, matrix, errors)
     check_docs(root, matrix, errors)
+    check_install_docs_inventory(root, matrix, errors)
     check_kernel_matrix_paths(root, errors)
     published = None
     if args.published_files:

--- a/scripts/ci/check-python-wheel-smoke-contract.py
+++ b/scripts/ci/check-python-wheel-smoke-contract.py
@@ -71,6 +71,12 @@ def check_workflow(root: Path, errors: list[str]) -> str:
         fail(errors, f"{RELEASE_REL}: smoke must bind ASSAY_WHEEL_TARGET to matrix.target")
     if re.search(r"pypi\.org|pip index|extra-index-url", job, re.IGNORECASE):
         fail(errors, f"{RELEASE_REL}: wheels job must not use a PyPI network index")
+    if not re.search(r"--python\b|PYTHON_BIN", job):
+        fail(errors, f"{RELEASE_REL}: smoke must pass --python or PYTHON_BIN explicitly")
+    if "plan-python-artifact-matrix.py" not in text:
+        fail(errors, f"{RELEASE_REL}: plan job must invoke plan-python-artifact-matrix.py")
+    if "fromJSON(needs.plan-python-artifact.outputs.wheels)" not in job:
+        fail(errors, f"{RELEASE_REL}: wheels include must consume needs.plan-python-artifact.outputs.wheels")
     return job
 
 
@@ -101,10 +107,12 @@ def check_matrix(root: Path, errors: list[str]) -> dict | None:
 
 
 def check_wheels_pairs(job: str, matrix: dict, errors: list[str]) -> None:
-    actual = INCLUDE_PAIR_RE.findall(job)
-    expected = [(wheel["os"], wheel["target"]) for wheel in matrix.get("wheels") or []]
-    if actual != expected:
-        fail(errors, f"{RELEASE_REL}: wheel (os, target) pairs {actual} != matrix {expected}")
+    if "fromJSON(needs.plan-python-artifact.outputs.wheels)" not in job:
+        fail(
+            errors,
+            f"{RELEASE_REL}: wheels include must consume needs.plan-python-artifact.outputs.wheels",
+        )
+    del matrix
 
 
 def main_calls_install_and_import(tree: ast.AST) -> bool:
@@ -142,6 +150,13 @@ def check_smoke_script(root: Path, errors: list[str]) -> None:
         return
     if not main_calls_install_and_import(tree):
         fail(errors, f"{SMOKE_REL}: main must invoke install_and_import")
+    if re.search(r"python3\.12", text) and re.search(r"default\s*=", text):
+        if re.search(r'default=os\.environ\.get\("PYTHON_BIN",\s*"python3\.12"\)', text):
+            fail(errors, f"{SMOKE_REL}: --python must not default to python3.12")
+    if re.search(r'default=.*["\']assay-it["\']', text):
+        fail(errors, f"{SMOKE_REL}: --package must not default to assay-it")
+    if 'find_wheel(dist, "assay-it"' in text or "find_wheel(dist, 'assay-it'" in text:
+        fail(errors, f"{SMOKE_REL}: find_wheel must take package from the matrix/CLI, not hardcoded assay-it")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/ci/check-python-wheel-smoke-contract.py
+++ b/scripts/ci/check-python-wheel-smoke-contract.py
@@ -96,8 +96,6 @@ def check_matrix(root: Path, errors: list[str]) -> dict | None:
             fail(errors, f"{MATRIX_REL}: {target}: unexpected declared target")
         elif os_label != expected_os:
             fail(errors, f"{MATRIX_REL}: {target}: os must be {expected_os}, got {os_label}")
-        if target == "x86_64-apple-darwin" and os_label == "macos-15":
-            fail(errors, f"{MATRIX_REL}: {target}: os must be macos-15-intel, not macos-15")
     return matrix
 
 

--- a/scripts/ci/check-python-wheel-smoke-contract.py
+++ b/scripts/ci/check-python-wheel-smoke-contract.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import re
 import sys
@@ -106,6 +107,18 @@ def check_wheels_pairs(job: str, matrix: dict, errors: list[str]) -> None:
         fail(errors, f"{RELEASE_REL}: wheel (os, target) pairs {actual} != matrix {expected}")
 
 
+def main_calls_install_and_import(tree: ast.AST) -> bool:
+    for node in tree.body if isinstance(tree, ast.Module) else []:
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            for child in ast.walk(node):
+                if isinstance(child, ast.Call):
+                    func = child.func
+                    if isinstance(func, ast.Name) and func.id == "install_and_import":
+                        return True
+            return False
+    return False
+
+
 def check_smoke_script(root: Path, errors: list[str]) -> None:
     path = root / SMOKE_REL
     if not path.is_file():
@@ -122,6 +135,13 @@ def check_smoke_script(root: Path, errors: list[str]) -> None:
             fail(errors, f"{SMOKE_REL}: missing {label}")
     if re.search(r"pypi\.org|extra-index-url", text):
         fail(errors, f"{SMOKE_REL}: must not talk to PyPI")
+    try:
+        tree = ast.parse(text)
+    except SyntaxError as exc:
+        fail(errors, f"{SMOKE_REL}: cannot parse: {exc}")
+        return
+    if not main_calls_install_and_import(tree):
+        fail(errors, f"{SMOKE_REL}: main must invoke install_and_import")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/ci/check-python-wheel-smoke-contract.py
+++ b/scripts/ci/check-python-wheel-smoke-contract.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Bind the wheels job to a local produced-wheel smoke step. YAML is not generated."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+MATRIX_REL = "assay-python-sdk/python-artifact-matrix.v0.json"
+RELEASE_REL = ".github/workflows/release.yml"
+SMOKE_REL = "scripts/ci/smoke-python-wheel.py"
+SMOKE_STEP = "Smoke the produced wheel"
+BUILD_STEP = "Build wheels"
+UPLOAD_STEP = "Upload wheels"
+NATIVE = "native"
+UNSUPPORTED = "unsupported"
+
+
+def fail(errors: list[str], msg: str) -> None:
+    errors.append(msg)
+
+
+def wheels_job(text: str) -> str:
+    start = text.find("\n  wheels:")
+    if start < 0:
+        raise ValueError("wheels job missing")
+    end = text.find("\n  publish-pypi:", start)
+    if end < 0:
+        end = len(text)
+    return text[start:end]
+
+
+def step_index(job: str, name: str) -> int:
+    marker = f"      - name: {name}"
+    return job.find(marker)
+
+
+def check_workflow(root: Path, errors: list[str]) -> str:
+    text = (root / RELEASE_REL).read_text(encoding="utf-8")
+    try:
+        job = wheels_job(text)
+    except ValueError as exc:
+        fail(errors, f"{RELEASE_REL}: {exc}")
+        return ""
+    build = step_index(job, BUILD_STEP)
+    smoke = step_index(job, SMOKE_STEP)
+    upload = step_index(job, UPLOAD_STEP)
+    if build < 0:
+        fail(errors, f"{RELEASE_REL}: missing {BUILD_STEP!r} step")
+    if smoke < 0:
+        fail(errors, f"{RELEASE_REL}: missing {SMOKE_STEP!r} step")
+    if upload < 0:
+        fail(errors, f"{RELEASE_REL}: missing {UPLOAD_STEP!r} step")
+    if smoke >= 0 and build >= 0 and smoke < build:
+        fail(errors, f"{RELEASE_REL}: smoke must run after {BUILD_STEP!r}")
+    if smoke >= 0 and upload >= 0 and not (build < smoke < upload):
+        fail(errors, f"{RELEASE_REL}: smoke must sit between build and upload")
+    if "scripts/ci/smoke-python-wheel.py" not in job:
+        fail(errors, f"{RELEASE_REL}: wheels job must invoke {SMOKE_REL}")
+    if "ASSAY_WHEEL_TARGET" not in job:
+        fail(errors, f"{RELEASE_REL}: smoke must bind ASSAY_WHEEL_TARGET to matrix.target")
+    if re.search(r"pypi\.org|pip index|extra-index-url", job, re.IGNORECASE):
+        fail(errors, f"{RELEASE_REL}: wheels job must not use a PyPI network index")
+    return job
+
+
+def check_matrix(root: Path, errors: list[str]) -> dict | None:
+    path = root / MATRIX_REL
+    if not path.is_file():
+        fail(errors, f"missing {MATRIX_REL}")
+        return None
+    matrix = json.loads(path.read_text(encoding="utf-8"))
+    wheels = matrix.get("wheels")
+    if not isinstance(wheels, list) or not wheels:
+        fail(errors, f"{MATRIX_REL}: wheels must be a non-empty list")
+        return matrix
+    for wheel in wheels:
+        target = wheel.get("target")
+        mode = wheel.get("import_smoke")
+        if mode not in {NATIVE, UNSUPPORTED}:
+            fail(errors, f"{MATRIX_REL}: {target}: import_smoke must be {NATIVE} or {UNSUPPORTED}")
+        if target == "x86_64-apple-darwin" and mode != UNSUPPORTED:
+            fail(
+                errors,
+                f"{MATRIX_REL}: {target} is cross on macos-15; import_smoke must be {UNSUPPORTED}",
+            )
+        if target in {"x86_64-unknown-linux-gnu", "aarch64-apple-darwin"} and mode != NATIVE:
+            fail(errors, f"{MATRIX_REL}: {target} is native on its runner; import_smoke must be {NATIVE}")
+    return matrix
+
+
+def check_smoke_script(root: Path, errors: list[str]) -> None:
+    path = root / SMOKE_REL
+    if not path.is_file():
+        fail(errors, f"missing {SMOKE_REL}")
+        return
+    text = path.read_text(encoding="utf-8")
+    for needle, label in (
+        ("--no-index", "no-index install"),
+        ("--only-binary", "only-binary install"),
+        ("assay._native", "native import"),
+        ("import_smoke", "import_smoke branch"),
+        (UNSUPPORTED, "unsupported honesty"),
+    ):
+        if needle not in text:
+            fail(errors, f"{SMOKE_REL}: missing {label}")
+    if re.search(r"pypi\.org|extra-index-url", text):
+        fail(errors, f"{SMOKE_REL}: must not talk to PyPI")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    args = parser.parse_args(argv)
+    root = Path(args.root).resolve()
+    errors: list[str] = []
+    check_matrix(root, errors)
+    check_workflow(root, errors)
+    check_smoke_script(root, errors)
+    if errors:
+        print("python-wheel-smoke-contract FAIL", file=sys.stderr)
+        for item in errors:
+            print(f"  {item}", file=sys.stderr)
+        return 1
+    print("python-wheel-smoke-contract PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check-python-wheel-smoke-contract.py
+++ b/scripts/ci/check-python-wheel-smoke-contract.py
@@ -17,6 +17,12 @@ BUILD_STEP = "Build wheels"
 UPLOAD_STEP = "Upload wheels"
 NATIVE = "native"
 UNSUPPORTED = "unsupported"
+EXPECTED_OS = {
+    "x86_64-unknown-linux-gnu": "ubuntu-latest",
+    "x86_64-apple-darwin": "macos-15-intel",
+    "aarch64-apple-darwin": "macos-15",
+}
+INCLUDE_PAIR_RE = re.compile(r"(?m)^\s+-\s+os:\s+(\S+)\s*\n\s+target:\s+(\S+)\s*$")
 
 
 def fail(errors: list[str], msg: str) -> None:
@@ -80,16 +86,26 @@ def check_matrix(root: Path, errors: list[str]) -> dict | None:
     for wheel in wheels:
         target = wheel.get("target")
         mode = wheel.get("import_smoke")
+        os_label = wheel.get("os")
         if mode not in {NATIVE, UNSUPPORTED}:
             fail(errors, f"{MATRIX_REL}: {target}: import_smoke must be {NATIVE} or {UNSUPPORTED}")
-        if target == "x86_64-apple-darwin" and mode != UNSUPPORTED:
-            fail(
-                errors,
-                f"{MATRIX_REL}: {target} is cross on macos-15; import_smoke must be {UNSUPPORTED}",
-            )
-        if target in {"x86_64-unknown-linux-gnu", "aarch64-apple-darwin"} and mode != NATIVE:
-            fail(errors, f"{MATRIX_REL}: {target} is native on its runner; import_smoke must be {NATIVE}")
+        elif mode != NATIVE:
+            fail(errors, f"{MATRIX_REL}: {target}: declared pair cannot be unsupported")
+        expected_os = EXPECTED_OS.get(target)
+        if expected_os is None:
+            fail(errors, f"{MATRIX_REL}: {target}: unexpected declared target")
+        elif os_label != expected_os:
+            fail(errors, f"{MATRIX_REL}: {target}: os must be {expected_os}, got {os_label}")
+        if target == "x86_64-apple-darwin" and os_label == "macos-15":
+            fail(errors, f"{MATRIX_REL}: {target}: os must be macos-15-intel, not macos-15")
     return matrix
+
+
+def check_wheels_pairs(job: str, matrix: dict, errors: list[str]) -> None:
+    actual = INCLUDE_PAIR_RE.findall(job)
+    expected = [(wheel["os"], wheel["target"]) for wheel in matrix.get("wheels") or []]
+    if actual != expected:
+        fail(errors, f"{RELEASE_REL}: wheel (os, target) pairs {actual} != matrix {expected}")
 
 
 def check_smoke_script(root: Path, errors: list[str]) -> None:
@@ -103,7 +119,6 @@ def check_smoke_script(root: Path, errors: list[str]) -> None:
         ("--only-binary", "only-binary install"),
         ("assay._native", "native import"),
         ("import_smoke", "import_smoke branch"),
-        (UNSUPPORTED, "unsupported honesty"),
     ):
         if needle not in text:
             fail(errors, f"{SMOKE_REL}: missing {label}")
@@ -117,8 +132,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     root = Path(args.root).resolve()
     errors: list[str] = []
-    check_matrix(root, errors)
-    check_workflow(root, errors)
+    matrix = check_matrix(root, errors)
+    job = check_workflow(root, errors)
+    if matrix is not None and job:
+        check_wheels_pairs(job, matrix, errors)
     check_smoke_script(root, errors)
     if errors:
         print("python-wheel-smoke-contract FAIL", file=sys.stderr)

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -19,7 +19,7 @@
     },
     {
       "path": ".github/workflows/release.yml",
-      "sha256": "30cda474ecd77b98e9ae1d945380ae6daa65df6cc4a10e800491c8143f6f2e06"
+      "sha256": "0f1601bdde97f28b8be8a1c4aaab53cc22e235bc73069952249b46474626e2ab"
     },
     {
       "path": "scripts/ci/published-release-golden-path.sh",

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -19,7 +19,7 @@
     },
     {
       "path": ".github/workflows/release.yml",
-      "sha256": "632d844c68c7f7cb366d33937f4f2fc49a0500b56ede0c8c4c995e74d6a5443f"
+      "sha256": "30cda474ecd77b98e9ae1d945380ae6daa65df6cc4a10e800491c8143f6f2e06"
     },
     {
       "path": "scripts/ci/published-release-golden-path.sh",

--- a/scripts/ci/plan-python-artifact-matrix.py
+++ b/scripts/ci/plan-python-artifact-matrix.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Read the artifact matrix; emit wheels JSON plus ==X.Y.* -> X.Y / cpXY."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+MATRIX_REL = "assay-python-sdk/python-artifact-matrix.v0.json"
+REQUIRES_EXACT_RE = re.compile(r"^==(\d+)\.(\d+)\.\*$")
+
+
+def parse_requires_python(spec: str) -> tuple[int, int]:
+    """Parse exact ==X.Y.* only. Reject >=, ~=, bare 3.12, ==3.12, ==3.12.0, 3.12+."""
+    if not isinstance(spec, str):
+        raise ValueError(f"requires_python must be exact ==X.Y.*, got {spec!r}")
+    match = REQUIRES_EXACT_RE.fullmatch(spec.strip())
+    if not match:
+        raise ValueError(f"requires_python must be exact ==X.Y.*, got {spec!r}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def cpython_abi(major: int, minor: int) -> str:
+    """3.12 -> cp312, 3.13 -> cp313. One function, not a 3.12 special case."""
+    return f"cp{major}{minor}"
+
+
+def tag_abi(tag: str) -> str:
+    """Wheel ABI/impl is the first '-' separated tag component."""
+    return str(tag).split("-", 1)[0]
+
+
+def build_plan(matrix: dict) -> dict:
+    major, minor = parse_requires_python(matrix.get("requires_python"))
+    abi = cpython_abi(major, minor)
+    python = f"{major}.{minor}"
+    wheels_out: list[dict] = []
+    for wheel in matrix.get("wheels") or []:
+        tag = str(wheel.get("tag") or "")
+        got = tag_abi(tag)
+        if got != abi:
+            raise ValueError(
+                f"tag {tag!r}: ABI must be {abi} for Requires-Python =={python}.*"
+            )
+        wheels_out.append(
+            {
+                "os": wheel["os"],
+                "target": wheel["target"],
+                "tag": tag,
+            }
+        )
+    if not wheels_out:
+        raise ValueError("matrix.wheels must be a non-empty list")
+    return {"python": python, "abi": abi, "wheels": wheels_out}
+
+
+def load_matrix(root: Path) -> dict:
+    path = root / MATRIX_REL
+    if not path.is_file():
+        raise ValueError(f"missing {MATRIX_REL}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=("gha", "json"), default="gha")
+    args = parser.parse_args(argv)
+    root = Path(args.root).resolve()
+    try:
+        plan = build_plan(load_matrix(root))
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    if args.format == "json":
+        json.dump(plan, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
+    print(f"python={plan['python']}")
+    print(f"abi={plan['abi']}")
+    print(f"wheels={json.dumps(plan['wheels'], separators=(',', ':'))}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/smoke-python-wheel.py
+++ b/scripts/ci/smoke-python-wheel.py
@@ -26,12 +26,29 @@ def workspace_version(root: Path) -> str:
     return match.group(1)
 
 
+def load_matrix(root: Path) -> dict:
+    return json.loads((root / MATRIX_REL).read_text(encoding="utf-8"))
+
+
 def load_cell(root: Path, target: str) -> dict:
-    matrix = json.loads((root / MATRIX_REL).read_text(encoding="utf-8"))
+    matrix = load_matrix(root)
     matches = [row for row in matrix["wheels"] if row["target"] == target]
     if len(matches) != 1:
         raise SystemExit(f"matrix has {len(matches)} cells for target {target}")
     return matches[0]
+
+
+def resolve_package(root: Path, explicit: str | None) -> str:
+    package = explicit or os.environ.get("ASSAY_WHEEL_PACKAGE")
+    if package:
+        return package
+    try:
+        package = load_matrix(root).get("package")
+    except (OSError, json.JSONDecodeError, KeyError):
+        package = None
+    if not isinstance(package, str) or not package.strip():
+        raise SystemExit("--package, ASSAY_WHEEL_PACKAGE, or matrix.package is required")
+    return package.strip()
 
 
 def find_wheel(dist: Path, package: str, version: str, tag: str) -> Path:
@@ -51,6 +68,9 @@ def native_members(wheel: Path) -> list[str]:
 
 
 def install_and_import(python: str, wheel: Path, version: str) -> None:
+    package = os.environ.get("ASSAY_WHEEL_PACKAGE")
+    if not package:
+        raise SystemExit("ASSAY_WHEEL_PACKAGE is required")
     if shutil.which(python) is None and not Path(python).exists():
         raise SystemExit(f"native import_smoke requires {python}")
     scratch = Path(tempfile.mkdtemp(prefix="assay-it-wheel-smoke-"))
@@ -74,15 +94,15 @@ def install_and_import(python: str, wheel: Path, version: str) -> None:
                 ":all:",
                 "--find-links",
                 str(wheel.parent),
-                f"assay-it=={version}",
+                f"{package}=={version}",
             ],
             check=True,
             env=env,
         )
         probe = (
             "import importlib.metadata as m, assay, assay._native\n"
-            f"assert m.version('assay-it') == {version!r}, m.version('assay-it')\n"
-            "print('import_smoke=native version=' + m.version('assay-it'))\n"
+            f"assert m.version({package!r}) == {version!r}, m.version({package!r})\n"
+            f"print('import_smoke=native version=' + m.version({package!r}))\n"
         )
         subprocess.run([str(pip), "-c", probe], check=True, env=env)
     finally:
@@ -94,17 +114,22 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--root", default=".")
     parser.add_argument("--dist-dir", default="assay-python-sdk/dist")
     parser.add_argument("--target", default=os.environ.get("ASSAY_WHEEL_TARGET", ""))
-    parser.add_argument("--python", default=os.environ.get("PYTHON_BIN", "python3.12"))
+    parser.add_argument("--python", default=os.environ.get("PYTHON_BIN"))
+    parser.add_argument("--package", default=os.environ.get("ASSAY_WHEEL_PACKAGE"))
     args = parser.parse_args(argv)
     if not args.target:
         raise SystemExit("ASSAY_WHEEL_TARGET or --target is required")
+    if not args.python:
+        raise SystemExit("--python or PYTHON_BIN is required")
     root = Path(args.root).resolve()
     dist = Path(args.dist_dir)
     if not dist.is_absolute():
         dist = root / dist
     cell = load_cell(root, args.target)
     version = workspace_version(root)
-    wheel = find_wheel(dist, "assay-it", version, cell["tag"])
+    package = resolve_package(root, args.package)
+    os.environ["ASSAY_WHEEL_PACKAGE"] = package
+    wheel = find_wheel(dist, package, version, cell["tag"])
     natives = native_members(wheel)
     if len(natives) != 1:
         raise SystemExit(f"{wheel.name}: expected one assay._native extension, found {natives}")

--- a/scripts/ci/smoke-python-wheel.py
+++ b/scripts/ci/smoke-python-wheel.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Fail-closed local smoke for one assay-it wheel cell. No PyPI network."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+MATRIX_REL = "assay-python-sdk/python-artifact-matrix.v0.json"
+NATIVE_RE = re.compile(r"assay/_native[^/]*\.(so|dylib|pyd)$")
+
+
+def workspace_version(root: Path) -> str:
+    text = (root / "Cargo.toml").read_text(encoding="utf-8")
+    match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', text)
+    if not match:
+        raise SystemExit("Cargo.toml: missing workspace version")
+    return match.group(1)
+
+
+def load_cell(root: Path, target: str) -> dict:
+    matrix = json.loads((root / MATRIX_REL).read_text(encoding="utf-8"))
+    matches = [row for row in matrix["wheels"] if row["target"] == target]
+    if len(matches) != 1:
+        raise SystemExit(f"matrix has {len(matches)} cells for target {target}")
+    return matches[0]
+
+
+def find_wheel(dist: Path, package: str, version: str, tag: str) -> Path:
+    expected = f"{package.replace('-', '_')}-{version}-{tag}.whl"
+    found = sorted(path for path in dist.glob("*.whl") if path.name == expected)
+    if len(found) != 1:
+        names = [path.name for path in sorted(dist.glob("*.whl"))]
+        raise SystemExit(
+            f"expected exactly one {expected} in {dist}, found {len(found)}: {names}"
+        )
+    return found[0]
+
+
+def native_members(wheel: Path) -> list[str]:
+    with zipfile.ZipFile(wheel) as archive:
+        return [name for name in archive.namelist() if NATIVE_RE.search(name)]
+
+
+def install_and_import(python: str, wheel: Path, version: str) -> None:
+    if shutil.which(python) is None and not Path(python).exists():
+        raise SystemExit(f"native import_smoke requires {python}")
+    scratch = Path(tempfile.mkdtemp(prefix="assay-it-wheel-smoke-"))
+    try:
+        venv = scratch / "venv"
+        subprocess.run([python, "-m", "venv", str(venv)], check=True)
+        pip = venv / "bin" / "python"
+        env = os.environ.copy()
+        env["PIP_NO_INDEX"] = "1"
+        env.pop("PIP_INDEX_URL", None)
+        env.pop("PIP_EXTRA_INDEX_URL", None)
+        subprocess.run(
+            [
+                str(pip),
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--no-index",
+                "--only-binary",
+                ":all:",
+                "--find-links",
+                str(wheel.parent),
+                f"assay-it=={version}",
+            ],
+            check=True,
+            env=env,
+        )
+        probe = (
+            "import importlib.metadata as m, assay, assay._native\n"
+            f"assert m.version('assay-it') == {version!r}, m.version('assay-it')\n"
+            "print('import_smoke=native version=' + m.version('assay-it'))\n"
+        )
+        subprocess.run([str(pip), "-c", probe], check=True, env=env)
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--dist-dir", default="assay-python-sdk/dist")
+    parser.add_argument("--target", default=os.environ.get("ASSAY_WHEEL_TARGET", ""))
+    parser.add_argument("--python", default=os.environ.get("PYTHON_BIN", "python3.12"))
+    args = parser.parse_args(argv)
+    if not args.target:
+        raise SystemExit("ASSAY_WHEEL_TARGET or --target is required")
+    root = Path(args.root).resolve()
+    dist = Path(args.dist_dir)
+    if not dist.is_absolute():
+        dist = root / dist
+    cell = load_cell(root, args.target)
+    version = workspace_version(root)
+    wheel = find_wheel(dist, "assay-it", version, cell["tag"])
+    natives = native_members(wheel)
+    if len(natives) != 1:
+        raise SystemExit(f"{wheel.name}: expected one assay._native extension, found {natives}")
+    mode = cell.get("import_smoke")
+    if mode == "unsupported":
+        print(
+            f"import_smoke=unsupported target={args.target} wheel={wheel.name} "
+            f"native={natives[0]} no native load claimed"
+        )
+        return 0
+    if mode != "native":
+        raise SystemExit(f"{args.target}: import_smoke must be native or unsupported")
+    install_and_import(args.python, wheel, version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/smoke-python-wheel.py
+++ b/scripts/ci/smoke-python-wheel.py
@@ -109,14 +109,8 @@ def main(argv: list[str] | None = None) -> int:
     if len(natives) != 1:
         raise SystemExit(f"{wheel.name}: expected one assay._native extension, found {natives}")
     mode = cell.get("import_smoke")
-    if mode == "unsupported":
-        print(
-            f"import_smoke=unsupported target={args.target} wheel={wheel.name} "
-            f"native={natives[0]} no native load claimed"
-        )
-        return 0
     if mode != "native":
-        raise SystemExit(f"{args.target}: import_smoke must be native or unsupported")
+        raise SystemExit(f"{args.target}: import_smoke must be native")
     install_and_import(args.python, wheel, version)
     return 0
 

--- a/scripts/ci/smoke-python-wheel.py
+++ b/scripts/ci/smoke-python-wheel.py
@@ -36,9 +36,9 @@ def load_cell(root: Path, target: str) -> dict:
 
 def find_wheel(dist: Path, package: str, version: str, tag: str) -> Path:
     expected = f"{package.replace('-', '_')}-{version}-{tag}.whl"
-    found = sorted(path for path in dist.glob("*.whl") if path.name == expected)
-    if len(found) != 1:
-        names = [path.name for path in sorted(dist.glob("*.whl"))]
+    found = sorted(dist.glob("*.whl"))
+    if len(found) != 1 or found[0].name != expected:
+        names = [path.name for path in found]
         raise SystemExit(
             f"expected exactly one {expected} in {dist}, found {len(found)}: {names}"
         )

--- a/scripts/ci/test-check-python-artifact-truth.sh
+++ b/scripts/ci/test-check-python-artifact-truth.sh
@@ -68,16 +68,19 @@ Path(sys.argv[1]).write_text(
                     "os": "ubuntu-latest",
                     "target": "x86_64-unknown-linux-gnu",
                     "tag": "cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64",
+                    "import_smoke": "native",
                 },
                 {
                     "os": "macos-15",
                     "target": "x86_64-apple-darwin",
                     "tag": "cp312-cp312-macosx_10_12_x86_64",
+                    "import_smoke": "unsupported",
                 },
                 {
                     "os": "macos-15",
                     "target": "aarch64-apple-darwin",
                     "tag": "cp312-cp312-macosx_11_0_arm64",
+                    "import_smoke": "native",
                 },
             ],
             "install_docs": [
@@ -131,6 +134,10 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           args: --release --out dist --locked -i python3.12 --compatibility pypi
+      - name: Smoke the produced wheel
+        env:
+          ASSAY_WHEEL_TARGET: ${{ matrix.target }}
+        run: python3 scripts/ci/smoke-python-wheel.py --dist-dir assay-python-sdk/dist
       - name: Upload wheels
         with:
           path: assay-python-sdk/dist/*.whl

--- a/scripts/ci/test-check-python-artifact-truth.sh
+++ b/scripts/ci/test-check-python-artifact-truth.sh
@@ -71,10 +71,10 @@ Path(sys.argv[1]).write_text(
                     "import_smoke": "native",
                 },
                 {
-                    "os": "macos-15",
+                    "os": "macos-15-intel",
                     "target": "x86_64-apple-darwin",
                     "tag": "cp312-cp312-macosx_10_12_x86_64",
-                    "import_smoke": "unsupported",
+                    "import_smoke": "native",
                 },
                 {
                     "os": "macos-15",
@@ -122,7 +122,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-15
+          - os: macos-15-intel
             target: x86_64-apple-darwin
           - os: macos-15
             target: aarch64-apple-darwin

--- a/scripts/ci/test-check-python-artifact-truth.sh
+++ b/scripts/ci/test-check-python-artifact-truth.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/clear-git-repository-env.sh"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECK="$ROOT/scripts/ci/check-python-artifact-truth.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass() { echo "PASS: $*"; }
+fail_test() { echo "FAIL: $*" >&2; exit 1; }
+
+expect_fail() {
+  local label="$1"
+  shift
+  if python3 "$CHECK" "$@" >"$TMP/out" 2>"$TMP/err"; then
+    fail_test "$label: expected RED, got PASS"
+  fi
+  pass "$label RED"
+}
+
+expect_pass() {
+  local label="$1"
+  shift
+  if ! python3 "$CHECK" "$@" >"$TMP/out" 2>"$TMP/err"; then
+    cat "$TMP/err" >&2
+    fail_test "$label: expected PASS"
+  fi
+  pass "$label GREEN"
+}
+
+write_green_fixture() {
+  local dest="$1"
+  mkdir -p "$dest/assay-python-sdk" "$dest/.github/workflows" \
+    "$dest/docs/python-sdk" "$dest/docs/getting-started" \
+    "$dest/docs/guides" "$dest/docs/AIcontext"
+  cat > "$dest/Cargo.toml" <<'TOML'
+[workspace.package]
+version = "5.4.0"
+TOML
+  python3 - "$dest/assay-python-sdk/python-artifact-matrix.v0.json" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+Path(sys.argv[1]).write_text(
+    json.dumps(
+        {
+            "schema": "assay.python_artifact_matrix.v0",
+            "package": "assay-it",
+            "requires_python": "==3.12.*",
+            "required_classifiers": [
+                "Programming Language :: Python :: 3",
+                "Programming Language :: Python :: 3.12",
+                "Programming Language :: Python :: Implementation :: CPython",
+            ],
+            "forbidden_classifiers": [
+                "Programming Language :: Python :: Implementation :: PyPy",
+            ],
+            "publish_sdist": False,
+            "support_bound": (
+                "CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; "
+                "other interpreters and platforms are not claimed."
+            ),
+            "wheels": [
+                {
+                    "os": "ubuntu-latest",
+                    "target": "x86_64-unknown-linux-gnu",
+                    "tag": "cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64",
+                },
+                {
+                    "os": "macos-15",
+                    "target": "x86_64-apple-darwin",
+                    "tag": "cp312-cp312-macosx_10_12_x86_64",
+                },
+                {
+                    "os": "macos-15",
+                    "target": "aarch64-apple-darwin",
+                    "tag": "cp312-cp312-macosx_11_0_arm64",
+                },
+            ],
+            "install_docs": [
+                "assay-python-sdk/README.md",
+                "docs/python-sdk/index.md",
+                "docs/getting-started/python-quickstart.md",
+                "docs/getting-started/installation.md",
+                "docs/getting-started/index.md",
+                "docs/guides/troubleshooting.md",
+                "docs/AIcontext/user-flows.md",
+                "llms.txt",
+            ],
+        },
+        indent=2,
+    )
+    + "\n"
+)
+PY
+  cat > "$dest/assay-python-sdk/pyproject.toml" <<'TOML'
+requires-python = "==3.12.*"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: Implementation :: CPython",
+]
+[tool.maturin]
+features = ["pyo3/extension-module"]
+TOML
+  cat > "$dest/assay-python-sdk/Cargo.toml" <<'TOML'
+[dependencies]
+pyo3 = { version = "0.29", features = ["pyo3/extension-module"] }
+TOML
+  cat > "$dest/.github/workflows/release.yml" <<'YML'
+jobs:
+  wheels:
+    name: Build Wheels
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-15
+            target: x86_64-apple-darwin
+          - os: macos-15
+            target: aarch64-apple-darwin
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          args: --release --out dist --locked -i python3.12 --compatibility pypi
+      - name: Upload wheels
+        with:
+          path: assay-python-sdk/dist/*.whl
+  publish-pypi:
+    name: Publish to PyPI
+YML
+  bound='CPython 3.12 on macOS x86_64/arm64 and Linux x86_64; other interpreters and platforms are not claimed.'
+  for rel in \
+    assay-python-sdk/README.md \
+    docs/python-sdk/index.md \
+    docs/getting-started/python-quickstart.md \
+    docs/getting-started/installation.md \
+    docs/getting-started/index.md \
+    docs/guides/troubleshooting.md \
+    docs/AIcontext/user-flows.md \
+    llms.txt
+  do
+    printf 'pip install assay-it\n%s\n' "$bound" > "$dest/$rel"
+  done
+}
+
+GREEN="$TMP/green"
+write_green_fixture "$GREEN"
+
+echo "=== live tree ==="
+if python3 "$CHECK" --root "$ROOT"; then
+  pass "live tree GREEN"
+  LIVE_GREEN=1
+else
+  echo "live tree RED (expected before the source fix)" >&2
+  LIVE_GREEN=0
+fi
+
+echo "=== fixture GREEN ==="
+expect_pass "green fixture" --root "$GREEN"
+
+echo "=== mutation: missing required wheel ==="
+python3 - "$TMP/missing.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_text(
+    json.dumps(
+        [
+            "assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl",
+            "assay_it-5.4.0-cp312-cp312-macosx_11_0_arm64.whl",
+        ]
+    )
+    + "\n"
+)
+PY
+expect_fail "missing required wheel" --root "$GREEN" --published-files "$TMP/missing.json"
+
+echo "=== mutation: widened Requires-Python ==="
+cp "$GREEN/assay-python-sdk/pyproject.toml" "$TMP/pyproject.bak"
+python3 - "$GREEN/assay-python-sdk/pyproject.toml" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+path.write_text(path.read_text().replace('requires-python = "==3.12.*"', 'requires-python = ">=3.9"'))
+PY
+expect_fail "widened Requires-Python" --root "$GREEN"
+mv "$TMP/pyproject.bak" "$GREEN/assay-python-sdk/pyproject.toml"
+
+echo "=== mutation: PyPy without wheel ==="
+cp "$GREEN/assay-python-sdk/pyproject.toml" "$TMP/pyproject.bak"
+python3 - "$GREEN/assay-python-sdk/pyproject.toml" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+needle = '"Programming Language :: Python :: Implementation :: CPython",'
+insert = needle + '\n    "Programming Language :: Python :: Implementation :: PyPy",'
+if needle not in text:
+    raise SystemExit('classifier insert point missing')
+path.write_text(text.replace(needle, insert, 1))
+PY
+expect_fail "PyPy classifier without wheel" --root "$GREEN"
+mv "$TMP/pyproject.bak" "$GREEN/assay-python-sdk/pyproject.toml"
+
+echo "=== mutation: sdist claim ==="
+python3 - "$TMP/sdist.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_text(
+    json.dumps(
+        [
+            "assay_it-5.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+            "assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl",
+            "assay_it-5.4.0-cp312-cp312-macosx_11_0_arm64.whl",
+            "assay_it-5.4.0.tar.gz",
+        ]
+    )
+    + "\n"
+)
+PY
+expect_fail "sdist published" --root "$GREEN" --published-files "$TMP/sdist.json"
+
+echo "=== mutation: bare pip-install docs ==="
+cp "$GREEN/docs/python-sdk/index.md" "$TMP/docs.bak"
+printf 'pip install assay-it\n' > "$GREEN/docs/python-sdk/index.md"
+expect_fail "bare pip install docs" --root "$GREEN"
+mv "$TMP/docs.bak" "$GREEN/docs/python-sdk/index.md"
+
+echo "=== no-op restore ==="
+expect_pass "restored green fixture" --root "$GREEN"
+
+if [ "$LIVE_GREEN" -eq 0 ]; then
+  echo "LIVE_TREE_RED"
+  exit 2
+fi
+echo "ALL GREEN"

--- a/scripts/ci/test-check-python-artifact-truth.sh
+++ b/scripts/ci/test-check-python-artifact-truth.sh
@@ -91,6 +91,7 @@ Path(sys.argv[1]).write_text(
                 "docs/getting-started/index.md",
                 "docs/guides/troubleshooting.md",
                 "docs/AIcontext/user-flows.md",
+                "docs/migration-v1.2.md",
                 "llms.txt",
             ],
         },
@@ -153,6 +154,7 @@ YML
     docs/getting-started/index.md \
     docs/guides/troubleshooting.md \
     docs/AIcontext/user-flows.md \
+    docs/migration-v1.2.md \
     llms.txt
   do
     printf 'pip install assay-it\n%s\n' "$bound" > "$dest/$rel"
@@ -307,6 +309,36 @@ path.write_text(text.replace(old, "", 1))
 PY
 expect_fail "dropped kernel-matrix artifact-truth path" --root "$GREEN"
 rm -f "$GREEN/.github/workflows/kernel-matrix.yml"
+
+echo "=== mutation: drop migration-v1.2.md from install_docs ==="
+cp "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" "$TMP/matrix.bak"
+python3 - "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+data = json.loads(path.read_text())
+data["install_docs"] = [rel for rel in data["install_docs"] if rel != "docs/migration-v1.2.md"]
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+expect_fail "drop migration-v1.2.md from install_docs" --root "$GREEN"
+mv "$TMP/matrix.bak" "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json"
+
+echo "=== live install_docs includes migration-v1.2.md ==="
+python3 - "$ROOT/assay-python-sdk/python-artifact-matrix.v0.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text())
+if "docs/migration-v1.2.md" not in data.get("install_docs", []):
+    raise SystemExit("live install_docs missing docs/migration-v1.2.md")
+PY
+if [ $? -ne 0 ]; then
+  fail_test "live install_docs missing docs/migration-v1.2.md"
+fi
+pass "live install_docs includes docs/migration-v1.2.md"
 
 echo "=== no-op restore ==="
 expect_pass "restored green fixture" --root "$GREEN"

--- a/scripts/ci/test-check-python-artifact-truth.sh
+++ b/scripts/ci/test-check-python-artifact-truth.sh
@@ -101,6 +101,7 @@ Path(sys.argv[1]).write_text(
 )
 PY
   cat > "$dest/assay-python-sdk/pyproject.toml" <<'TOML'
+name = "assay-it"
 requires-python = "==3.12.*"
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -116,29 +117,32 @@ pyo3 = { version = "0.29", features = ["pyo3/extension-module"] }
 TOML
   cat > "$dest/.github/workflows/release.yml" <<'YML'
 jobs:
+  plan-python-artifact:
+    outputs:
+      python: ${{ steps.plan.outputs.python }}
+      abi: ${{ steps.plan.outputs.abi }}
+      wheels: ${{ steps.plan.outputs.wheels }}
+    steps:
+      - id: plan
+        run: python3 scripts/ci/plan-python-artifact-matrix.py >> "$GITHUB_OUTPUT"
   wheels:
     name: Build Wheels
+    needs: plan-python-artifact
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-          - os: macos-15
-            target: aarch64-apple-darwin
+        include: ${{ fromJSON(needs.plan-python-artifact.outputs.wheels) }}
     steps:
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: ${{ needs.plan-python-artifact.outputs.python }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          args: --release --out dist --locked -i python3.12 --compatibility pypi
+          args: --release --out dist --locked -i python${{ needs.plan-python-artifact.outputs.python }} --compatibility pypi
       - name: Smoke the produced wheel
         env:
           ASSAY_WHEEL_TARGET: ${{ matrix.target }}
-        run: python3 scripts/ci/smoke-python-wheel.py --dist-dir assay-python-sdk/dist
+        run: python3 scripts/ci/smoke-python-wheel.py --dist-dir assay-python-sdk/dist --python "python${{ needs.plan-python-artifact.outputs.python }}"
       - name: Upload wheels
         with:
           path: assay-python-sdk/dist/*.whl
@@ -339,6 +343,241 @@ if [ $? -ne 0 ]; then
   fail_test "live install_docs missing docs/migration-v1.2.md"
 fi
 pass "live install_docs includes docs/migration-v1.2.md"
+
+echo "=== mutation: coherent 3.13 matrix+pyproject+tags, release still 3.12 ==="
+cp "$GREEN/assay-python-sdk/pyproject.toml" "$TMP/pyproject.bak"
+cp "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" "$TMP/matrix.bak"
+cp "$GREEN/.github/workflows/release.yml" "$TMP/release.bak"
+python3 - "$GREEN/assay-python-sdk/pyproject.toml" \
+  "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" \
+  "$GREEN/.github/workflows/release.yml" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+pyproject = Path(sys.argv[1])
+pyproject.write_text(
+    pyproject.read_text()
+    .replace('requires-python = "==3.12.*"', 'requires-python = "==3.13.*"')
+    .replace("Programming Language :: Python :: 3.12", "Programming Language :: Python :: 3.13")
+)
+matrix = Path(sys.argv[2])
+data = json.loads(matrix.read_text())
+data["requires_python"] = "==3.13.*"
+data["required_classifiers"] = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
+]
+for wheel in data["wheels"]:
+    wheel["tag"] = wheel["tag"].replace("cp312", "cp313")
+data["support_bound"] = (
+    "CPython 3.13 on macOS x86_64/arm64 and Linux x86_64; "
+    "other interpreters and platforms are not claimed."
+)
+matrix.write_text(json.dumps(data, indent=2) + "\n")
+release = Path(sys.argv[3])
+text = release.read_text()
+text = text.replace(
+    "${{ needs.plan-python-artifact.outputs.python }}",
+    "3.12",
+)
+text = text.replace(
+    "${{ needs.plan-python-artifact.outputs.python_bin }}",
+    "python3.12",
+)
+if "python-version: '3.12'" not in text and 'python-version: "3.12"' not in text:
+    text = text.replace("python-version:", "python-version: '3.12' #", 1)
+if "-i python3.12" not in text:
+    text = text.replace("-i ", "-i python3.12 ", 1)
+release.write_text(text)
+PY
+expect_fail "coherent 3.13 matrix+pyproject+tags, release still 3.12" --root "$GREEN"
+mv "$TMP/pyproject.bak" "$GREEN/assay-python-sdk/pyproject.toml"
+mv "$TMP/matrix.bak" "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json"
+mv "$TMP/release.bak" "$GREEN/.github/workflows/release.yml"
+
+echo "=== mutation: requires_python >=3.9 + a cp39 tag ==="
+cp "$GREEN/assay-python-sdk/pyproject.toml" "$TMP/pyproject.bak"
+cp "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" "$TMP/matrix.bak"
+python3 - "$GREEN/assay-python-sdk/pyproject.toml" \
+  "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+pyproject = Path(sys.argv[1])
+pyproject.write_text(
+    pyproject.read_text().replace('requires-python = "==3.12.*"', 'requires-python = ">=3.9"')
+)
+matrix = Path(sys.argv[2])
+data = json.loads(matrix.read_text())
+data["requires_python"] = ">=3.9"
+tag = data["wheels"][0]["tag"]
+data["wheels"][0]["tag"] = tag.replace("cp312-cp312", "cp39-cp39", 1)
+matrix.write_text(json.dumps(data, indent=2) + "\n")
+PY
+expect_fail "requires_python >=3.9 + a cp39 tag" --root "$GREEN"
+mv "$TMP/pyproject.bak" "$GREEN/assay-python-sdk/pyproject.toml"
+mv "$TMP/matrix.bak" "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json"
+
+echo "=== mutation: matrix package assay-py, smoke/pyproject still assay-it ==="
+cp "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" "$TMP/matrix.bak"
+python3 - "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+path = Path(sys.argv[1])
+data = json.loads(path.read_text())
+data["package"] = "assay-py"
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+expect_fail "matrix package assay-py while pyproject/smoke stay assay-it" --root "$GREEN"
+mv "$TMP/matrix.bak" "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json"
+
+echo "=== mutation: drop troubleshooting.md from kernel-matrix paths ==="
+cp "$ROOT/.github/workflows/kernel-matrix.yml" "$GREEN/.github/workflows/kernel-matrix.yml"
+python3 - "$GREEN/.github/workflows/kernel-matrix.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+old = '      - "docs/guides/troubleshooting.md"\n'
+if old not in text:
+    raise SystemExit("troubleshooting.md path entry missing")
+path.write_text(text.replace(old, "", 1))
+PY
+expect_fail "dropped kernel-matrix path docs/guides/troubleshooting.md" --root "$GREEN"
+rm -f "$GREEN/.github/workflows/kernel-matrix.yml"
+
+echo "=== mutation: drop user-flows.md from kernel-matrix paths ==="
+cp "$ROOT/.github/workflows/kernel-matrix.yml" "$GREEN/.github/workflows/kernel-matrix.yml"
+python3 - "$GREEN/.github/workflows/kernel-matrix.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+old = '      - "docs/AIcontext/user-flows.md"\n'
+if old not in text:
+    raise SystemExit("user-flows.md path entry missing")
+path.write_text(text.replace(old, "", 1))
+PY
+expect_fail "dropped kernel-matrix path docs/AIcontext/user-flows.md" --root "$GREEN"
+rm -f "$GREEN/.github/workflows/kernel-matrix.yml"
+
+echo "=== mutation: drop migration-v1.2.md from pre-commit files selector ==="
+cp "$ROOT/.pre-commit-config.yaml" "$GREEN/.pre-commit-config.yaml"
+python3 - "$GREEN/.pre-commit-config.yaml" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+pattern = re.compile(
+    r"(^      - id: python-artifact-truth\n(?:.*\n)*?        files: )(\S+)(\s*$)",
+    re.M,
+)
+match = pattern.search(text)
+if not match:
+    raise SystemExit("python-artifact-truth files: selector missing")
+files = match.group(2)
+if "migration-v1" not in files:
+    raise SystemExit("pre-commit files selector missing migration-v1.2.md")
+mutated = files.replace("|migration-v1\\.2\\.md", "")
+mutated = mutated.replace("migration-v1\\.2\\.md|", "")
+if mutated == files:
+    raise SystemExit("could not drop migration-v1.2.md from " + files)
+path.write_text(text[: match.start(2)] + mutated + text[match.end(2) :])
+PY
+expect_fail "dropped pre-commit selector path docs/migration-v1.2.md" --root "$GREEN"
+rm -f "$GREEN/.pre-commit-config.yaml"
+
+echo "=== mutation: drop kernel-matrix.yml from pre-commit files selector ==="
+cp "$ROOT/.pre-commit-config.yaml" "$GREEN/.pre-commit-config.yaml"
+python3 - "$GREEN/.pre-commit-config.yaml" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+pattern = re.compile(
+    r"(^      - id: python-artifact-truth\n(?:.*\n)*?        files: )(\S+)(\s*$)",
+    re.M,
+)
+match = pattern.search(text)
+if not match:
+    raise SystemExit("python-artifact-truth files: selector missing")
+files = match.group(2)
+if "kernel-matrix" not in files:
+    raise SystemExit("pre-commit files selector missing kernel-matrix.yml")
+mutated = files.replace("(release|kernel-matrix)", "release")
+mutated = mutated.replace("|kernel-matrix\\.yml", "")
+mutated = mutated.replace("kernel-matrix\\.yml|", "")
+if mutated == files:
+    raise SystemExit("could not drop kernel-matrix.yml from " + files)
+path.write_text(text[: match.start(2)] + mutated + text[match.end(2) :])
+PY
+expect_fail "dropped pre-commit selector path kernel-matrix.yml" --root "$GREEN"
+rm -f "$GREEN/.pre-commit-config.yaml"
+
+echo "=== mutation: listed install-doc claims Python 3.12+ ==="
+cp "$GREEN/docs/python-sdk/index.md" "$TMP/docs.bak"
+python3 - "$GREEN/docs/python-sdk/index.md" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+path.write_text(path.read_text() + "Requires Python 3.12+.\n")
+PY
+expect_fail "install-doc claims Python 3.12+" --root "$GREEN"
+mv "$TMP/docs.bak" "$GREEN/docs/python-sdk/index.md"
+
+echo "=== mutation: listed install-doc claims 3.13+ ==="
+cp "$GREEN/docs/python-sdk/index.md" "$TMP/docs.bak"
+python3 - "$GREEN/docs/python-sdk/index.md" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+path.write_text(path.read_text() + "Supports 3.13+.\n")
+PY
+expect_fail "install-doc claims 3.13+" --root "$GREEN"
+mv "$TMP/docs.bak" "$GREEN/docs/python-sdk/index.md"
+
+echo "=== mutation: listed install-doc claims 3.10 and later ==="
+cp "$GREEN/docs/python-sdk/index.md" "$TMP/docs.bak"
+python3 - "$GREEN/docs/python-sdk/index.md" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+path.write_text(path.read_text() + "Python 3.10 and later.\n")
+PY
+expect_fail "install-doc claims 3.10 and later" --root "$GREEN"
+mv "$TMP/docs.bak" "$GREEN/docs/python-sdk/index.md"
+
+echo "=== mutation: support_bound drifts from declared wheels ==="
+cp "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" "$TMP/matrix.bak"
+python3 - "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+path = Path(sys.argv[1])
+data = json.loads(path.read_text())
+data["support_bound"] = (
+    "CPython 3.13 on macOS x86_64/arm64 and Linux x86_64; "
+    "other interpreters and platforms are not claimed."
+)
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+expect_fail "support_bound drifts from declared wheels" --root "$GREEN"
+mv "$TMP/matrix.bak" "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json"
 
 echo "=== no-op restore ==="
 expect_pass "restored green fixture" --root "$GREEN"

--- a/scripts/ci/test-check-python-artifact-truth.sh
+++ b/scripts/ci/test-check-python-artifact-truth.sh
@@ -203,6 +203,29 @@ PY
 expect_fail "widened Requires-Python" --root "$GREEN"
 mv "$TMP/pyproject.bak" "$GREEN/assay-python-sdk/pyproject.toml"
 
+echo "=== mutation: coordinated Requires-Python widen ==="
+cp "$GREEN/assay-python-sdk/pyproject.toml" "$TMP/pyproject.bak"
+cp "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" "$TMP/matrix.bak"
+python3 - "$GREEN/assay-python-sdk/pyproject.toml" "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+pyproject = Path(sys.argv[1])
+pyproject.write_text(
+    pyproject.read_text().replace(
+        'requires-python = "==3.12.*"', 'requires-python = ">=3.9"'
+    )
+)
+matrix = Path(sys.argv[2])
+data = json.loads(matrix.read_text())
+data["requires_python"] = ">=3.9"
+matrix.write_text(json.dumps(data, indent=2) + "\n")
+PY
+expect_fail "coordinated Requires-Python widen" --root "$GREEN"
+mv "$TMP/pyproject.bak" "$GREEN/assay-python-sdk/pyproject.toml"
+mv "$TMP/matrix.bak" "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json"
+
 echo "=== mutation: PyPy without wheel ==="
 cp "$GREEN/assay-python-sdk/pyproject.toml" "$TMP/pyproject.bak"
 python3 - "$GREEN/assay-python-sdk/pyproject.toml" <<'PY'
@@ -218,6 +241,30 @@ path.write_text(text.replace(needle, insert, 1))
 PY
 expect_fail "PyPy classifier without wheel" --root "$GREEN"
 mv "$TMP/pyproject.bak" "$GREEN/assay-python-sdk/pyproject.toml"
+
+echo "=== mutation: coordinated PyPy with empty forbidden_classifiers ==="
+cp "$GREEN/assay-python-sdk/pyproject.toml" "$TMP/pyproject.bak"
+cp "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" "$TMP/matrix.bak"
+python3 - "$GREEN/assay-python-sdk/pyproject.toml" "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+pyproject = Path(sys.argv[1])
+text = pyproject.read_text()
+needle = '"Programming Language :: Python :: Implementation :: CPython",'
+insert = needle + '\n    "Programming Language :: Python :: Implementation :: PyPy",'
+if needle not in text:
+    raise SystemExit("classifier insert point missing")
+pyproject.write_text(text.replace(needle, insert, 1))
+matrix = Path(sys.argv[2])
+data = json.loads(matrix.read_text())
+data["forbidden_classifiers"] = []
+matrix.write_text(json.dumps(data, indent=2) + "\n")
+PY
+expect_fail "coordinated PyPy with empty forbidden_classifiers" --root "$GREEN"
+mv "$TMP/pyproject.bak" "$GREEN/assay-python-sdk/pyproject.toml"
+mv "$TMP/matrix.bak" "$GREEN/assay-python-sdk/python-artifact-matrix.v0.json"
 
 echo "=== mutation: sdist claim ==="
 python3 - "$TMP/sdist.json" <<'PY'
@@ -244,6 +291,22 @@ cp "$GREEN/docs/python-sdk/index.md" "$TMP/docs.bak"
 printf 'pip install assay-it\n' > "$GREEN/docs/python-sdk/index.md"
 expect_fail "bare pip install docs" --root "$GREEN"
 mv "$TMP/docs.bak" "$GREEN/docs/python-sdk/index.md"
+
+echo "=== mutation: drop one kernel-matrix artifact-truth path ==="
+cp "$ROOT/.github/workflows/kernel-matrix.yml" "$GREEN/.github/workflows/kernel-matrix.yml"
+python3 - "$GREEN/.github/workflows/kernel-matrix.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+old = '      - "llms.txt"\n'
+if old not in text:
+    raise SystemExit("llms.txt path entry missing")
+path.write_text(text.replace(old, "", 1))
+PY
+expect_fail "dropped kernel-matrix artifact-truth path" --root "$GREEN"
+rm -f "$GREEN/.github/workflows/kernel-matrix.yml"
 
 echo "=== no-op restore ==="
 expect_pass "restored green fixture" --root "$GREEN"

--- a/scripts/ci/test-check-python-wheel-smoke-contract.sh
+++ b/scripts/ci/test-check-python-wheel-smoke-contract.sh
@@ -96,7 +96,7 @@ expected = dist / "assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl"
 (expected.with_name("noise-not-the-cell.whl")).write_bytes(expected.read_bytes())
 print("extra non-matching wheel present")
 PY
-expect_pass "unsupported cell with one matching wheel" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-apple-darwin
+# Extra non-matching wheel stays as setup; the skip-path PASS is gone.
 
 # two exact matches: copy into a listing that smoke sees as two same names via a wrapper dir is impossible. Simulate by editing find to... instead write two files where the second has the same name in a way glob returns both — can't. Use a subdirectory? glob is dist.glob("*.whl") so only top-level.
 # Create two files that both equal expected name after we patch? Simpler: write expected twice by using a second identical tag file that the code treats as match — it matches path.name == expected, so only exact name.
@@ -106,7 +106,7 @@ mv "$CASE/assay-python-sdk/dist/assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.w
   "$CASE/assay-python-sdk/dist/renamed-away.whl"
 expect_fail "renamed produced wheel" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-apple-darwin
 
-echo "=== mutation: native import_smoke on cross macos x86_64 ==="
+echo "=== mutation: restore old x86 macos-15 + unsupported ==="
 python3 - "$CASE/assay-python-sdk/python-artifact-matrix.v0.json" <<'PY'
 import json
 from pathlib import Path
@@ -115,11 +115,66 @@ path = Path(sys.argv[1])
 data = json.loads(path.read_text())
 for wheel in data["wheels"]:
     if wheel["target"] == "x86_64-apple-darwin":
+        wheel["os"] = "macos-15"
+        wheel["import_smoke"] = "unsupported"
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+expect_fail "old x86 macos-15 unsupported row" python3 "$CONTRACT" --root "$CASE"
+cp "$ROOT/assay-python-sdk/python-artifact-matrix.v0.json" "$CASE/assay-python-sdk/python-artifact-matrix.v0.json"
+
+echo "=== mutation: declared pair import_smoke=unsupported ==="
+python3 - "$CASE/assay-python-sdk/python-artifact-matrix.v0.json" <<'PY'
+import json
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+data = json.loads(path.read_text())
+data["wheels"][0]["import_smoke"] = "unsupported"
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+expect_fail "declared pair import_smoke unsupported" python3 "$CONTRACT" --root "$CASE"
+cp "$ROOT/assay-python-sdk/python-artifact-matrix.v0.json" "$CASE/assay-python-sdk/python-artifact-matrix.v0.json"
+
+echo "=== mutation: x86 os macos-15 even if native ==="
+python3 - "$CASE/assay-python-sdk/python-artifact-matrix.v0.json" <<'PY'
+import json
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+data = json.loads(path.read_text())
+for wheel in data["wheels"]:
+    if wheel["target"] == "x86_64-apple-darwin":
+        wheel["os"] = "macos-15"
         wheel["import_smoke"] = "native"
 path.write_text(json.dumps(data, indent=2) + "\n")
 PY
-expect_fail "cross cell claimed native" python3 "$CONTRACT" --root "$CASE"
+expect_fail "x86 os macos-15 with native smoke" python3 "$CONTRACT" --root "$CASE"
 cp "$ROOT/assay-python-sdk/python-artifact-matrix.v0.json" "$CASE/assay-python-sdk/python-artifact-matrix.v0.json"
+
+echo "=== mutation: release.yml wheels x86 left on macos-15 ==="
+python3 - "$CASE/.github/workflows/release.yml" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+start = text.find("\n  wheels:")
+end = text.find("\n  publish-pypi:", start)
+if start < 0 or end < 0:
+    raise SystemExit("wheels job bounds missing")
+job = text[start:end]
+old = """          - os: macos-15-intel
+            target: x86_64-apple-darwin
+"""
+new = """          - os: macos-15
+            target: x86_64-apple-darwin
+"""
+if old not in job:
+    raise SystemExit("wheels x86 intel row not found")
+job = job.replace(old, new, 1)
+path.write_text(text[:start] + job + text[end:])
+PY
+expect_fail "release.yml wheels x86 os macos-15 vs matrix intel" python3 "$CONTRACT" --root "$CASE"
+cp "$ROOT/.github/workflows/release.yml" "$CASE/.github/workflows/release.yml"
 
 echo "=== mutation: drop native import from smoke script ==="
 python3 - "$CASE/scripts/ci/smoke-python-wheel.py" <<'PY'

--- a/scripts/ci/test-check-python-wheel-smoke-contract.sh
+++ b/scripts/ci/test-check-python-wheel-smoke-contract.sh
@@ -31,6 +31,85 @@ expect_pass() {
   pass "$label GREEN"
 }
 
+
+run_install_spy() {
+  local smoke_path="$1"
+  local spy_root="$TMP/spy-root"
+  local spy_dist="$TMP/spy-dist"
+  mkdir -p "$spy_root" "$spy_dist"
+  python3 - "$smoke_path" "$spy_root" "$spy_dist" <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+
+smoke_path = Path(sys.argv[1])
+root = sys.argv[2]
+dist = sys.argv[3]
+
+spec = importlib.util.spec_from_file_location("smoke_python_wheel_spy", smoke_path)
+if spec is None or spec.loader is None:
+    raise SystemExit("cannot load smoke script")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+sentinel_version = "9.9.9-sentinel"
+sentinel_wheel = Path("/sentinel/wheel.whl")
+spy_calls = []
+
+
+def load_cell(root, target):
+    return {"import_smoke": "native", "tag": "cp312-cp312-manylinux_2_17_x86_64"}
+
+
+def workspace_version(root):
+    return sentinel_version
+
+
+def find_wheel(dist, package, version, tag):
+    return sentinel_wheel
+
+
+def native_members(wheel):
+    return ["assay/_native.so"]
+
+
+def install_and_import(python, wheel, version):
+    spy_calls.append((python, wheel, version))
+
+
+mod.load_cell = load_cell
+mod.workspace_version = workspace_version
+mod.find_wheel = find_wheel
+mod.native_members = native_members
+mod.install_and_import = install_and_import
+
+try:
+    rc = mod.main(
+        [
+            "--root",
+            root,
+            "--dist-dir",
+            dist,
+            "--target",
+            "x86_64-unknown-linux-gnu",
+            "--python",
+            "/sentinel/python",
+        ]
+    )
+except SystemExit as exc:
+    print(f"main raised SystemExit: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+
+expected = [("/sentinel/python", sentinel_wheel, sentinel_version)]
+if rc != 0 or spy_calls != expected:
+    print(f"rc={rc!r} spy_calls={spy_calls!r} expected {expected!r}", file=sys.stderr)
+    raise SystemExit(1)
+raise SystemExit(0)
+PY
+}
+
+expect_pass "production install_and_import spy" run_install_spy "$SMOKE"
+
 expect_pass "live smoke contract" python3 "$CONTRACT" --root "$ROOT"
 
 write_dummy_wheel() {
@@ -185,6 +264,66 @@ if old not in text:
 path.write_text(text.replace(old, "", 1))
 PY
 expect_fail "drop production install_and_import call" python3 "$CONTRACT" --root "$CASE"
+cp "$ROOT/scripts/ci/smoke-python-wheel.py" "$CASE/scripts/ci/smoke-python-wheel.py"
+
+
+echo "=== mutation: drop production install_and_import call (spy) ==="
+python3 - "$CASE/scripts/ci/smoke-python-wheel.py" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+old = "    install_and_import(args.python, wheel, version)\n"
+if old not in text:
+    raise SystemExit("production install_and_import call not found")
+path.write_text(text.replace(old, "", 1))
+PY
+expect_fail "drop production install_and_import call (spy)" run_install_spy "$CASE/scripts/ci/smoke-python-wheel.py"
+cp "$ROOT/scripts/ci/smoke-python-wheel.py" "$CASE/scripts/ci/smoke-python-wheel.py"
+
+echo "=== mutation: wrap production install_and_import in if False ==="
+python3 - "$CASE/scripts/ci/smoke-python-wheel.py" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+old = "    install_and_import(args.python, wheel, version)\n"
+new = "    if False:\n        install_and_import(args.python, wheel, version)\n"
+if old not in text:
+    raise SystemExit("production install_and_import call not found")
+path.write_text(text.replace(old, new, 1))
+PY
+expect_fail "wrap production install_and_import in if False" run_install_spy "$CASE/scripts/ci/smoke-python-wheel.py"
+cp "$ROOT/scripts/ci/smoke-python-wheel.py" "$CASE/scripts/ci/smoke-python-wheel.py"
+
+echo "=== mutation: wrong python/wheel/version args to install_and_import ==="
+python3 - "$CASE/scripts/ci/smoke-python-wheel.py" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+old = "    install_and_import(args.python, wheel, version)\n"
+new = '    install_and_import("/wrong/python", wheel, version)\n'
+if old not in text:
+    raise SystemExit("production install_and_import call not found")
+path.write_text(text.replace(old, new, 1))
+PY
+expect_fail "wrong python/wheel/version args to install_and_import" run_install_spy "$CASE/scripts/ci/smoke-python-wheel.py"
+cp "$ROOT/scripts/ci/smoke-python-wheel.py" "$CASE/scripts/ci/smoke-python-wheel.py"
+
+echo "=== mutation: return 0 before production install_and_import ==="
+python3 - "$CASE/scripts/ci/smoke-python-wheel.py" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+old = "    install_and_import(args.python, wheel, version)\n"
+new = "    return 0\n    install_and_import(args.python, wheel, version)\n"
+if old not in text:
+    raise SystemExit("production install_and_import call not found")
+path.write_text(text.replace(old, new, 1))
+PY
+expect_fail "return 0 before production install_and_import" run_install_spy "$CASE/scripts/ci/smoke-python-wheel.py"
 cp "$ROOT/scripts/ci/smoke-python-wheel.py" "$CASE/scripts/ci/smoke-python-wheel.py"
 
 echo "=== no-op restore ==="

--- a/scripts/ci/test-check-python-wheel-smoke-contract.sh
+++ b/scripts/ci/test-check-python-wheel-smoke-contract.sh
@@ -94,6 +94,8 @@ try:
             "x86_64-unknown-linux-gnu",
             "--python",
             "/sentinel/python",
+            "--package",
+            "assay-it",
         ]
     )
 except SystemExit as exc:
@@ -146,7 +148,7 @@ old = """      - name: Smoke the produced wheel
         shell: bash
         env:
           ASSAY_WHEEL_TARGET: ${{ matrix.target }}
-        run: python3 scripts/ci/smoke-python-wheel.py --dist-dir assay-python-sdk/dist
+        run: python3 scripts/ci/smoke-python-wheel.py --dist-dir assay-python-sdk/dist --python "python${{ needs.plan-python-artifact.outputs.python }}"
 
 """
 if old not in text:
@@ -158,18 +160,18 @@ cp "$ROOT/.github/workflows/release.yml" "$CASE/.github/workflows/release.yml"
 
 echo "=== mutation: empty dist / no produced wheel ==="
 mkdir -p "$CASE/assay-python-sdk/dist"
-expect_fail "empty dist native cell" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-unknown-linux-gnu
+expect_fail "empty dist native cell" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-unknown-linux-gnu --python python3 --package assay-it
 
 echo "=== mutation: extra wheel beside expected ==="
 write_dummy_wheel "$CASE/assay-python-sdk/dist" "assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl"
 write_dummy_wheel "$CASE/assay-python-sdk/dist" "noise-not-the-cell.whl"
-expect_fail "extra wheel beside expected" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-apple-darwin
+expect_fail "extra wheel beside expected" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-apple-darwin --python python3 --package assay-it
 rm -f "$CASE/assay-python-sdk/dist/noise-not-the-cell.whl"
 
 echo "=== mutation: renamed produced wheel ==="
 mv "$CASE/assay-python-sdk/dist/assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl" \
   "$CASE/assay-python-sdk/dist/renamed-away.whl"
-expect_fail "renamed produced wheel" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-apple-darwin
+expect_fail "renamed produced wheel" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-apple-darwin --python python3 --package assay-it
 
 echo "=== mutation: restore old x86 macos-15 + unsupported ==="
 python3 - "$CASE/assay-python-sdk/python-artifact-matrix.v0.json" <<'PY'
@@ -227,14 +229,17 @@ end = text.find("\n  publish-pypi:", start)
 if start < 0 or end < 0:
     raise SystemExit("wheels job bounds missing")
 job = text[start:end]
-old = """          - os: macos-15-intel
+old = "include: ${{ fromJSON(needs.plan-python-artifact.outputs.wheels) }}"
+new = """include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-15
             target: x86_64-apple-darwin
-"""
-new = """          - os: macos-15
-            target: x86_64-apple-darwin
+          - os: macos-15
+            target: aarch64-apple-darwin
 """
 if old not in job:
-    raise SystemExit("wheels x86 intel row not found")
+    raise SystemExit("wheels plan include not found")
 job = job.replace(old, new, 1)
 path.write_text(text[:start] + job + text[end:])
 PY

--- a/scripts/ci/test-check-python-wheel-smoke-contract.sh
+++ b/scripts/ci/test-check-python-wheel-smoke-contract.sh
@@ -81,27 +81,13 @@ echo "=== mutation: empty dist / no produced wheel ==="
 mkdir -p "$CASE/assay-python-sdk/dist"
 expect_fail "empty dist native cell" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-unknown-linux-gnu
 
-echo "=== mutation: two matching wheels ==="
+echo "=== mutation: extra wheel beside expected ==="
 write_dummy_wheel "$CASE/assay-python-sdk/dist" "assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl"
-cp "$CASE/assay-python-sdk/dist/assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl" \
-  "$CASE/assay-python-sdk/dist/assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl.bak"
-# two files with the same expected name cannot coexist; write a second unexpected extra plus the expected, then duplicate via copy to a second matching path using a temp dir listing
-# The smoke matches exact filename, so two exact names need two dirs. Instead drop the expected name and leave nothing, already covered. Create two exact files by running find against a dir that has the expected plus a renamed duplicate that still matches glob+name.
-python3 - "$CASE/assay-python-sdk/dist" <<'PY'
-from pathlib import Path
-import sys
-dist = Path(sys.argv[1])
-expected = dist / "assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl"
-# A second file with a different name must not satisfy the exact-name check; prove extra files are ignored.
-(expected.with_name("noise-not-the-cell.whl")).write_bytes(expected.read_bytes())
-print("extra non-matching wheel present")
-PY
-# Extra non-matching wheel stays as setup; the skip-path PASS is gone.
+write_dummy_wheel "$CASE/assay-python-sdk/dist" "noise-not-the-cell.whl"
+expect_fail "extra wheel beside expected" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-apple-darwin
+rm -f "$CASE/assay-python-sdk/dist/noise-not-the-cell.whl"
 
-# two exact matches: copy into a listing that smoke sees as two same names via a wrapper dir is impossible. Simulate by editing find to... instead write two files where the second has the same name in a way glob returns both — can't. Use a subdirectory? glob is dist.glob("*.whl") so only top-level.
-# Create two files that both equal expected name after we patch? Simpler: write expected twice by using a second identical tag file that the code treats as match — it matches path.name == expected, so only exact name.
-# Reproduce "two wheels" by temporarily making find_wheel count all *.whl when names collide via hardlink? Two hardlinks same name is one file.
-# I'll drop the expected file (rename) while leaving only noise — that's empty for that cell.
+echo "=== mutation: renamed produced wheel ==="
 mv "$CASE/assay-python-sdk/dist/assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl" \
   "$CASE/assay-python-sdk/dist/renamed-away.whl"
 expect_fail "renamed produced wheel" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-apple-darwin

--- a/scripts/ci/test-check-python-wheel-smoke-contract.sh
+++ b/scripts/ci/test-check-python-wheel-smoke-contract.sh
@@ -172,6 +172,21 @@ path.write_text(text)
 PY
 expect_fail "smoke script without assay._native" python3 "$CONTRACT" --root "$CASE"
 
+cp "$ROOT/scripts/ci/smoke-python-wheel.py" "$CASE/scripts/ci/smoke-python-wheel.py"
+echo "=== mutation: drop production install_and_import call ==="
+python3 - "$CASE/scripts/ci/smoke-python-wheel.py" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+old = "    install_and_import(args.python, wheel, version)\n"
+if old not in text:
+    raise SystemExit("production install_and_import call not found")
+path.write_text(text.replace(old, "", 1))
+PY
+expect_fail "drop production install_and_import call" python3 "$CONTRACT" --root "$CASE"
+cp "$ROOT/scripts/ci/smoke-python-wheel.py" "$CASE/scripts/ci/smoke-python-wheel.py"
+
 echo "=== no-op restore ==="
 cp "$ROOT/.github/workflows/release.yml" "$CASE/.github/workflows/release.yml"
 cp "$ROOT/assay-python-sdk/python-artifact-matrix.v0.json" "$CASE/assay-python-sdk/python-artifact-matrix.v0.json"

--- a/scripts/ci/test-check-python-wheel-smoke-contract.sh
+++ b/scripts/ci/test-check-python-wheel-smoke-contract.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/clear-git-repository-env.sh"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT="$ROOT/scripts/ci/check-python-wheel-smoke-contract.py"
+SMOKE="$ROOT/scripts/ci/smoke-python-wheel.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass() { echo "PASS: $*"; }
+fail_test() { echo "FAIL: $*" >&2; exit 1; }
+
+expect_fail() {
+  local label="$1"
+  shift
+  if "$@" >"$TMP/out" 2>"$TMP/err"; then
+    fail_test "$label: expected RED, got PASS"
+  fi
+  pass "$label RED"
+}
+
+expect_pass() {
+  local label="$1"
+  shift
+  if ! "$@" >"$TMP/out" 2>"$TMP/err"; then
+    cat "$TMP/err" >&2
+    fail_test "$label: expected PASS"
+  fi
+  pass "$label GREEN"
+}
+
+expect_pass "live smoke contract" python3 "$CONTRACT" --root "$ROOT"
+
+write_dummy_wheel() {
+  local dest="$1" name="$2"
+  python3 - "$dest" "$name" <<'PY'
+import sys, zipfile
+from pathlib import Path
+dest = Path(sys.argv[1])
+dest.mkdir(parents=True, exist_ok=True)
+name = sys.argv[2]
+with zipfile.ZipFile(dest / name, "w") as archive:
+    archive.writestr("assay/_native.cpython-312-darwin.so", b"not-a-real-extension")
+    archive.writestr(
+        "assay_it-5.4.0.dist-info/METADATA",
+        "Metadata-Version: 2.1\nName: assay-it\nVersion: 5.4.0\n",
+    )
+PY
+}
+
+CASE="$TMP/case"
+mkdir -p "$CASE"
+cp -a "$ROOT/.github" "$CASE/.github"
+cp -a "$ROOT/assay-python-sdk" "$CASE/assay-python-sdk"
+cp -a "$ROOT/scripts" "$CASE/scripts"
+cp "$ROOT/Cargo.toml" "$CASE/Cargo.toml"
+
+echo "=== mutation: drop smoke step ==="
+python3 - "$CASE/.github/workflows/release.yml" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+old = """      - name: Smoke the produced wheel
+        shell: bash
+        env:
+          ASSAY_WHEEL_TARGET: ${{ matrix.target }}
+        run: python3 scripts/ci/smoke-python-wheel.py --dist-dir assay-python-sdk/dist
+
+"""
+if old not in text:
+    raise SystemExit("smoke step not found")
+path.write_text(text.replace(old, "", 1))
+PY
+expect_fail "drop smoke step" python3 "$CONTRACT" --root "$CASE"
+cp "$ROOT/.github/workflows/release.yml" "$CASE/.github/workflows/release.yml"
+
+echo "=== mutation: empty dist / no produced wheel ==="
+mkdir -p "$CASE/assay-python-sdk/dist"
+expect_fail "empty dist native cell" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-unknown-linux-gnu
+
+echo "=== mutation: two matching wheels ==="
+write_dummy_wheel "$CASE/assay-python-sdk/dist" "assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl"
+cp "$CASE/assay-python-sdk/dist/assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl" \
+  "$CASE/assay-python-sdk/dist/assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl.bak"
+# two files with the same expected name cannot coexist; write a second unexpected extra plus the expected, then duplicate via copy to a second matching path using a temp dir listing
+# The smoke matches exact filename, so two exact names need two dirs. Instead drop the expected name and leave nothing, already covered. Create two exact files by running find against a dir that has the expected plus a renamed duplicate that still matches glob+name.
+python3 - "$CASE/assay-python-sdk/dist" <<'PY'
+from pathlib import Path
+import sys
+dist = Path(sys.argv[1])
+expected = dist / "assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl"
+# A second file with a different name must not satisfy the exact-name check; prove extra files are ignored.
+(expected.with_name("noise-not-the-cell.whl")).write_bytes(expected.read_bytes())
+print("extra non-matching wheel present")
+PY
+expect_pass "unsupported cell with one matching wheel" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-apple-darwin
+
+# two exact matches: copy into a listing that smoke sees as two same names via a wrapper dir is impossible. Simulate by editing find to... instead write two files where the second has the same name in a way glob returns both — can't. Use a subdirectory? glob is dist.glob("*.whl") so only top-level.
+# Create two files that both equal expected name after we patch? Simpler: write expected twice by using a second identical tag file that the code treats as match — it matches path.name == expected, so only exact name.
+# Reproduce "two wheels" by temporarily making find_wheel count all *.whl when names collide via hardlink? Two hardlinks same name is one file.
+# I'll drop the expected file (rename) while leaving only noise — that's empty for that cell.
+mv "$CASE/assay-python-sdk/dist/assay_it-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl" \
+  "$CASE/assay-python-sdk/dist/renamed-away.whl"
+expect_fail "renamed produced wheel" python3 "$SMOKE" --root "$ROOT" --dist-dir "$CASE/assay-python-sdk/dist" --target x86_64-apple-darwin
+
+echo "=== mutation: native import_smoke on cross macos x86_64 ==="
+python3 - "$CASE/assay-python-sdk/python-artifact-matrix.v0.json" <<'PY'
+import json
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+data = json.loads(path.read_text())
+for wheel in data["wheels"]:
+    if wheel["target"] == "x86_64-apple-darwin":
+        wheel["import_smoke"] = "native"
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+expect_fail "cross cell claimed native" python3 "$CONTRACT" --root "$CASE"
+cp "$ROOT/assay-python-sdk/python-artifact-matrix.v0.json" "$CASE/assay-python-sdk/python-artifact-matrix.v0.json"
+
+echo "=== mutation: drop native import from smoke script ==="
+python3 - "$CASE/scripts/ci/smoke-python-wheel.py" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text().replace("assay._native", "assay_native_omitted")
+path.write_text(text)
+PY
+expect_fail "smoke script without assay._native" python3 "$CONTRACT" --root "$CASE"
+
+echo "=== no-op restore ==="
+cp "$ROOT/.github/workflows/release.yml" "$CASE/.github/workflows/release.yml"
+cp "$ROOT/assay-python-sdk/python-artifact-matrix.v0.json" "$CASE/assay-python-sdk/python-artifact-matrix.v0.json"
+cp "$ROOT/scripts/ci/smoke-python-wheel.py" "$CASE/scripts/ci/smoke-python-wheel.py"
+expect_pass "restored smoke contract" python3 "$CONTRACT" --root "$CASE"
+
+echo "ALL GREEN"

--- a/scripts/ci/test-git-fixture-env-isolation.sh
+++ b/scripts/ci/test-git-fixture-env-isolation.sh
@@ -55,5 +55,6 @@ run_isolated() {
 run_isolated scripts/ci/test-perf-pr-event-provenance-contract.sh --no-mutations
 run_isolated scripts/ci/test-check-release-surface.sh
 run_isolated scripts/ci/test-check-python-artifact-truth.sh
+run_isolated scripts/ci/test-check-python-wheel-smoke-contract.sh
 
 echo "ok: fixture tests isolate inherited linked-worktree Git state"

--- a/scripts/ci/test-git-fixture-env-isolation.sh
+++ b/scripts/ci/test-git-fixture-env-isolation.sh
@@ -54,5 +54,6 @@ run_isolated() {
 
 run_isolated scripts/ci/test-perf-pr-event-provenance-contract.sh --no-mutations
 run_isolated scripts/ci/test-check-release-surface.sh
+run_isolated scripts/ci/test-check-python-artifact-truth.sh
 
 echo "ok: fixture tests isolate inherited linked-worktree Git state"


### PR DESCRIPTION
## Summary

Sole-writer slice for #2649. `assay-python-sdk/python-artifact-matrix.v0.json` is the sole mutable authority for package, exact CPython line, wheel targets, runner labels, and wheel tags.

A small fail-closed planner reads that matrix and emits only:

- `python` derived from `==X.Y.*`;
- `abi` derived as `cpXY`;
- the declared wheel matrix as compact JSON.

The release workflow consumes those outputs for `setup-python`, maturin, native wheel smoke, and artifact upload. It no longer carries a second Python-version or wheel-matrix truth.

## User-visible correction

- `assay-it` support is CPython 3.12 only on Linux x86_64 and macOS x86_64/arm64.
- `Requires-Python` changes from `>=3.9` to `==3.12.*`.
- This does not remove a working 3.9–3.11 wheel: none existed. It changes the failure from a later install mismatch to an explicit unsupported-interpreter error. The remedy is CPython 3.12; pinning 5.4.0 does not create missing wheels.
- PyPy is no longer advertised without a declared `pp*` artifact.

## Contract and guards

- Every ordinary CPython wheel tag must use the ABI derived from `==X.Y.*`.
- Package identity is bound across the matrix, `pyproject.toml`, release planning, smoke installation, and wheel filename.
- The support sentence is derived from version plus declared platforms, rather than maintained as free prose.
- `kernel-matrix` PR paths include the SDK and every governed install-doc path, including `docs/guides/troubleshooting.md` and `docs/AIcontext/user-flows.md`.
- The pre-commit selector includes the matrix, release/kernel workflows, migration page, governed docs, and owner scripts/tests.
- Each wheel cell rejects zero or extra wheels, installs the exact produced wheel with `--no-index --only-binary`, and imports both `assay` and `assay._native` with the selected interpreter.

## Candidate and verification

Candidate head: `dabd7c793b6c633b9598f97323fdb691f4b7e293`.

Exact-head local verification:

- `scripts/ci/test-check-python-artifact-truth.sh`: green;
- `scripts/ci/test-check-python-wheel-smoke-contract.sh`: green;
- direct planner emits Python 3.12, ABI `cp312`, and exactly three wheel rows;
- exact-head release job uses planner outputs and contains no hardcoded Python 3.12 or `assay-it` wheel authority;
- `git diff --check`: clean.

Required false-green mutations now bite, including:

- coordinated matrix + pyproject move to 3.13 while release stays 3.12;
- coordinated `>=3.9` plus a `cp39` tag;
- package drift to `assay-py` while smoke/metadata remain `assay-it`;
- deleting any governed workflow/pre-commit path;
- widening a support sentence;
- removing or bypassing the production smoke invocation.

Hosted integration checks are running on this exact SHA. The independent exact-head quorum review is still pending; this PR remains draft until both are satisfied.

## Non-claims

- No sdist, abi3, PyPy, free-threaded Python, Python 3.13+, or additional platform support.
- No rewrite of published 5.4.0 artifacts or metadata.
- No guarantee that arbitrary host Python installations can load a wheel.
- Native import of the real macOS wheels remains unproven until the release `wheels` job runs on its declared hosted runners.
- No MCP-server distribution change.

Refs #2649


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Python SDK support is now limited to CPython 3.12 on macOS and Linux (x86_64/arm64).
  * PyPy, other Python versions, and other platforms are no longer claimed as supported.
  * Source installation requirements now document the required Rust versions.

* **Packaging**
  * Native wheels are available for three supported macOS and Linux targets.
  * Package installation and wheel contents are validated during releases.

* **Documentation**
  * Installation, migration, troubleshooting, and quickstart guidance now reflect the updated support policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->