### PR TITLE
fix(cli): emit the owned fail-closed GitLab installer

### DIFF
--- a/.devcontainer/welcome.sh
+++ b/.devcontainer/welcome.sh
@@ -31,7 +31,7 @@ cat << 'EOF'
   ║     assay run --config eval.yaml \                           ║
   ║       --trace-file traces/safe.jsonl                         ║
   ║                                                              ║
-  ║   Docs:  https://assay.dev/docs                              ║
+  ║   Docs:  https://docs.getassay.dev                           ║
   ║   Repo:  https://github.com/Rul1an/assay                     ║
   ║                                                              ║
   ╚══════════════════════════════════════════════════════════════╝

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -375,7 +375,7 @@ repos:
         pass_filenames: false
         # Triggers on the files it can be wrong about, plus itself. It does not need a binary: with
         # no `target/` build it still verifies source and published-release truth independently.
-        files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag)\.sh|\.github/assay-release-tag|Cargo\.toml|README\.md|llms\.txt|examples/mcp-quickstart/README\.md|docs/(index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.pre-commit-config\.yaml)$
+        files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag)\.sh|\.github/assay-release-tag|Cargo\.toml|README\.md|llms\.txt|examples/mcp-quickstart/README\.md|docs/(index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.devcontainer/welcome\.sh|demo/CODESPACES-PLAYBOOK\.md|\.pre-commit-config\.yaml)$
 
 
 

--- a/crates/assay-cli/src/cli/commands/init_ci.rs
+++ b/crates/assay-cli/src/cli/commands/init_ci.rs
@@ -8,19 +8,7 @@ pub fn cmd_init_ci(args: InitCiArgs) -> anyhow::Result<i32> {
             crate::templates::CI_WORKFLOW_YML,
             ".github/workflows/assay.yml",
         ),
-        "gitlab" => (
-            r#"stages:
-  - test
-
-assay-check:
-  stage: test
-  image: ubuntu:latest
-  script:
-    - curl -sSL https://assay.dev/install.sh | sh
-    - assay validate --config assay.yaml --trace-file traces.jsonl
-"#,
-            ".gitlab-ci.yml",
-        ),
+        "gitlab" => (crate::templates::GITLAB_CI_YML, ".gitlab-ci.yml"),
         _ => anyhow::bail!(
             "Unknown provider: {}. Supported: github, gitlab",
             args.provider

--- a/crates/assay-cli/src/templates.rs
+++ b/crates/assay-cli/src/templates.rs
@@ -149,6 +149,8 @@ tests:
 mod gitlab_tests {
     use super::GITLAB_CI_YML;
 
+    const INIT_CI_SOURCE: &str = include_str!("cli/commands/init_ci.rs");
+
     #[test]
     fn gitlab_template_uses_the_owned_fail_closed_installer_once() {
         const INSTALL: &str = "curl -fsSL https://getassay.dev/install.sh | sh";
@@ -156,5 +158,20 @@ mod gitlab_tests {
         assert_eq!(GITLAB_CI_YML.matches(INSTALL).count(), 1);
         assert!(!GITLAB_CI_YML.contains("https://assay.dev/install.sh"));
         assert!(!GITLAB_CI_YML.contains("curl -sSL"));
+    }
+
+    #[test]
+    fn init_ci_reuses_the_gitlab_template_instead_of_copying_it() {
+        assert!(INIT_CI_SOURCE
+            .contains("\"gitlab\" => (crate::templates::GITLAB_CI_YML, \".gitlab-ci.yml\"),"));
+        assert_eq!(
+            INIT_CI_SOURCE
+                .matches("crate::templates::GITLAB_CI_YML")
+                .count(),
+            1
+        );
+        assert!(!INIT_CI_SOURCE.contains("getassay.dev/install.sh"));
+        assert!(!INIT_CI_SOURCE.contains("assay.dev/install.sh"));
+        assert!(!INIT_CI_SOURCE.contains("curl -"));
     }
 }

--- a/crates/assay-cli/src/templates.rs
+++ b/crates/assay-cli/src/templates.rs
@@ -116,12 +116,13 @@ jobs:
 
 "#;
 
-/// GitLab CI template for assay gate. Written to `.gitlab-ci.yml` by `assay init --ci gitlab`.
+/// GitLab CI template for assay gate. Written by `assay init --ci gitlab` and
+/// `assay init-ci --provider gitlab`.
 pub const GITLAB_CI_YML: &str = r#"assay:
   image: rust:1-bookworm
   script:
     - apt-get update -qq && apt-get install -y -qq curl
-    - curl -sSfL https://raw.githubusercontent.com/Rul1an/assay/main/scripts/install.sh | sh
+    - curl -fsSL https://getassay.dev/install.sh | sh
     - assay ci --config ci-eval.yaml --trace-file traces/ci.jsonl --sarif .assay/reports/sarif.json --junit .assay/reports/junit.xml
   artifacts:
     when: always
@@ -143,3 +144,17 @@ tests:
       pattern: ".*"
       flags: ["s"]
 "#;
+
+#[cfg(test)]
+mod gitlab_tests {
+    use super::GITLAB_CI_YML;
+
+    #[test]
+    fn gitlab_template_uses_the_owned_fail_closed_installer_once() {
+        const INSTALL: &str = "curl -fsSL https://getassay.dev/install.sh | sh";
+
+        assert_eq!(GITLAB_CI_YML.matches(INSTALL).count(), 1);
+        assert!(!GITLAB_CI_YML.contains("https://assay.dev/install.sh"));
+        assert!(!GITLAB_CI_YML.contains("curl -sSL"));
+    }
+}

--- a/demo/CODESPACES-PLAYBOOK.md
+++ b/demo/CODESPACES-PLAYBOOK.md
@@ -193,7 +193,7 @@ cat << 'EOF'
   ║     assay run --config eval.yaml \                           ║
   ║       --trace-file traces/safe.jsonl                         ║
   ║                                                              ║
-  ║   Docs:  https://assay.dev/docs                              ║
+  ║   Docs:  https://docs.getassay.dev                           ║
   ║   Repo:  https://github.com/...                              ║
   ║                                                              ║
   ╚══════════════════════════════════════════════════════════════╝
@@ -445,7 +445,7 @@ devpod up https://github.com/OWNER/assay
 Voor developers die lokaal willen installeren zonder Rust toolchain:
 
 ```bash
-curl -sSf https://assay.dev/install.sh | sh
+curl -fsSL https://getassay.dev/install.sh | sh
 ```
 
 **Vereist:**

--- a/scripts/ci/check-release-surface.sh
+++ b/scripts/ci/check-release-surface.sh
@@ -391,6 +391,10 @@ for file in README.md docs/guides/editor-mcp-recipe.md; do
   check_absent_regex "$file" 'assay mcp config-path (codex|<editor>)' \
     'config-path does not support Codex'
 done
+for file in .devcontainer/welcome.sh demo/CODESPACES-PLAYBOOK.md; do
+  check_absent_regex "$file" 'https://assay\.dev/' \
+    'unrelated assay.dev onboarding URL'
+done
 
 # ---------------------------------------------------------------------------
 note ""

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -10,7 +10,8 @@ trap 'rm -rf "$TMP"' EXIT
 
 mkdir -p "$TMP/scripts/ci" "$TMP/.github" "$TMP/docs/getting-started" "$TMP/docs/reference/cli" \
   "$TMP/docs/python-sdk" "$TMP/docs/use-cases" "$TMP/docs/AIcontext" "$TMP/docs/guides" \
-  "$TMP/examples/mcp-quickstart" "$TMP/crates/assay-x" "$TMP/bin"
+  "$TMP/examples/mcp-quickstart" "$TMP/crates/assay-x" "$TMP/bin" "$TMP/.devcontainer" \
+  "$TMP/demo"
 cp "$ROOT/scripts/ci/check-release-surface.sh" "$TMP/scripts/ci/"
 cp "$ROOT/scripts/ci/read-assay-release-tag.sh" "$TMP/scripts/ci/"
 cp "$ROOT/.pre-commit-config.yaml" "$TMP/"
@@ -97,10 +98,16 @@ For v5.4.0, run this from a source checkout. Published CLI archives do not carry
 DOC
 printf '%s\n' 'Current release: [`v5.1.0`](https://github.com/Rul1an/assay/releases/tag/v5.1.0)' > "$TMP/docs/index.md"
 printf '%s\n' 'Codex uses .codex/config.toml.' > "$TMP/docs/guides/editor-mcp-recipe.md"
+printf '%s\n' 'Docs: https://docs.getassay.dev' > "$TMP/.devcontainer/welcome.sh"
+cat > "$TMP/demo/CODESPACES-PLAYBOOK.md" <<'DOC'
+Docs: https://docs.getassay.dev
+curl -fsSL https://getassay.dev/install.sh | sh
+DOC
 (
   cd "$TMP"
   git init -q
-  git add -- .github/assay-release-tag Cargo.toml Cargo.lock crates docs examples scripts
+  git add -- .github/assay-release-tag Cargo.toml Cargo.lock crates docs examples scripts \
+    .devcontainer demo
 )
 
 run_check() {
@@ -128,6 +135,8 @@ for path in (
     "docs/getting-started/ci-integration.md",
     "docs/use-cases/air-gapped.md",
     "docs/use-cases/ci-gate.md",
+    ".devcontainer/welcome.sh",
+    "demo/CODESPACES-PLAYBOOK.md",
 ):
     if not pattern.search(path):
         raise SystemExit(f"release-surface hook omits {path}")
@@ -340,8 +349,15 @@ echo "PASS: duplicate-release"
 mutate_and_expect_failure stale-cli-version docs/reference/cli/index.md \
   's/# assay 5.1.0/# assay 5.0.0/' 'documented CLI version drift'
 
-if [ "$mutation_count" -ne 47 ]; then
-  echo "FAIL: expected 47 release-surface mutations, observed $mutation_count" >&2
+mutate_and_expect_failure stale-devcontainer-host .devcontainer/welcome.sh \
+  's#https://docs.getassay.dev#https://assay.dev/docs#' \
+  'unrelated assay.dev onboarding URL'
+mutate_and_expect_failure stale-codespaces-host demo/CODESPACES-PLAYBOOK.md \
+  's#https://getassay.dev/install.sh#https://assay.dev/install.sh#' \
+  'unrelated assay.dev onboarding URL'
+
+if [ "$mutation_count" -ne 49 ]; then
+  echo "FAIL: expected 49 release-surface mutations, observed $mutation_count" >&2
   exit 1
 fi
 echo "release-surface mutations: $mutation_count observed"

--- a/tests/init_ci.sh
+++ b/tests/init_ci.sh
@@ -3,6 +3,8 @@ set -e
 
 # Setup test jar
 TEST_DIR="test-init-ci-$(date +%s)"
+ROOT_DIR="$(pwd)"
+trap 'cd "$ROOT_DIR" && rm -rf "$TEST_DIR"' EXIT
 mkdir -p "$TEST_DIR"
 cd "$TEST_DIR"
 PATH="$PATH:$(pwd)/../target/debug"
@@ -32,6 +34,22 @@ else
     exit 1
 fi
 
+owned_install='    - curl -fsSL https://getassay.dev/install.sh | sh'
+if [ "$(grep -Fxc "$owned_install" .gitlab-ci.yml || true)" -ne 1 ]; then
+    echo "FAIL: GitLab workflow must contain exactly one owned fail-closed installer command"
+    cat .gitlab-ci.yml
+    exit 1
+fi
+if grep -Fq 'https://assay.dev/install.sh' .gitlab-ci.yml; then
+    echo "FAIL: GitLab workflow contains the unrelated assay.dev installer URL"
+    exit 1
+fi
+if grep -Fq 'curl -sSL' .gitlab-ci.yml; then
+    echo "FAIL: GitLab workflow installer does not fail on HTTP errors"
+    exit 1
+fi
+echo "PASS: GitLab workflow uses the owned fail-closed installer command"
+
 # Verify content (spot check)
 if grep -q "assay" .github/workflows/assay.yml; then
     echo "PASS: GitHub workflow contains assay"
@@ -44,5 +62,3 @@ else
 fi
 
 echo "All tests passed!"
-cd ..
-rm -rf "$TEST_DIR"


### PR DESCRIPTION
## Summary

- make `assay init-ci --provider gitlab` reuse the shipped GitLab template
- emit exactly `curl -fsSL https://getassay.dev/install.sh | sh`
- pin that single-source ownership with a structural contract
- correct live devcontainer/Codespaces onboarding hosts
- extend the release-surface guard to reject recurrence

Closes #2675.

## Verification

Measured on `8d650c1ee44f22d743aa2ef4f62dd01ecb35ea2f` in `/Users/roelschuurkes/wt-codex-2675-init-ci-installer`:

- `cargo test -p assay-cli templates::gitlab_tests`
- duplicate byte-identical inline GitLab generator mutation: exit 101 in `init_ci_reuses_the_gitlab_template_instead_of_copying_it`
- restored shared implementation: 2/2 focused tests pass
- `cargo build -p assay-cli --bin assay`
- `bash tests/init_ci.sh`
- `bash scripts/ci/test-check-release-surface.sh` (62/62 release-surface mutations observed)
- `bash scripts/ci/check-release-surface.sh`
- `cargo fmt --all -- --check`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- `git diff --check`
- complete pre-commit and pre-push hook suites

## Non-claims

This establishes owned installer transport, curl HTTP failure behavior, and one source for the generated GitLab template. It does not prove checksum, provenance, installer-content authenticity, or availability of the external endpoint.
