### PR TITLE
release: bind archive README rendering to assembled cwd

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -32,6 +32,7 @@ on:
       # Candidate source identity is checked by the pre-commit leg below.
       - "Cargo.toml"
       - "CHANGELOG.md"
+      - "README.md"
       - "docs/reference/release.md"
       # The editor MCP recipe is judged by the editor-mcp-recipe-truth hook, which runs
       # under Lint (pre-commit) here. `scripts/**` covers a guard change; a recipe-only drift

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,10 @@ jobs:
           cp examples/mcp-quickstart/policy.yaml "dist/${ARCHIVE_NAME}/examples/mcp-quickstart/"
           cp examples/mcp-quickstart/run.py "dist/${ARCHIVE_NAME}/examples/mcp-quickstart/"
           cp examples/mcp-quickstart/mock_server.py "dist/${ARCHIVE_NAME}/examples/mcp-quickstart/"
-          python3 scripts/ci/release_readme.py "$VERSION" "dist/${ARCHIVE_NAME}" > "dist/${ARCHIVE_NAME}/README.md"
+          (
+            cd "dist/${ARCHIVE_NAME}"
+            python3 "$GITHUB_WORKSPACE/scripts/ci/release_readme.py" "$VERSION" --assembled-cwd > README.md
+          )
           cd dist
           tar -czvf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
 
@@ -238,7 +241,12 @@ jobs:
           Copy-Item examples/mcp-quickstart/policy.yaml "dist\${ARCHIVE_NAME}\examples\mcp-quickstart\"
           Copy-Item examples/mcp-quickstart/run.py "dist\${ARCHIVE_NAME}\examples\mcp-quickstart\"
           Copy-Item examples/mcp-quickstart/mock_server.py "dist\${ARCHIVE_NAME}\examples\mcp-quickstart\"
-          python scripts/ci/release_readme.py "$VERSION" "dist\${ARCHIVE_NAME}" > "dist\${ARCHIVE_NAME}\README.md"
+          Push-Location "dist\${ARCHIVE_NAME}"
+          try {
+            python "$env:GITHUB_WORKSPACE\scripts\ci\release_readme.py" "$VERSION" --assembled-cwd > README.md
+          } finally {
+            Pop-Location
+          }
           Compress-Archive -Path "dist\${ARCHIVE_NAME}" -DestinationPath "dist\${ARCHIVE_NAME}.zip"
 
       - name: Write archive checksum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,12 +214,12 @@ jobs:
           ARCHIVE_NAME="assay-${VERSION}-${{ matrix.target }}"
           mkdir -p "dist/${ARCHIVE_NAME}"
           cp "target/${{ matrix.target }}/release/${{ matrix.artifact }}" "dist/${ARCHIVE_NAME}/"
-          python3 scripts/ci/release_readme.py "$VERSION" > "dist/${ARCHIVE_NAME}/README.md"
           cp LICENSE "dist/${ARCHIVE_NAME}/"
           mkdir -p "dist/${ARCHIVE_NAME}/examples/mcp-quickstart"
           cp examples/mcp-quickstart/policy.yaml "dist/${ARCHIVE_NAME}/examples/mcp-quickstart/"
           cp examples/mcp-quickstart/run.py "dist/${ARCHIVE_NAME}/examples/mcp-quickstart/"
           cp examples/mcp-quickstart/mock_server.py "dist/${ARCHIVE_NAME}/examples/mcp-quickstart/"
+          python3 scripts/ci/release_readme.py "$VERSION" "dist/${ARCHIVE_NAME}" > "dist/${ARCHIVE_NAME}/README.md"
           cd dist
           tar -czvf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
 
@@ -233,12 +233,12 @@ jobs:
           $ARCHIVE_NAME = "assay-${VERSION}-${{ matrix.target }}"
           New-Item -ItemType Directory -Force -Path "dist\${ARCHIVE_NAME}"
           Copy-Item "target\${{ matrix.target }}\release\${{ matrix.artifact }}" "dist\${ARCHIVE_NAME}\"
-          python scripts/ci/release_readme.py "$VERSION" > "dist\${ARCHIVE_NAME}\README.md"
           Copy-Item LICENSE "dist\${ARCHIVE_NAME}\"
           New-Item -ItemType Directory -Force -Path "dist\${ARCHIVE_NAME}\examples\mcp-quickstart"
           Copy-Item examples/mcp-quickstart/policy.yaml "dist\${ARCHIVE_NAME}\examples\mcp-quickstart\"
           Copy-Item examples/mcp-quickstart/run.py "dist\${ARCHIVE_NAME}\examples\mcp-quickstart\"
           Copy-Item examples/mcp-quickstart/mock_server.py "dist\${ARCHIVE_NAME}\examples\mcp-quickstart\"
+          python scripts/ci/release_readme.py "$VERSION" "dist\${ARCHIVE_NAME}" > "dist\${ARCHIVE_NAME}\README.md"
           Compress-Archive -Path "dist\${ARCHIVE_NAME}" -DestinationPath "dist\${ARCHIVE_NAME}.zip"
 
       - name: Write archive checksum

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -19,7 +19,7 @@
     },
     {
       "path": ".github/workflows/release.yml",
-      "sha256": "0f1601bdde97f28b8be8a1c4aaab53cc22e235bc73069952249b46474626e2ab"
+      "sha256": "1a8eb7874f622f70dcf92884d3b78acccf4e2ef6f59c6f9aa7d297620fd126fc"
     },
     {
       "path": "scripts/ci/published-release-golden-path.sh",

--- a/scripts/ci/release_readme.py
+++ b/scripts/ci/release_readme.py
@@ -22,8 +22,27 @@ CHECKOUT_RE = re.compile(
     r"The installer and the\s+published v5\.4\.0 CLI archive install the binary "
     r"but do not carry the bounded\s+quickstart assets\."
 )
+FIRST_PARTY_GITHUB_RE = re.compile(
+    r"^https://github\.com/Rul1an/assay/(blob|tree|raw)/([^/]+)(?:/(.*))?$"
+)
+FIRST_PARTY_RAW_RE = re.compile(
+    r"^https://raw\.githubusercontent\.com/Rul1an/assay/([^/]+)(?:/(.*))?$"
+)
+MUTABLE_FIRST_PARTY_RE = re.compile(
+    r"https://(?:github\.com/Rul1an/assay/(?:blob|tree|raw)|"
+    r"raw\.githubusercontent\.com/Rul1an/assay)/(?:HEAD|main|master)(?:/|$)"
+)
 MAX_LINK_LABEL = 512
 MAX_LINK_URL = 2048
+OVERLONG_PROBE = 4096
+MUTABLE_REFS = frozenset({"HEAD", "main", "master"})
+FIRST_PARTY_REPO = "Rul1an/assay"
+PACKED_SOURCE_PATHS = (
+    "LICENSE",
+    "examples/mcp-quickstart/policy.yaml",
+    "examples/mcp-quickstart/run.py",
+    "examples/mcp-quickstart/mock_server.py",
+)
 ROOT = Path(__file__).resolve().parents[2]
 ARCHIVE_QUICKSTART = (
     "From the root of this extracted CLI archive, with `assay` on PATH "
@@ -33,32 +52,128 @@ ARCHIVE_QUICKSTART = (
 )
 
 
-def _is_external_or_fragment(url: str) -> bool:
-    return url.startswith(("http://", "https://", "mailto:", "#", "//"))
+def immutable_ref(version: str) -> str:
+    """Tag-bound ref for first-party URLs. Shared policy for #2676."""
+    return f"v{version}"
 
 
-def _is_archive_relative(url: str) -> bool:
-    path = url.split("#", 1)[0]
-    if path == "LICENSE":
-        return True
-    return path == "examples/mcp-quickstart" or path.startswith(
-        "examples/mcp-quickstart/"
-    )
+def expand_archive_members(paths: set[str] | frozenset[str] | tuple[str, ...]) -> frozenset[str]:
+    members: set[str] = set()
+    for raw in paths:
+        path = raw.replace("\\", "/").strip()
+        if not path or path == ".":
+            continue
+        members.add(path)
+        trimmed = path.strip("/")
+        members.add(trimmed)
+        members.add(trimmed + "/")
+        acc: list[str] = []
+        for part in trimmed.split("/"):
+            acc.append(part)
+            joined = "/".join(acc)
+            members.add(joined)
+            members.add(joined + "/")
+    return frozenset(members)
 
 
-def _github_url(url: str, version: str) -> str:
-    path, _, fragment = url.partition("#")
-    path = path.lstrip("./")
-    last = path.rstrip("/").rsplit("/", 1)[-1]
-    kind = "tree" if path.endswith("/") or "." not in last else "blob"
-    rewritten = f"https://github.com/Rul1an/assay/{kind}/v{version}/{path}"
+def default_packed_members() -> frozenset[str]:
+    return expand_archive_members(PACKED_SOURCE_PATHS)
+
+
+def list_archive_members(root: Path) -> frozenset[str]:
+    collected: set[str] = set()
+    resolved = root.resolve()
+    for path in resolved.rglob("*"):
+        relative = path.relative_to(resolved).as_posix()
+        if relative == "README.md":
+            continue
+        collected.add(relative)
+    return expand_archive_members(collected)
+
+
+def peel_dot_slash(path: str) -> str:
+    while path.startswith("./"):
+        path = path[2:]
+    return path
+
+
+def normalize_repo_path(path: str) -> str:
+    path = path.replace("\\", "/")
+    path, _, fragment = path.partition("#")
+    path = peel_dot_slash(path)
+    if path.startswith("/") or path == ".." or path.startswith("../") or "/../" in path:
+        raise ValueError("path traversal is unclassifiable")
+    trimmed = path.rstrip("/")
+    if not trimmed:
+        raise ValueError("path traversal is unclassifiable")
+    parts = trimmed.split("/")
+    if any(part in {"", ".", "..", "..."} for part in parts):
+        raise ValueError("path traversal is unclassifiable")
+    if parts[0] == ".github":
+        raise ValueError("unclassifiable repository path")
+    return f"{path}#{fragment}" if fragment else path
+
+
+def _member_keys(path: str) -> set[str]:
+    file_path = path.split("#", 1)[0]
+    return {file_path, file_path.rstrip("/"), file_path if file_path.endswith("/") else file_path + "/"}
+
+
+def _github_url(path: str, version: str, *, media: bool) -> str:
+    file_path, _, fragment = path.partition("#")
+    tag = immutable_ref(version)
+    if media:
+        rewritten = f"https://raw.githubusercontent.com/{FIRST_PARTY_REPO}/{tag}/{file_path}"
+    else:
+        last = file_path.rstrip("/").rsplit("/", 1)[-1]
+        kind = "tree" if file_path.endswith("/") or "." not in last else "blob"
+        rewritten = f"https://github.com/{FIRST_PARTY_REPO}/{kind}/{tag}/{file_path}"
     return f"{rewritten}#{fragment}" if fragment else rewritten
 
 
-def _rewrite_target(url: str, version: str) -> str:
-    if _is_external_or_fragment(url) or _is_archive_relative(url):
+def rewrite_first_party_url(
+    url: str, version: str, members: frozenset[str], *, media: bool
+) -> str | None:
+    """Rewrite repo-owned mutable HEAD/main/master refs. None if not first-party mutable."""
+    github = FIRST_PARTY_GITHUB_RE.fullmatch(url)
+    raw = FIRST_PARTY_RAW_RE.fullmatch(url)
+    if github is None and raw is None:
+        return None
+    if github is not None:
+        kind, ref, path = github.group(1), github.group(2), github.group(3) or ""
+    else:
+        kind, ref, path = "raw", raw.group(1), raw.group(2) or ""
+    if ref not in MUTABLE_REFS:
+        return None
+    path = normalize_repo_path(path) if path else path
+    file_path = path.split("#", 1)[0]
+    if file_path and _member_keys(file_path) & members and not media:
+        return path
+    if kind == "raw" and not media:
+        return _github_url(file_path, version, media=False) if file_path else url
+    return _github_url(file_path, version, media=media) if file_path else url
+
+
+def _rewrite_target(
+    url: str, version: str, members: frozenset[str], *, media: bool
+) -> str:
+    url = url.strip()
+    if url.startswith(("#", "mailto:")):
         return url
-    return _github_url(url, version)
+    first_party = rewrite_first_party_url(url, version, members, media=media)
+    if first_party is not None:
+        return first_party
+    if url.startswith(("http://", "https://", "//")):
+        return url
+    path = normalize_repo_path(url)
+    file_path = path.split("#", 1)[0]
+    if _member_keys(file_path) & members:
+        if media:
+            return _github_url(file_path, version, media=True)
+        return path
+    if file_path.startswith("examples/mcp-quickstart"):
+        raise ValueError("not an assembled archive member")
+    return _github_url(path, version, media=media)
 
 
 def _scan_delimited(source: str, start: int, closer: str, ceiling: int) -> int | None:
@@ -66,49 +181,77 @@ def _scan_delimited(source: str, start: int, closer: str, ceiling: int) -> int |
     return None if found == -1 else found
 
 
-def _rewrite_repo_links(source: str, version: str) -> str:
+def _rewrite_repo_links(source: str, version: str, members: frozenset[str]) -> str:
     out: list[str] = []
     index = 0
     length = len(source)
+    html_forms = (
+        ('href="', '"', False),
+        ("href='", "'", False),
+        ('src="', '"', True),
+        ("src='", "'", True),
+    )
     while index < length:
-        if source.startswith('href="', index):
-            url_start = index + 6
-            url_end = _scan_delimited(source, url_start, '"', MAX_LINK_URL)
-            if url_end is not None:
-                out.append('href="')
-                out.append(_rewrite_target(source[url_start:url_end], version))
-                out.append('"')
+        handled = False
+        for prefix, quote, media in html_forms:
+            if source.startswith(prefix, index):
+                url_start = index + len(prefix)
+                url_end = _scan_delimited(source, url_start, quote, MAX_LINK_URL)
+                if url_end is None:
+                    raise ValueError("unclassifiable html attribute")
+                out.append(prefix)
+                out.append(_rewrite_target(source[url_start:url_end], version, members, media=media))
+                out.append(quote)
                 index = url_end + 1
-                continue
+                handled = True
+                break
+        if handled:
+            continue
         bang = source[index] == "!"
         open_at = index + 1 if bang else index
         if open_at < length and source[open_at] == "[":
             label_end = _scan_delimited(source, open_at + 1, "]", MAX_LINK_LABEL)
-            if (
-                label_end is not None
-                and label_end + 1 < length
-                and source[label_end + 1] == "("
-            ):
-                url_end = _scan_delimited(source, label_end + 2, ")", MAX_LINK_URL)
-                url = source[label_end + 2 : url_end] if url_end is not None else ""
-                if url_end is not None and "[" not in url and "]" not in url:
-                    if bang:
-                        out.append("!")
-                    out.append("[")
-                    out.append(source[open_at + 1 : label_end])
-                    out.append("](")
-                    out.append(_rewrite_target(url, version))
-                    out.append(")")
-                    index = url_end + 1
-                    continue
+            if label_end is None:
+                later = source.find("]", open_at + 1, open_at + 1 + OVERLONG_PROBE)
+                if (
+                    later != -1
+                    and later + 1 < length
+                    and source[later + 1] == "("
+                    and "[" not in source[open_at + 1 : later]
+                ):
+                    raise ValueError("unclassifiable markdown link label")
+            else:
+                nxt = source[label_end + 1] if label_end + 1 < length else ""
+                if nxt == "[":
+                    raise ValueError("unclassifiable reference-style link")
+                if nxt == ":" and (open_at == 0 or source[open_at - 1] == "\n"):
+                    raise ValueError("unclassifiable reference-style link")
+                if nxt == "(":
+                    url_end = _scan_delimited(source, label_end + 2, ")", MAX_LINK_URL)
+                    url = source[label_end + 2 : url_end] if url_end is not None else ""
+                    if url_end is not None and "[" not in url and "]" not in url:
+                        if bang:
+                            out.append("!")
+                        out.append("[")
+                        out.append(source[open_at + 1 : label_end])
+                        out.append("](")
+                        out.append(
+                            _rewrite_target(url, version, members, media=bang)
+                        )
+                        out.append(")")
+                        index = url_end + 1
+                        continue
         out.append(source[index])
         index += 1
     return "".join(out)
 
 
-def render_release_readme(source: str, version: str) -> str:
+def render_release_readme(
+    source: str, version: str, members: frozenset[str] | None = None
+) -> str:
     if VERSION_RE.fullmatch(version) is None:
         raise ValueError("release version must be exact X.Y.Z")
+    assembled = default_packed_members() if members is None else frozenset(members)
     installs = INSTALL_RE.findall(source)
     if len(installs) != 1:
         raise ValueError("README must carry exactly one release-pinned install command")
@@ -128,16 +271,18 @@ def render_release_readme(source: str, version: str) -> str:
         count=1,
     )
     rendered = CHECKOUT_RE.sub(ARCHIVE_QUICKSTART, rendered, count=1)
-    rendered = _rewrite_repo_links(rendered, version)
+    rendered = _rewrite_repo_links(rendered, version, assembled)
     if INSTALL_RE.findall(rendered) != [version] or RELEASE_RE.findall(rendered) != [version]:
         raise ValueError("rendered README release claims did not converge")
+    if MUTABLE_FIRST_PARTY_RE.search(rendered):
+        raise ValueError("first-party mutable HEAD/main/master ref survived")
     return rendered
 
 
 def main(argv: list[str] | None = None) -> int:
     args = sys.argv[1:] if argv is None else argv
-    if len(args) != 1:
-        print("usage: release_readme.py TAG", file=sys.stderr)
+    if len(args) not in {1, 2}:
+        print("usage: release_readme.py TAG [ARCHIVE_ROOT]", file=sys.stderr)
         return 2
     tag = TAG_RE.fullmatch(args[0])
     if tag is None:
@@ -146,8 +291,11 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+    members = (
+        list_archive_members(Path(args[1])) if len(args) == 2 else default_packed_members()
+    )
     rendered = render_release_readme(
-        (ROOT / "README.md").read_text(encoding="utf-8"), tag.group(1)
+        (ROOT / "README.md").read_text(encoding="utf-8"), tag.group(1), members=members
     )
     sys.stdout.write(rendered)
     return 0

--- a/scripts/ci/release_readme.py
+++ b/scripts/ci/release_readme.py
@@ -17,7 +17,63 @@ RELEASE_RE = re.compile(
 )
 VERSION_RE = re.compile(rf"^{VERSION_PATTERN}$")
 TAG_RE = re.compile(rf"^v({VERSION_PATTERN})$")
+CHECKOUT_RE = re.compile(
+    r"For v5\.4\.0, run the last command from a source checkout\.\s+"
+    r"The installer and the\s+published v5\.4\.0 CLI archive install the binary "
+    r"but do not carry the bounded\s+quickstart assets\."
+)
+MARKDOWN_LINK_RE = re.compile(r"(!?\[[^\]]*\]\()([^)]+)(\))")
+HREF_RE = re.compile(r'(href=")([^"]+)(")')
 ROOT = Path(__file__).resolve().parents[2]
+ARCHIVE_QUICKSTART = (
+    "From the root of this extracted CLI archive, with `assay` on PATH "
+    "(this archive's binary directory), run `python3 examples/mcp-quickstart/run.py`. "
+    "This archive packs LICENSE plus examples/mcp-quickstart/policy.yaml, "
+    "examples/mcp-quickstart/run.py, and examples/mcp-quickstart/mock_server.py."
+)
+
+
+def _is_external_or_fragment(url: str) -> bool:
+    return url.startswith(("http://", "https://", "mailto:", "#", "//"))
+
+
+def _is_archive_relative(url: str) -> bool:
+    path = url.split("#", 1)[0]
+    if path == "LICENSE":
+        return True
+    return path == "examples/mcp-quickstart" or path.startswith(
+        "examples/mcp-quickstart/"
+    )
+
+
+def _github_url(url: str, version: str) -> str:
+    path, _, fragment = url.partition("#")
+    path = path.lstrip("./")
+    last = path.rstrip("/").rsplit("/", 1)[-1]
+    kind = "tree" if path.endswith("/") or "." not in last else "blob"
+    rewritten = f"https://github.com/Rul1an/assay/{kind}/v{version}/{path}"
+    return f"{rewritten}#{fragment}" if fragment else rewritten
+
+
+def _rewrite_target(url: str, version: str) -> str:
+    if _is_external_or_fragment(url) or _is_archive_relative(url):
+        return url
+    return _github_url(url, version)
+
+
+def _rewrite_repo_links(source: str, version: str) -> str:
+    rewritten = MARKDOWN_LINK_RE.sub(
+        lambda match: match.group(1)
+        + _rewrite_target(match.group(2), version)
+        + match.group(3),
+        source,
+    )
+    return HREF_RE.sub(
+        lambda match: match.group(1)
+        + _rewrite_target(match.group(2), version)
+        + match.group(3),
+        rewritten,
+    )
 
 
 def render_release_readme(source: str, version: str) -> str:
@@ -29,6 +85,9 @@ def render_release_readme(source: str, version: str) -> str:
     releases = RELEASE_RE.findall(source)
     if len(releases) != 1:
         raise ValueError("README must carry exactly one current-release link")
+    checkouts = CHECKOUT_RE.findall(source)
+    if len(checkouts) > 1:
+        raise ValueError("README must carry exactly one published-checkout sentence")
 
     rendered = INSTALL_RE.sub(
         f"cargo install assay-cli --version {version} --locked", source, count=1
@@ -38,6 +97,9 @@ def render_release_readme(source: str, version: str) -> str:
         rendered,
         count=1,
     )
+    if checkouts:
+        rendered = CHECKOUT_RE.sub(ARCHIVE_QUICKSTART, rendered, count=1)
+    rendered = _rewrite_repo_links(rendered, version)
     if INSTALL_RE.findall(rendered) != [version] or RELEASE_RE.findall(rendered) != [version]:
         raise ValueError("rendered README release claims did not converge")
     return rendered

--- a/scripts/ci/release_readme.py
+++ b/scripts/ci/release_readme.py
@@ -22,8 +22,8 @@ CHECKOUT_RE = re.compile(
     r"The installer and the\s+published v5\.4\.0 CLI archive install the binary "
     r"but do not carry the bounded\s+quickstart assets\."
 )
-MARKDOWN_LINK_RE = re.compile(r"(!?\[[^\]]*\]\()([^)]+)(\))")
-HREF_RE = re.compile(r'(href=")([^"]+)(")')
+MAX_LINK_LABEL = 512
+MAX_LINK_URL = 2048
 ROOT = Path(__file__).resolve().parents[2]
 ARCHIVE_QUICKSTART = (
     "From the root of this extracted CLI archive, with `assay` on PATH "
@@ -61,19 +61,49 @@ def _rewrite_target(url: str, version: str) -> str:
     return _github_url(url, version)
 
 
+def _scan_delimited(source: str, start: int, closer: str, ceiling: int) -> int | None:
+    found = source.find(closer, start, start + ceiling)
+    return None if found == -1 else found
+
+
 def _rewrite_repo_links(source: str, version: str) -> str:
-    rewritten = MARKDOWN_LINK_RE.sub(
-        lambda match: match.group(1)
-        + _rewrite_target(match.group(2), version)
-        + match.group(3),
-        source,
-    )
-    return HREF_RE.sub(
-        lambda match: match.group(1)
-        + _rewrite_target(match.group(2), version)
-        + match.group(3),
-        rewritten,
-    )
+    out: list[str] = []
+    index = 0
+    length = len(source)
+    while index < length:
+        if source.startswith('href="', index):
+            url_start = index + 6
+            url_end = _scan_delimited(source, url_start, '"', MAX_LINK_URL)
+            if url_end is not None:
+                out.append('href="')
+                out.append(_rewrite_target(source[url_start:url_end], version))
+                out.append('"')
+                index = url_end + 1
+                continue
+        bang = source[index] == "!"
+        open_at = index + 1 if bang else index
+        if open_at < length and source[open_at] == "[":
+            label_end = _scan_delimited(source, open_at + 1, "]", MAX_LINK_LABEL)
+            if (
+                label_end is not None
+                and label_end + 1 < length
+                and source[label_end + 1] == "("
+            ):
+                url_end = _scan_delimited(source, label_end + 2, ")", MAX_LINK_URL)
+                url = source[label_end + 2 : url_end] if url_end is not None else ""
+                if url_end is not None and "[" not in url and "]" not in url:
+                    if bang:
+                        out.append("!")
+                    out.append("[")
+                    out.append(source[open_at + 1 : label_end])
+                    out.append("](")
+                    out.append(_rewrite_target(url, version))
+                    out.append(")")
+                    index = url_end + 1
+                    continue
+        out.append(source[index])
+        index += 1
+    return "".join(out)
 
 
 def render_release_readme(source: str, version: str) -> str:
@@ -86,7 +116,7 @@ def render_release_readme(source: str, version: str) -> str:
     if len(releases) != 1:
         raise ValueError("README must carry exactly one current-release link")
     checkouts = CHECKOUT_RE.findall(source)
-    if len(checkouts) > 1:
+    if len(checkouts) != 1:
         raise ValueError("README must carry exactly one published-checkout sentence")
 
     rendered = INSTALL_RE.sub(
@@ -97,8 +127,7 @@ def render_release_readme(source: str, version: str) -> str:
         rendered,
         count=1,
     )
-    if checkouts:
-        rendered = CHECKOUT_RE.sub(ARCHIVE_QUICKSTART, rendered, count=1)
+    rendered = CHECKOUT_RE.sub(ARCHIVE_QUICKSTART, rendered, count=1)
     rendered = _rewrite_repo_links(rendered, version)
     if INSTALL_RE.findall(rendered) != [version] or RELEASE_RE.findall(rendered) != [version]:
         raise ValueError("rendered README release claims did not converge")

--- a/scripts/ci/release_readme.py
+++ b/scripts/ci/release_readme.py
@@ -282,7 +282,7 @@ def render_release_readme(
 def main(argv: list[str] | None = None) -> int:
     args = sys.argv[1:] if argv is None else argv
     if len(args) not in {1, 2}:
-        print("usage: release_readme.py TAG [ARCHIVE_ROOT]", file=sys.stderr)
+        print("usage: release_readme.py TAG [--assembled-cwd]", file=sys.stderr)
         return 2
     tag = TAG_RE.fullmatch(args[0])
     if tag is None:
@@ -291,8 +291,11 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+    if len(args) == 2 and args[1] != "--assembled-cwd":
+        print("second argument must be --assembled-cwd", file=sys.stderr)
+        return 2
     members = (
-        list_archive_members(Path(args[1])) if len(args) == 2 else default_packed_members()
+        list_archive_members(Path.cwd()) if len(args) == 2 else default_packed_members()
     )
     rendered = render_release_readme(
         (ROOT / "README.md").read_text(encoding="utf-8"), tag.group(1), members=members

--- a/scripts/ci/test_release_quickstart.py
+++ b/scripts/ci/test_release_quickstart.py
@@ -200,5 +200,130 @@ class ReleaseArchiveShape(unittest.TestCase):
             self.assertNotIn("archive carries this bounded quickstart", readme)
 
 
+
+
+PACKED_SOURCE_MEMBERS = (
+    ("binary", "${{ matrix.artifact }}"),
+    ("license", "LICENSE"),
+    ("quickstart-policy", "examples/mcp-quickstart/policy.yaml"),
+    ("quickstart-run", "examples/mcp-quickstart/run.py"),
+    ("quickstart-mock", "examples/mcp-quickstart/mock_server.py"),
+)
+CHECKOUT_SENTENCE = "For v5.4.0, run the last command from a source checkout."
+ARCHIVE_ROOT_CLAIM = "From the root of this extracted CLI archive"
+QUICKSTART_COMMAND = "python3 examples/mcp-quickstart/run.py"
+
+
+def package_step(workflow: str, heading: str) -> str:
+    marker = f"      - name: {heading}\n"
+    parts = workflow.split(marker)
+    if len(parts) != 2:
+        raise AssertionError(f"expected one {heading!r} step")
+    rest = parts[1]
+    nxt = rest.find("\n      - name: ")
+    if nxt == -1:
+        raise AssertionError(f"{heading!r} step was not followed by another named step")
+    return rest[:nxt]
+
+
+class ReleaseArchiveMemberInventory(unittest.TestCase):
+    def test_unix_and_windows_package_steps_copy_five_packed_source_classes(self):
+        workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        unix = package_step(workflow, "Package (Unix)")
+        windows = package_step(workflow, "Package (Windows)")
+        self.assertIn('scripts/ci/release_readme.py "$VERSION"', unix)
+        self.assertIn('scripts/ci/release_readme.py "$VERSION"', windows)
+        for name, fragment in PACKED_SOURCE_MEMBERS:
+            with self.subTest(platform="unix", member=name):
+                self.assertIn(fragment, unix)
+            with self.subTest(platform="windows", member=name):
+                self.assertIn(fragment, windows)
+
+
+class ReleaseArchiveReadmeContract(unittest.TestCase):
+    def test_source_readme_keeps_published_v54_checkout_wording(self):
+        source = (ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn(CHECKOUT_SENTENCE, source)
+        self.assertNotIn(ARCHIVE_ROOT_CLAIM, source)
+
+    def test_rendered_readme_rewrites_absent_links_and_states_packed_quickstart(self):
+        module = load_module()
+        source = (ROOT / "README.md").read_text(encoding="utf-8")
+        rendered = module.render_release_readme(source, "5.5.0")
+        self.assertNotIn(CHECKOUT_SENTENCE, rendered)
+        self.assertIn(ARCHIVE_ROOT_CLAIM, rendered)
+        self.assertIn(QUICKSTART_COMMAND, rendered)
+        self.assertIn("examples/mcp-quickstart/policy.yaml", rendered)
+        self.assertIn("examples/mcp-quickstart/run.py", rendered)
+        self.assertIn("examples/mcp-quickstart/mock_server.py", rendered)
+        self.assertIn("assay` on PATH", rendered)
+        self.assertIn("[MIT](LICENSE)", rendered)
+        self.assertIn("[MCP Quick Start](examples/mcp-quickstart/)", rendered)
+        self.assertIn("[MCP Quickstart](examples/mcp-quickstart/)", rendered)
+        self.assertIn('href="examples/mcp-quickstart/"', rendered)
+        self.assertIn(
+            "[CHANGELOG.md](https://github.com/Rul1an/assay/blob/v5.5.0/CHANGELOG.md)",
+            rendered,
+        )
+        self.assertIn(
+            "[release-pinned agent journey](https://github.com/Rul1an/assay/blob/v5.5.0/docs/guides/agent-golden-path.md)",
+            rendered,
+        )
+        self.assertIn(
+            "(https://github.com/Rul1an/assay/tree/v5.5.0/examples/privileged-action-gate/)",
+            rendered,
+        )
+        self.assertIn(
+            "(https://github.com/Rul1an/assay/blob/v5.5.0/demo/output/screenshots/mcp-wrap-demo.svg)",
+            rendered,
+        )
+        self.assertIn(
+            'href="https://github.com/Rul1an/assay/blob/v5.5.0/docs/security/OWASP-MCP-TOP10-MAPPING.md"',
+            rendered,
+        )
+        self.assertNotIn("(docs/guides/agent-golden-path.md)", rendered)
+        self.assertNotIn("(CHANGELOG.md)", rendered)
+        self.assertNotIn("[MIT](https://github.com/Rul1an/assay/blob/v5.5.0/LICENSE)", rendered)
+
+    def test_renderer_keeps_https_and_hash_targets(self):
+        module = load_module()
+        source = """# Assay
+
+```bash
+cargo install assay-cli --version 5.4.0 --locked
+```
+
+Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0).
+
+For v5.4.0, run the last command from a source checkout. The installer and the
+published v5.4.0 CLI archive install the binary but do not carry the bounded
+quickstart assets.
+
+See [scope](docs/concepts/scope.md) and [license](LICENSE) and [quickstart](examples/mcp-quickstart/run.py) and [here](#quickstart) and [action](https://github.com/marketplace/actions/assay-ai-agent-security).
+"""
+        rendered = module.render_release_readme(source, "5.5.0")
+        self.assertIn("[scope](https://github.com/Rul1an/assay/blob/v5.5.0/docs/concepts/scope.md)", rendered)
+        self.assertIn("[license](LICENSE)", rendered)
+        self.assertIn("[quickstart](examples/mcp-quickstart/run.py)", rendered)
+        self.assertIn("[here](#quickstart)", rendered)
+        self.assertIn("[action](https://github.com/marketplace/actions/assay-ai-agent-security)", rendered)
+        self.assertIn(ARCHIVE_ROOT_CLAIM, rendered)
+        self.assertNotIn(CHECKOUT_SENTENCE, rendered)
+
+    def test_renderer_refuses_ambiguous_checkout_sentence(self):
+        module = load_module()
+        source = """cargo install assay-cli --version 5.4.0 --locked
+Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0).
+For v5.4.0, run the last command from a source checkout. The installer and the
+published v5.4.0 CLI archive install the binary but do not carry the bounded
+quickstart assets.
+For v5.4.0, run the last command from a source checkout. The installer and the
+published v5.4.0 CLI archive install the binary but do not carry the bounded
+quickstart assets.
+"""
+        with self.assertRaisesRegex(ValueError, "exactly one published-checkout sentence"):
+            module.render_release_readme(source, "5.5.0")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/test_release_quickstart.py
+++ b/scripts/ci/test_release_quickstart.py
@@ -7,6 +7,8 @@ import sys
 import tempfile
 import time
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 from pathlib import Path
 from unittest import mock
 
@@ -169,7 +171,7 @@ class ReleaseArchiveShape(unittest.TestCase):
     def test_all_cli_archives_carry_the_bounded_quickstart(self):
         workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
         required_twice = [
-            'scripts/ci/release_readme.py "$VERSION"',
+            'release_readme.py" "$VERSION" --assembled-cwd',
             "examples/mcp-quickstart/policy.yaml",
             "examples/mcp-quickstart/run.py",
             "examples/mcp-quickstart/mock_server.py",
@@ -236,8 +238,8 @@ class ReleaseArchiveMemberInventory(unittest.TestCase):
         workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
         unix = package_step(workflow, "Package (Unix)")
         windows = package_step(workflow, "Package (Windows)")
-        self.assertIn('scripts/ci/release_readme.py "$VERSION"', unix)
-        self.assertIn('scripts/ci/release_readme.py "$VERSION"', windows)
+        self.assertIn('release_readme.py" "$VERSION" --assembled-cwd', unix)
+        self.assertIn('release_readme.py" "$VERSION" --assembled-cwd', windows)
         for name, fragment in PACKED_SOURCE_MEMBERS:
             with self.subTest(platform="unix", member=name):
                 self.assertIn(fragment, unix)
@@ -514,6 +516,34 @@ class ReleaseArchiveReadmeFollowOn(unittest.TestCase):
                 copy_at = step.find(fragment)
                 self.assertGreater(copy_at, -1, f"{heading} missing {name}")
                 self.assertLess(copy_at, render_at, f"{heading} {name} copied after render")
+
+    def test_renderer_cli_rejects_arbitrary_archive_path_before_filesystem_access(self):
+        module = load_module()
+        with mock.patch.object(module, "list_archive_members") as list_members:
+            with redirect_stderr(StringIO()):
+                result = module.main(["v5.5.0", "/tmp/attacker-selected-archive"])
+        self.assertEqual(result, 2)
+        list_members.assert_not_called()
+
+    def test_renderer_cli_assembled_mode_reads_only_the_current_directory(self):
+        module = load_module()
+        cwd = Path("/assembled/archive")
+        members = module.default_packed_members()
+        with mock.patch.object(module.Path, "cwd", return_value=cwd), mock.patch.object(
+            module, "list_archive_members", return_value=members
+        ) as list_members, redirect_stdout(StringIO()):
+            result = module.main(["v5.5.0", "--assembled-cwd"])
+        self.assertEqual(result, 0)
+        list_members.assert_called_once_with(cwd)
+
+    def test_package_steps_enter_the_assembled_directory_for_rendering(self):
+        workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        unix = package_step(workflow, "Package (Unix)")
+        windows = package_step(workflow, "Package (Windows)")
+        self.assertIn('cd "dist/${ARCHIVE_NAME}"', unix)
+        self.assertIn("--assembled-cwd", unix)
+        self.assertIn('Push-Location "dist\\${ARCHIVE_NAME}"', windows)
+        self.assertIn("--assembled-cwd", windows)
 
     def test_unix_and_windows_assembled_member_sets_render(self):
         module = load_module()

--- a/scripts/ci/test_release_quickstart.py
+++ b/scripts/ci/test_release_quickstart.py
@@ -279,9 +279,17 @@ class ReleaseArchiveReadmeContract(unittest.TestCase):
             rendered,
         )
         self.assertIn(
-            "(https://github.com/Rul1an/assay/blob/v5.5.0/demo/output/screenshots/mcp-wrap-demo.svg)",
+            "(https://raw.githubusercontent.com/Rul1an/assay/v5.5.0/demo/output/screenshots/mcp-wrap-demo.svg)",
             rendered,
         )
+        self.assertNotIn(
+            "github.com/Rul1an/assay/blob/v5.5.0/demo/output/screenshots/mcp-wrap-demo.svg",
+            rendered,
+        )
+        self.assertNotIn("github.com/Rul1an/assay/blob/main/", rendered)
+        self.assertNotIn("github.com/Rul1an/assay/tree/main/", rendered)
+        self.assertNotIn("github.com/Rul1an/assay/raw/main/", rendered)
+        self.assertIn('href="LICENSE"', rendered)
         self.assertIn(
             'href="https://github.com/Rul1an/assay/blob/v5.5.0/docs/security/OWASP-MCP-TOP10-MAPPING.md"',
             rendered,
@@ -379,6 +387,164 @@ quickstart assets.
             rendered,
         )
         self.assertNotIn(CHECKOUT_SENTENCE, rendered)
+
+PINNED_SOURCE = (
+    "cargo install assay-cli --version 5.4.0 --locked\n"
+    "Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0).\n"
+    "For v5.4.0, run the last command from a source checkout. The installer and the\n"
+    "published v5.4.0 CLI archive install the binary but do not carry the bounded\n"
+    "quickstart assets.\n"
+)
+PACKED_MEMBER_PATHS = frozenset(
+    {
+        "LICENSE",
+        "examples/mcp-quickstart",
+        "examples/mcp-quickstart/",
+        "examples/mcp-quickstart/policy.yaml",
+        "examples/mcp-quickstart/run.py",
+        "examples/mcp-quickstart/mock_server.py",
+    }
+)
+
+
+class ReleaseArchiveReadmeFollowOn(unittest.TestCase):
+    def test_renderer_rewrites_first_party_mutable_main_ref(self):
+        module = load_module()
+        source = PINNED_SOURCE + (
+            '<a href="https://github.com/Rul1an/assay/blob/main/LICENSE">'
+            "license</a>\n"
+            "[tree](https://github.com/Rul1an/assay/tree/HEAD/docs/)\n"
+            "[raw](https://raw.githubusercontent.com/Rul1an/assay/master/CHANGELOG.md)\n"
+        )
+        rendered = module.render_release_readme(source, "5.5.0")
+        self.assertNotIn("/blob/main/", rendered)
+        self.assertNotIn("/tree/HEAD/", rendered)
+        self.assertNotIn("/master/", rendered)
+        self.assertIn('href="LICENSE"', rendered)
+        self.assertIn(
+            "[tree](https://github.com/Rul1an/assay/tree/v5.5.0/docs/)",
+            rendered,
+        )
+        self.assertIn(
+            "[raw](https://github.com/Rul1an/assay/blob/v5.5.0/CHANGELOG.md)",
+            rendered,
+        )
+
+    def test_renderer_uses_raw_tag_urls_for_media(self):
+        module = load_module()
+        source = PINNED_SOURCE + (
+            "![demo](demo/output/screenshots/mcp-wrap-demo.svg)\n"
+            "![gif](examples/privileged-action-gate/demo.gif)\n"
+        )
+        rendered = module.render_release_readme(source, "5.5.0")
+        self.assertIn(
+            "![demo](https://raw.githubusercontent.com/Rul1an/assay/v5.5.0/demo/output/screenshots/mcp-wrap-demo.svg)",
+            rendered,
+        )
+        self.assertIn(
+            "![gif](https://raw.githubusercontent.com/Rul1an/assay/v5.5.0/examples/privileged-action-gate/demo.gif)",
+            rendered,
+        )
+        self.assertNotIn("github.com/Rul1an/assay/blob/", rendered)
+
+    def test_renderer_refuses_a_nonexistent_quickstart_member(self):
+        module = load_module()
+        source = PINNED_SOURCE + "[missing](examples/mcp-quickstart/not-packed.py)\n"
+        with self.assertRaisesRegex(ValueError, "assembled archive member"):
+            module.render_release_readme(source, "5.5.0")
+
+    def test_renderer_refuses_a_github_workflow_path(self):
+        module = load_module()
+        source = PINNED_SOURCE + "[ci](.github/workflows/ci.yml)\n"
+        with self.assertRaisesRegex(ValueError, "unclassifiable"):
+            module.render_release_readme(source, "5.5.0")
+
+    def test_renderer_refuses_a_reference_style_link(self):
+        module = load_module()
+        source = PINNED_SOURCE + "[see][docs]\n\n[docs]: docs/concepts/scope.md\n"
+        with self.assertRaisesRegex(ValueError, "unclassifiable"):
+            module.render_release_readme(source, "5.5.0")
+
+    def test_renderer_refuses_an_overlong_link_label(self):
+        module = load_module()
+        source = PINNED_SOURCE + "[" + ("A" * 600) + "](docs/concepts/scope.md)\n"
+        with self.assertRaisesRegex(ValueError, "unclassifiable"):
+            module.render_release_readme(source, "5.5.0")
+
+    def test_renderer_rewrites_html_img_src(self):
+        module = load_module()
+        source = PINNED_SOURCE + (
+            '<img src="demo/output/screenshots/mcp-wrap-demo.svg" alt="demo">\n'
+        )
+        rendered = module.render_release_readme(source, "5.5.0")
+        self.assertIn(
+            'src="https://raw.githubusercontent.com/Rul1an/assay/v5.5.0/demo/output/screenshots/mcp-wrap-demo.svg"',
+            rendered,
+        )
+
+    def test_renderer_rewrites_single_quoted_href(self):
+        module = load_module()
+        source = PINNED_SOURCE + "<a href='docs/concepts/scope.md'>scope</a>\n"
+        rendered = module.render_release_readme(source, "5.5.0")
+        self.assertIn(
+            "href='https://github.com/Rul1an/assay/blob/v5.5.0/docs/concepts/scope.md'",
+            rendered,
+        )
+
+    def test_renderer_peels_dot_slash_and_rejects_traversal(self):
+        module = load_module()
+        source = PINNED_SOURCE + "[ok](./LICENSE)\n"
+        rendered = module.render_release_readme(source, "5.5.0")
+        self.assertIn("[ok](LICENSE)", rendered)
+        self.assertNotIn("lstrip(", (ROOT / "scripts/ci/release_readme.py").read_text(encoding="utf-8"))
+        for hostile in ("../LICENSE", "/LICENSE", ".../LICENSE"):
+            with self.subTest(path=hostile):
+                with self.assertRaisesRegex(ValueError, "traversal|unclassifiable"):
+                    module.render_release_readme(
+                        PINNED_SOURCE + f"[x]({hostile})\n", "5.5.0"
+                    )
+
+    def test_package_steps_assemble_members_before_rendering(self):
+        workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        for heading in ("Package (Unix)", "Package (Windows)"):
+            step = package_step(workflow, heading)
+            render_at = step.find("release_readme.py")
+            self.assertGreater(render_at, 0, heading)
+            for name, fragment in PACKED_SOURCE_MEMBERS:
+                copy_at = step.find(fragment)
+                self.assertGreater(copy_at, -1, f"{heading} missing {name}")
+                self.assertLess(copy_at, render_at, f"{heading} {name} copied after render")
+
+    def test_unix_and_windows_assembled_member_sets_render(self):
+        module = load_module()
+        source = (ROOT / "README.md").read_text(encoding="utf-8")
+        members = module.expand_archive_members(
+            {
+                "assay",
+                "LICENSE",
+                "examples/mcp-quickstart/policy.yaml",
+                "examples/mcp-quickstart/run.py",
+                "examples/mcp-quickstart/mock_server.py",
+            }
+        )
+        self.assertTrue(PACKED_MEMBER_PATHS <= members)
+        rendered = module.render_release_readme(source, "5.5.0", members=members)
+        self.assertIn("[MIT](LICENSE)", rendered)
+        self.assertIn(
+            "https://raw.githubusercontent.com/Rul1an/assay/v5.5.0/demo/output/screenshots/mcp-wrap-demo.svg",
+            rendered,
+        )
+        self.assertNotRegex(rendered, r"github\.com/Rul1an/assay/(blob|tree|raw)/(HEAD|main|master)/")
+        self.assertNotRegex(
+            rendered, r"raw\.githubusercontent\.com/Rul1an/assay/(HEAD|main|master)/"
+        )
+
+    def test_kernel_matrix_paths_include_readme(self):
+        workflow = (ROOT / ".github/workflows/kernel-matrix.yml").read_text(encoding="utf-8")
+        paths = workflow.split("paths:", 1)[1].split("workflow_dispatch", 1)[0]
+        self.assertIn('"README.md"', paths)
+
+
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_release_quickstart.py
+++ b/scripts/ci/test_release_quickstart.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -59,6 +60,10 @@ cargo install assay-cli --version 5.4.0 --locked
 ```
 
 Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0).
+
+For v5.4.0, run the last command from a source checkout. The installer and the
+published v5.4.0 CLI archive install the binary but do not carry the bounded
+quickstart assets.
 
 Historical note: v5.3.0 shipped earlier.
 """
@@ -310,6 +315,16 @@ See [scope](docs/concepts/scope.md) and [license](LICENSE) and [quickstart](exam
         self.assertIn(ARCHIVE_ROOT_CLAIM, rendered)
         self.assertNotIn(CHECKOUT_SENTENCE, rendered)
 
+    def test_renderer_refuses_a_source_with_zero_checkout_matches(self):
+        module = load_module()
+        source = """cargo install assay-cli --version 5.4.0 --locked
+Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0).
+"""
+        with self.assertRaisesRegex(ValueError, "exactly one published-checkout sentence"):
+            rendered = module.render_release_readme(source, "5.5.0")
+            returned_without_archive_truth = ARCHIVE_ROOT_CLAIM not in rendered
+            self.fail(f"returned_without_archive_truth={returned_without_archive_truth}")
+
     def test_renderer_refuses_ambiguous_checkout_sentence(self):
         module = load_module()
         source = """cargo install assay-cli --version 5.4.0 --locked
@@ -323,6 +338,47 @@ quickstart assets.
 """
         with self.assertRaisesRegex(ValueError, "exactly one published-checkout sentence"):
             module.render_release_readme(source, "5.5.0")
+
+    def test_renderer_rejects_the_polynomial_markdown_link_regex(self):
+        source = MODULE_PATH.read_text(encoding="utf-8")
+        self.assertNotIn("MARKDOWN_LINK_RE", source)
+        self.assertNotIn(r"(!?\[[^\]]*\]\()", source)
+
+    def test_renderer_rewrites_hostile_bracket_input_in_bounded_time(self):
+        module = load_module()
+        hostile = "[" * 20_000 + "[](" * 20_000
+        source = (
+            "cargo install assay-cli --version 5.4.0 --locked\n"
+            "Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0).\n"
+            "For v5.4.0, run the last command from a source checkout. The installer and the\n"
+            "published v5.4.0 CLI archive install the binary but do not carry the bounded\n"
+            "quickstart assets.\n"
+            + hostile
+            + "\nSee [scope](docs/concepts/scope.md) and [license](LICENSE) and "
+            "[quickstart](examples/mcp-quickstart/run.py) and [here](#quickstart) and "
+            "[action](https://github.com/marketplace/actions/assay-ai-agent-security).\n"
+            '<a href="docs/concepts/scope.md">scope</a>\n'
+        )
+        started = time.perf_counter()
+        rendered = module.render_release_readme(source, "5.5.0")
+        elapsed = time.perf_counter() - started
+        self.assertLess(elapsed, 0.25, f"rewrite exceeded linear ceiling: {elapsed:.3f}s")
+        self.assertIn(
+            "[scope](https://github.com/Rul1an/assay/blob/v5.5.0/docs/concepts/scope.md)",
+            rendered,
+        )
+        self.assertIn("[license](LICENSE)", rendered)
+        self.assertIn("[quickstart](examples/mcp-quickstart/run.py)", rendered)
+        self.assertIn("[here](#quickstart)", rendered)
+        self.assertIn(
+            "[action](https://github.com/marketplace/actions/assay-ai-agent-security)",
+            rendered,
+        )
+        self.assertIn(
+            'href="https://github.com/Rul1an/assay/blob/v5.5.0/docs/concepts/scope.md"',
+            rendered,
+        )
+        self.assertNotIn(CHECKOUT_SENTENCE, rendered)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- preserve Ruley's archive-valid README renderer and immutable link work from draft #2679
- remove the attacker-shaped archive-root CLI argument that CodeQL flagged
- accept only the closed `--assembled-cwd` mode and enumerate `Path.cwd()`
- enter the assembled archive directory on Unix and Windows before rendering
- refresh the frozen published-release harness digest for the changed release workflow

Closes #2677. Supersedes #2679 without rewriting its branch.

## RED -> GREEN

RED on inherited head `0876bd9e9087bc92a6f59a66b0b7260100170eb1` after merging current main:
- arbitrary archive path reached `list_archive_members`
- `--assembled-cwd` was interpreted as a filesystem path
- Unix and Windows package steps did not enter the assembled directory

GREEN at `8ce3affb166c7212c125be9af9984db11447dade`:
- `python3 scripts/ci/test_release_quickstart.py` (34/34)
- `bash scripts/ci/test-published-release-golden-path-contract.sh`
- pre-commit on the four changed paths
- `git diff --check`

## Mutation evidence

All four mutations fail with the control green:
- remove the argv allowlist
- replace `Path.cwd()` with `Path(args[1])`
- remove Unix `cd` into the assembled archive
- remove Windows `Push-Location` into the assembled archive

## Non-claims

- no v5.5 tag, publish, or hosted archive proof
- no general-purpose archive path validator
- CodeQL and cross-platform packaging remain hosted-CI claims


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release archives now include README instructions tailored to the packaged files.
  * README links and media in releases are pinned to the specific release version for reliable access.
  * Release packaging now assembles archive contents before generating release documentation.

* **Bug Fixes**
  * Updated workflow triggers ensure kernel checks run when README changes.
  * Improved validation prevents unsafe, ambiguous, or invalid links in release documentation.

* **Tests**
  * Expanded coverage for release archives, README rendering, link handling, and packaging workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->