### PR TITLE
ci(dx): host the Claude plugin install self-test in Kernel Matrix (#2685)

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -114,6 +114,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Claude plugin install self-test
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/test-claude-plugin-install.sh --self-test
+
       - name: Cache pre-commit
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -13,7 +13,7 @@ trap 'rm -rf "$SCRATCH"' EXIT
 # the 58-case durability boundary established by PR B0.
 # CI-5C (#2196): +3 skill generator-destination omissions and +3 packaged-resource
 # destination drifts beyond the original baseline-only packaged drift case.
-EXPECTED_CASES=100
+EXPECTED_CASES=108
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # The 23 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode,
 # 1 release-split, and 2 inline-parser checks; pin them so deletion cannot leave
@@ -491,6 +491,35 @@ replacements = {
         '  lint:\n    name: Lint (pre-commit)\n    runs-on: ubuntu-latest\n',
         '  lint:\n    name: Lint (pre-commit)\n    runs-on: ubuntu-24.04\n',
     ),
+    "delete-claude-self-test": (
+        '      - name: Claude plugin install self-test\n'
+        '        shell: bash\n'
+        '        run: |\n'
+        '          set -euo pipefail\n'
+        '          bash scripts/ci/test-claude-plugin-install.sh --self-test\n',
+        '',
+    ),
+    "comment-claude-self-test": (
+        '          bash scripts/ci/test-claude-plugin-install.sh --self-test\n',
+        '          # bash scripts/ci/test-claude-plugin-install.sh --self-test\n',
+    ),
+    "argv-claude-self-test": (
+        '          bash scripts/ci/test-claude-plugin-install.sh --self-test\n',
+        '          bash scripts/ci/test-claude-plugin-install.sh\n',
+    ),
+    "claude-self-test-if-false": (
+        '      - name: Claude plugin install self-test\n        shell: bash\n',
+        '      - name: Claude plugin install self-test\n        shell: bash\n        if: false\n',
+    ),
+    "claude-self-test-continue-on-error": (
+        '      - name: Claude plugin install self-test\n        shell: bash\n',
+        '      - name: Claude plugin install self-test\n        shell: bash\n        continue-on-error: true\n',
+    ),
+    "claude-self-test-outside-comment": (
+        '      - name: Cache pre-commit\n',
+        '      # comment outside the Claude plugin install self-test step\n'
+        '      - name: Cache pre-commit\n',
+    ),
 }
 
 try:
@@ -949,7 +978,8 @@ for workflow_path in \
   '.github/workflows/kernel-matrix.yml' \
   '.claude-plugin/**' \
   'packaging/claude-plugin/**' \
-  'packaging/agent-plugin/**'
+  'packaging/agent-plugin/**' \
+  'docs/guides/editor-mcp-recipe.md'
 do
   for mutation in remove comment; do
     case_root="$SCRATCH/workflow-$mutation-$(printf '%s' "$workflow_path" | tr '/.*' '---')"
@@ -1347,6 +1377,28 @@ for executor_case in "${executor_mutations[@]}"; do
   mutate_workflow "$case_root" "$mutation"
   expect_named_failure "$name" "$case_root" "$expected"
 done
+
+declare -a claude_self_test_mutations=(
+  "delete-claude-self-test|missing hosted Claude plugin self-test|kernel-matrix lint job must run exactly one active Claude plugin install self-test"
+  "comment-claude-self-test|commented hosted Claude plugin self-test|kernel-matrix lint job must run exactly one active Claude plugin install self-test"
+  "argv-claude-self-test|noncanonical Claude plugin self-test argv|kernel-matrix lint job must run exactly one active Claude plugin install self-test"
+  "claude-self-test-if-false|conditional Claude plugin self-test|kernel-matrix Claude plugin install self-test must not be conditional"
+  "claude-self-test-continue-on-error|fail-open Claude plugin self-test|kernel-matrix Claude plugin install self-test must fail closed"
+)
+
+for claude_case in "${claude_self_test_mutations[@]}"; do
+  IFS='|' read -r mutation name expected <<<"$claude_case"
+  case_root="$SCRATCH/claude-self-test-$mutation"
+  seed_case "$case_root"
+  mutate_workflow "$case_root" "$mutation"
+  expect_named_failure "$name" "$case_root" "$expected"
+done
+
+case_root="$SCRATCH/claude-self-test-outside-comment"
+seed_case "$case_root"
+mutate_workflow "$case_root" "claude-self-test-outside-comment"
+expect_named_success "comment outside Claude plugin self-test step" "$case_root"
+
 
 declare -a structural_workflow_mutations=(
   "duplicate-path-entry|duplicate pull-request path entry|kernel-matrix pull_request.paths duplicates entry: crates/assay-ebpf/**"

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -13,7 +13,7 @@ trap 'rm -rf "$SCRATCH"' EXIT
 # the 58-case durability boundary established by PR B0.
 # CI-5C (#2196): +3 skill generator-destination omissions and +3 packaged-resource
 # destination drifts beyond the original baseline-only packaged drift case.
-EXPECTED_CASES=108
+EXPECTED_CASES=110
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # The 23 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode,
 # 1 release-split, and 2 inline-parser checks; pin them so deletion cannot leave
@@ -519,6 +519,40 @@ replacements = {
         '      - name: Cache pre-commit\n',
         '      # comment outside the Claude plugin install self-test step\n'
         '      - name: Cache pre-commit\n',
+    ),
+    "claude-self-test-shell-decoy": (
+        '      - name: Claude plugin install self-test\n        shell: bash\n',
+        '      - name: Claude plugin install self-test\n        shell: echo {0}\n',
+    ),
+    "claude-self-test-before-setup": (
+        '      - uses: ./.github/actions/setup-rust\n'
+        '        with:\n'
+        '          components: rustfmt, clippy\n'
+        '\n'
+        '      - name: Set up Python\n'
+        '        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0\n'
+        '        with:\n'
+        '          python-version: "3.12"\n'
+        '\n'
+        '      - name: Claude plugin install self-test\n'
+        '        shell: bash\n'
+        '        run: |\n'
+        '          set -euo pipefail\n'
+        '          bash scripts/ci/test-claude-plugin-install.sh --self-test\n',
+        '      - name: Claude plugin install self-test\n'
+        '        shell: bash\n'
+        '        run: |\n'
+        '          set -euo pipefail\n'
+        '          bash scripts/ci/test-claude-plugin-install.sh --self-test\n'
+        '\n'
+        '      - uses: ./.github/actions/setup-rust\n'
+        '        with:\n'
+        '          components: rustfmt, clippy\n'
+        '\n'
+        '      - name: Set up Python\n'
+        '        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0\n'
+        '        with:\n'
+        '          python-version: "3.12"\n',
     ),
 }
 
@@ -1384,6 +1418,8 @@ declare -a claude_self_test_mutations=(
   "argv-claude-self-test|noncanonical Claude plugin self-test argv|kernel-matrix lint job must run exactly one active Claude plugin install self-test"
   "claude-self-test-if-false|conditional Claude plugin self-test|kernel-matrix Claude plugin install self-test must not be conditional"
   "claude-self-test-continue-on-error|fail-open Claude plugin self-test|kernel-matrix Claude plugin install self-test must fail closed"
+  "claude-self-test-shell-decoy|shell-decoy Claude plugin self-test|kernel-matrix Claude plugin install self-test must use canonical bash"
+  "claude-self-test-before-setup|Claude plugin self-test before setup|kernel-matrix Claude plugin install self-test must run after setup-rust and setup-python"
 )
 
 for claude_case in "${claude_self_test_mutations[@]}"; do

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -207,6 +207,8 @@ class PrecommitHookContract:
 class WorkflowStepContract:
     condition: str | None
     continue_on_error: bool | None
+    shell: str | None
+    uses: str | None
     shell_lines: tuple[str, ...]
 
 
@@ -615,6 +617,8 @@ def parse_lint_step(
             fields.get("continue-on-error", ""),
             "kernel-matrix lint step continue-on-error",
         ),
+        shell=fields.get("shell"),
+        uses=fields.get("uses"),
         shell_lines=shell_lines,
     )
 
@@ -778,6 +782,9 @@ def validate_lint_executor(contract: WorkflowContract) -> None:
 
 
 CLAUDE_PLUGIN_SELF_TEST = "bash scripts/ci/test-claude-plugin-install.sh --self-test"
+CANONICAL_LINT_SHELL = "bash"
+SETUP_RUST_USES = "./.github/actions/setup-rust"
+SETUP_PYTHON_USES_PREFIX = "actions/setup-python@"
 
 
 def lint_step_self_test_lines(step: WorkflowStepContract) -> tuple[str, ...]:
@@ -792,6 +799,21 @@ def lint_step_is_claude_plugin_self_test(step: WorkflowStepContract) -> bool:
     return CLAUDE_PLUGIN_SELF_TEST in lint_step_self_test_lines(step)
 
 
+def lint_step_uses(step: WorkflowStepContract) -> str | None:
+    if step.uses is None:
+        return None
+    return step.uses.split("#", 1)[0].strip() or None
+
+
+def lint_step_is_setup_rust(step: WorkflowStepContract) -> bool:
+    return lint_step_uses(step) == SETUP_RUST_USES
+
+
+def lint_step_is_setup_python(step: WorkflowStepContract) -> bool:
+    uses = lint_step_uses(step)
+    return uses is not None and uses.startswith(SETUP_PYTHON_USES_PREFIX)
+
+
 def validate_hosted_claude_plugin_self_test(contract: WorkflowContract) -> None:
     matches = [
         (index, step)
@@ -801,12 +823,26 @@ def validate_hosted_claude_plugin_self_test(contract: WorkflowContract) -> None:
     if len(matches) != 1:
         fail("kernel-matrix lint job must run exactly one active Claude plugin install self-test")
     index, step = matches[0]
-    if index == 0:
-        fail("kernel-matrix Claude plugin install self-test must run after setup")
+    rust_indices = [
+        rust_index
+        for rust_index, candidate in enumerate(contract.lint_steps)
+        if lint_step_is_setup_rust(candidate)
+    ]
+    python_indices = [
+        python_index
+        for python_index, candidate in enumerate(contract.lint_steps)
+        if lint_step_is_setup_python(candidate)
+    ]
+    if len(rust_indices) != 1 or len(python_indices) != 1:
+        fail("kernel-matrix lint job must run setup-rust and setup-python before the Claude plugin install self-test")
+    if index <= rust_indices[0] or index <= python_indices[0]:
+        fail("kernel-matrix Claude plugin install self-test must run after setup-rust and setup-python")
     if step.condition is not None:
         fail("kernel-matrix Claude plugin install self-test must not be conditional")
     if step.continue_on_error is True:
         fail("kernel-matrix Claude plugin install self-test must fail closed")
+    if step.shell != CANONICAL_LINT_SHELL:
+        fail("kernel-matrix Claude plugin install self-test must use canonical bash")
     if lint_step_self_test_lines(step) != (CLAUDE_PLUGIN_SELF_TEST,):
         fail("kernel-matrix Claude plugin install self-test command is noncanonical")
 

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -777,6 +777,41 @@ def validate_lint_executor(contract: WorkflowContract) -> None:
             fail("kernel-matrix lint pre-commit command is noncanonical")
 
 
+CLAUDE_PLUGIN_SELF_TEST = "bash scripts/ci/test-claude-plugin-install.sh --self-test"
+
+
+def lint_step_self_test_lines(step: WorkflowStepContract) -> tuple[str, ...]:
+    return tuple(
+        line.strip()
+        for line in step.shell_lines
+        if line.strip() and line.strip() != "set -euo pipefail"
+    )
+
+
+def lint_step_is_claude_plugin_self_test(step: WorkflowStepContract) -> bool:
+    return CLAUDE_PLUGIN_SELF_TEST in lint_step_self_test_lines(step)
+
+
+def validate_hosted_claude_plugin_self_test(contract: WorkflowContract) -> None:
+    matches = [
+        (index, step)
+        for index, step in enumerate(contract.lint_steps)
+        if lint_step_is_claude_plugin_self_test(step)
+    ]
+    if len(matches) != 1:
+        fail("kernel-matrix lint job must run exactly one active Claude plugin install self-test")
+    index, step = matches[0]
+    if index == 0:
+        fail("kernel-matrix Claude plugin install self-test must run after setup")
+    if step.condition is not None:
+        fail("kernel-matrix Claude plugin install self-test must not be conditional")
+    if step.continue_on_error is True:
+        fail("kernel-matrix Claude plugin install self-test must fail closed")
+    if lint_step_self_test_lines(step) != (CLAUDE_PLUGIN_SELF_TEST,):
+        fail("kernel-matrix Claude plugin install self-test command is noncanonical")
+
+
+
 def precommit_line_indentation(line: str, line_number: int) -> int:
     prefix = line[: len(line) - len(line.lstrip())]
     if "\t" in prefix:
@@ -1239,6 +1274,7 @@ def main() -> None:
     workflow = read_bounded_evidence(WORKFLOW_PATH, "workflow evidence").decode("utf-8")
     workflow_contract = parse_kernel_matrix_workflow(workflow)
     validate_lint_executor(workflow_contract)
+    validate_hosted_claude_plugin_self_test(workflow_contract)
     workflow_paths = set(workflow_contract.pull_request_paths)
     if "main" not in workflow_contract.pull_request_branches:
         fail("kernel-matrix pull_request does not cover main")
@@ -1257,6 +1293,7 @@ def main() -> None:
         '.github/assay-release-tag',
         'docs/generated/**',
         'docs/guides/agent-golden-path.md',
+        'docs/guides/editor-mcp-recipe.md',
         '.github/workflows/kernel-matrix.yml',
     )
     for path in required_workflow_paths:


### PR DESCRIPTION
## Summary
Hosted Kernel Matrix Lint ran `pre-commit run --all-files` on the default stage. The credential-free Claude plugin install self-test lived only on `stages: [pre-push]`, so hosted CI could stay green without it.

This PR does not touch `.pre-commit-config.yaml` or Cursor's #2487 worktree.

Closes #2685.

## RED
`scripts/ci/test-agent-golden-path-skill.py` now requires exactly one active Lint step:
`bash scripts/ci/test-claude-plugin-install.sh --self-test`
after `./.github/actions/setup-rust` and `actions/setup-python@`, with `shell: bash` only, no `if`, no `continue-on-error`, and no comment decoy.

On `1ce76dc4` that assertion failed:
`kernel-matrix lint job must run exactly one active Claude plugin install self-test`.

On `d6e483ac` two further gaps were RED-reproduced locally in the Ruley worktree `/tmp/wt-ruley-2685-claude-install-hosted-ci` with `/usr/bin/python3` 3.13.5:
- `shell: echo {0}` stayed GREEN (contract did not retain `shell`)
- moving the step before setup-rust/setup-python stayed GREEN (`index == 0` only)

## GREEN
One Lint step after Set up Python, `shell: bash`. `docs/guides/editor-mcp-recipe.md` is a required pull_request path (already present in the workflow; the pin keeps it covered). Workflow YAML is unchanged on the repair commit.

## Mutations
Local hosted-checker evidence on head `af3da8c7938523c38581c98833e3e192691ba019` in `/tmp/wt-ruley-2685-claude-install-hosted-ci` with `/usr/bin/python3` 3.13.5 (Linux 6.12.94+ x86_64). This is not a pre-push hook run and not hosted CI.

| mutation | result | needle |
|---|---|---|
| step deleted | RED | exactly one active Claude plugin install self-test |
| run line commented | RED | exactly one active Claude plugin install self-test |
| argv drops `--self-test` | RED | exactly one active Claude plugin install self-test |
| `if: false` | RED | must not be conditional |
| `continue-on-error: true` | RED | must fail closed |
| `shell: echo {0}` | RED | must use canonical bash |
| step moved before setup-rust/setup-python | RED | must run after setup-rust and setup-python |
| comment outside the step | GREEN | live checker stays clean |

## Hosted caller
Run [33238176148](https://github.com/Rul1an/assay/actions/runs/33238176148) on `d6e483acbbb48c28c6ebe010bca1ef55ac1e08cb` is the Kernel Matrix proof that the actual hosted `bash` self-test ran and succeeded. It does not prove the local mutation harness or this repair commit.

## Non-claims
- Not a live Claude / model / auth / marketplace install.
- Not a change to the pre-push hook or `.pre-commit-config.yaml`.
- Not #2487 historical retention, not a v5.5 tag, no Cargo.
- Full hardening.sh was not re-run here: this box has no `pre-commit` binary; the eight named mutations were proven directly against the hosted checker.
- Caller-and-gate: the production caller is the Kernel Matrix Lint step. The pre-push hook remaining is a second surface, not a substitute.

Base: `1ce76dc4f02adcaa33683f4fc4d7a4375d8a1ddd`
Head: `af3da8c7938523c38581c98833e3e192691ba019`
Worktree: `/tmp/wt-ruley-2685-claude-install-hosted-ci`
Toolchain: `/usr/bin/python3` 3.13.5

Stop for independent exact-head review. Do not merge. Do not mark ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated self-test for Claude plugin installation during kernel workflow checks.

* **Bug Fixes**
  * Strengthened workflow validation to detect missing, reordered, conditional, fail-open, or incorrectly configured self-test steps.
  * Expanded validation coverage for editor MCP recipe changes.

* **Tests**
  * Added additional workflow-hardening scenarios and increased expected test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->