### PR TITLE
ci(release): derive published install truth in pre-tag verification

### DIFF
--- a/scripts/ci/test-verify-release.sh
+++ b/scripts/ci/test-verify-release.sh
@@ -29,6 +29,111 @@ trap 'rm -rf "$tmp"' EXIT
 
 release_tag="$(bash "$RELEASE_TAG_READER")"
 
+candidate_paths=(
+  Cargo.toml .github/assay-release-tag README.md docs/index.md
+  docs/getting-started/index.md docs/getting-started/installation.md
+  docs/getting-started/quickstart.md docs/getting-started/ci-integration.md
+  docs/reference/cli/index.md docs/AIcontext/user-flows.md docs/use-cases/ci-gate.md
+)
+
+make_candidate() {
+  local destination="$1" version="$2"
+  local path
+  for path in "${candidate_paths[@]}"; do
+    mkdir -p "$destination/$(dirname "$path")"
+    cp "$ROOT/$path" "$destination/$path"
+  done
+  python3 - "$destination/Cargo.toml" "$version" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+section = re.search(r"(?ms)^\[workspace\.package\]$(.*?)(?=^\[|\Z)", text)
+if not section:
+    raise SystemExit("workspace.package section is missing")
+replacement = re.sub(
+    r'^version\s*=\s*"[^"]+"\s*$',
+    f'version = "{sys.argv[2]}"',
+    section.group(1),
+    count=1,
+    flags=re.M,
+)
+if not re.search(r'^version\s*=\s*"[^"]+"\s*$', section.group(1), re.M):
+    raise SystemExit("workspace.package version is missing")
+path.write_text(text[: section.start(1)] + replacement + text[section.end(1) :], encoding="utf-8")
+PY
+}
+
+fixture_gh="$tmp/fixture-gh"
+cat >"$fixture_gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == api && "${2:-}" =~ /contents/(.*)\?ref= ]] || exit 64
+path="${BASH_REMATCH[1]}"
+python3 - "$FIXTURE_ROOT/$path" <<'PY'
+import base64
+import json
+import pathlib
+import sys
+
+print(json.dumps({"content": base64.b64encode(pathlib.Path(sys.argv[1]).read_bytes()).decode()}))
+PY
+SH
+chmod +x "$fixture_gh"
+
+# Candidate source version and last-published install truth are independent.
+# A release-prep tree may lead the install pin until the new release exists.
+current_candidate="$tmp/current-candidate"
+make_candidate "$current_candidate" 5.4.0
+expect_status 0 env FIXTURE_ROOT="$current_candidate" GH="$fixture_gh" \
+  VERSION=5.4.0 PIN_SHA="$(git -C "$ROOT" rev-parse HEAD)" "$ORACLE" --pre-tag
+
+next_candidate="$tmp/next-candidate"
+make_candidate "$next_candidate" 5.5.0
+expect_status 0 env FIXTURE_ROOT="$next_candidate" GH="$fixture_gh" \
+  VERSION=5.5.0 PIN_SHA="$(git -C "$ROOT" rev-parse HEAD)" "$ORACLE" --pre-tag
+
+drift_candidate="$tmp/drift-candidate"
+cp -R "$current_candidate" "$drift_candidate"
+printf 'v5.3.0\n' >"$drift_candidate/.github/assay-release-tag"
+expect_status 1 env FIXTURE_ROOT="$drift_candidate" GH="$fixture_gh" \
+  VERSION=5.4.0 PIN_SHA="$(git -C "$ROOT" rev-parse HEAD)" "$ORACLE" --pre-tag
+
+malformed_candidate="$tmp/malformed-candidate"
+cp -R "$current_candidate" "$malformed_candidate"
+printf 'latest\n' >"$malformed_candidate/.github/assay-release-tag"
+expect_status 1 env FIXTURE_ROOT="$malformed_candidate" GH="$fixture_gh" \
+  VERSION=5.4.0 PIN_SHA="$(git -C "$ROOT" rev-parse HEAD)" "$ORACLE" --pre-tag
+
+# Mutation proof: restoring the old release-specific literal must fail on the
+# current candidate instead of turning the next release into another edit site.
+pin_mutant_dir="$tmp/pin-mutant"
+mkdir -p "$pin_mutant_dir"
+cp "$ORACLE" "$ASSET_CONTRACT" "$RELEASE_TAG_READER" "$pin_mutant_dir/"
+python3 - "$pin_mutant_dir/verify-release.sh" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+dynamic_pin = 'pin = f"cargo install assay-cli --version {published_version} --locked"'
+dynamic_link = 'link = f"Current release: [`{published_tag}`](https://github.com/Rul1an/assay/releases/tag/{published_tag})"'
+if text.count(dynamic_pin) != 1 or text.count(dynamic_link) != 1:
+    raise SystemExit("published release derivation anchors moved")
+text = text.replace(dynamic_pin, 'pin = "cargo install assay-cli --version 5.3.0 --locked"', 1)
+text = text.replace(
+    dynamic_link,
+    'link = "Current release: [`v5.3.0`](https://github.com/Rul1an/assay/releases/tag/v5.3.0)"',
+    1,
+)
+path.write_text(text, encoding="utf-8")
+PY
+expect_status 1 env FIXTURE_ROOT="$current_candidate" GH="$fixture_gh" \
+  VERSION=5.4.0 PIN_SHA="$(git -C "$ROOT" rev-parse HEAD)" \
+  "$pin_mutant_dir/verify-release.sh" --pre-tag
+
 expected_assets="$("$ORACLE" --unit-expected-assets 5.3.0)"
 [[ "$(printf '%s\n' "$expected_assets" | wc -l | tr -d ' ')" -eq 23 ]] \
   || fail "asset generator did not produce 23 names"

--- a/scripts/ci/test-verify-release.sh
+++ b/scripts/ci/test-verify-release.sh
@@ -70,8 +70,10 @@ fixture_gh="$tmp/fixture-gh"
 cat >"$fixture_gh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
-[[ "${1:-}" == api && "${2:-}" =~ /contents/(.*)\?ref= ]] || exit 64
+[[ "${1:-}" == api && "${2:-}" =~ ^repos/Rul1an/assay/contents/(.*)\?ref=([0-9a-f]{40})$ ]] \
+  || exit 64
 path="${BASH_REMATCH[1]}"
+[[ "${BASH_REMATCH[2]}" == "${PIN_SHA:-}" ]] || exit 65
 python3 - "$FIXTURE_ROOT/$path" <<'PY'
 import base64
 import json
@@ -133,6 +135,27 @@ PY
 expect_status 1 env FIXTURE_ROOT="$current_candidate" GH="$fixture_gh" \
   VERSION=5.4.0 PIN_SHA="$(git -C "$ROOT" rev-parse HEAD)" \
   "$pin_mutant_dir/verify-release.sh" --pre-tag
+
+# Mutation proof: the source fetch must stay bound to the requested candidate
+# commit, not merely to the expected repository path.
+ref_mutant_dir="$tmp/ref-mutant"
+mkdir -p "$ref_mutant_dir"
+cp "$ORACLE" "$ASSET_CONTRACT" "$RELEASE_TAG_READER" "$ref_mutant_dir/"
+python3 - "$ref_mutant_dir/verify-release.sh" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+anchor = 'repos/$REPO/contents/$path?ref=$sha'
+if text.count(anchor) != 1:
+    raise SystemExit("candidate source ref anchor moved")
+text = text.replace(anchor, f"repos/$REPO/contents/$path?ref={'0' * 40}", 1)
+path.write_text(text, encoding="utf-8")
+PY
+expect_status 2 env FIXTURE_ROOT="$current_candidate" GH="$fixture_gh" \
+  VERSION=5.4.0 PIN_SHA="$(git -C "$ROOT" rev-parse HEAD)" \
+  "$ref_mutant_dir/verify-release.sh" --pre-tag
 
 expected_assets="$("$ORACLE" --unit-expected-assets 5.3.0)"
 [[ "$(printf '%s\n' "$expected_assets" | wc -l | tr -d ' ')" -eq 23 ]] \

--- a/scripts/ci/verify-release.sh
+++ b/scripts/ci/verify-release.sh
@@ -263,7 +263,7 @@ PY
 }
 
 check_tag_tree() {
-  local sha="$1" tree="$2"
+  local sha="$1" tree="$2" published_tag
   valid_sha "$sha" || finding "refused non-canonical or abbreviated tag commit SHA: $sha"
   mkdir -p "$tree"
   local path
@@ -273,31 +273,34 @@ check_tag_tree() {
     docs/reference/cli/index.md docs/AIcontext/user-flows.md docs/use-cases/ci-gate.md; do
     copy_tag_file "$sha" "$path" "$tree/$path" || infra "could not materialize tag tree file: $path"
   done
-  "$PYTHON" - "$tree" "$VERSION" <<'PY'
+  published_tag="$(
+    ASSAY_RELEASE_TAG_FILE="$tree/.github/assay-release-tag" \
+      bash "$SCRIPT_DIR/read-assay-release-tag.sh"
+  )" || finding "candidate tree has an invalid published release pin"
+  "$PYTHON" - "$tree" "$VERSION" "$published_tag" <<'PY'
 import pathlib
 import re
 import sys
 
-root, version = pathlib.Path(sys.argv[1]), sys.argv[2]
+root, version, published_tag = pathlib.Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+published_version = published_tag.removeprefix("v")
 cargo = (root / "Cargo.toml").read_text(encoding="utf-8")
 section = re.search(r"(?ms)^\[workspace\.package\]$(.*?)(?=^\[|\Z)", cargo)
 if not section or not re.search(rf'^version\s*=\s*"{re.escape(version)}"\s*$', section.group(1), re.M):
     raise SystemExit("workspace.package.version does not equal release version")
-if (root / ".github/assay-release-tag").read_bytes() != b"v5.3.0\n":
-    raise SystemExit("assay-release-tag is not exactly the separate v5.3.0 install pin")
 install_counts = {
     "README.md": 1, "docs/getting-started/index.md": 1,
     "docs/getting-started/installation.md": 2, "docs/getting-started/quickstart.md": 1,
     "docs/getting-started/ci-integration.md": 4, "docs/reference/cli/index.md": 1,
     "docs/AIcontext/user-flows.md": 1, "docs/use-cases/ci-gate.md": 1,
 }
-pin = "cargo install assay-cli --version 5.3.0 --locked"
+pin = f"cargo install assay-cli --version {published_version} --locked"
 for path, count in install_counts.items():
     text = (root / path).read_text(encoding="utf-8")
     commands = re.findall(r"cargo install assay-cli --version \S+ --locked", text)
     if len(commands) != count or commands.count(pin) != count:
         raise SystemExit(f"{path}: install pin drift")
-link = "Current release: [`v5.3.0`](https://github.com/Rul1an/assay/releases/tag/v5.3.0)"
+link = f"Current release: [`{published_tag}`](https://github.com/Rul1an/assay/releases/tag/{published_tag})"
 for path in ("README.md", "docs/index.md"):
     text = (root / path).read_text(encoding="utf-8")
     if text.count("Current release:") != 1 or text.count(link) != 1:


### PR DESCRIPTION
Closes #2692.

## Contract

Pre-tag verification treats the candidate workspace version and the last-published install tag as separate facts. The candidate tree's copied `.github/assay-release-tag` is validated by the existing single pin parser, then drives install commands and `Current release` links. The workspace remains independently bound to `VERSION`.

This permits the v5.5 pre-tag tree to declare source version `5.5.0` while installers and published docs remain on installable `v5.4.0`. The published pin moves only after v5.5 assets exist and verify.

## RED -> GREEN

- old release-specific literal rejected a release-prep candidate whose workspace leads the published pin
- current `5.4.0` candidate with `v5.4.0` published pin passes
- next `5.5.0` candidate with `v5.4.0` published pin passes
- pin/docs drift fails
- malformed pin (`latest`) fails
- restored hardcoded `v5.3.0` mutant fails
- source-fetch wrong-ref mutant fails as infrastructure exit 2

## Verification

- `bash scripts/ci/test-verify-release.sh`
- `PIN_SHA=fe82a46f897cd4e298a0a44f974f24ed4b1e9858 VERSION=5.4.0 bash scripts/ci/verify-release.sh --pre-tag` -> `CLEAN`
- `bash -n` on both changed scripts
- ShellCheck at warning severity
- scoped pre-commit and full pre-push gates
- `git diff --check`

## Prerequisite evidence

Published historical retention passed end-to-end on merged `main` run `33278629839`, head `effa36c505a900e1a63616d67ad3a57ad981831b`, artifact `9722285138`.

## Non-claims

- No release, tag, registry, asset, or documentation version is changed here.
- Post-publish behavior is unchanged.
- A green pre-tag oracle does not prove v5.5 assets exist; actual publication and post-publish verification remain separate steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release verification now checks the candidate’s published release tag dynamically, preventing failures caused by outdated hardcoded version references.
  * Documentation links and installation references are validated against the correct release version.

* **Tests**
  * Added offline verification coverage for current, upcoming, drifted, and malformed release candidates.
  * Added mutation tests to detect regressions in release tag and source-reference validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->