### PR TITLE
fix(release): build the historical evidence profile

### DIFF
--- a/scripts/ci/check-published-release-historical-retention-contract.py
+++ b/scripts/ci/check-published-release-historical-retention-contract.py
@@ -821,7 +821,7 @@ def validate_source_contract(
     )
     require(
         driver_text,
-        '\\"type\\":\\"file_open\\",\\"path\\":\\"retained-v5.3-profile-event\\"',
+        '\\"type\\":\\"file_open\\",\\"path\\":\\"retained-v5.3-profile-event\\",\\"timestamp\\":1}',
         "driver must create the declared v5.3 profile event",
         problems,
     )

--- a/scripts/ci/check-published-release-historical-retention-contract.py
+++ b/scripts/ci/check-published-release-historical-retention-contract.py
@@ -821,6 +821,12 @@ def validate_source_contract(
     )
     require(
         driver_text,
+        '\\"type\\":\\"file_open\\",\\"path\\":\\"retained-v5.3-profile-event\\"',
+        "driver must create the declared v5.3 profile event",
+        problems,
+    )
+    require(
+        driver_text,
         "evidence export --profile v0-profile.yaml",
         "driver must export the initialized v5.3 evidence profile",
         problems,

--- a/scripts/ci/check-published-release-historical-retention-contract.py
+++ b/scripts/ci/check-published-release-historical-retention-contract.py
@@ -30,7 +30,10 @@ V1_RELEASE_PAIR = ("v5.3.0", "v5.4.0")
 V1_COMMAND_CLASSES = {
     "state_producing": [
         "create-journey-canary",
+        "create-profile-event-v5.3",
         "init",
+        "profile-init-v5.3",
+        "profile-update-v5.3",
         "export-v0-bundle",
         "import-v1-bundle",
         "stage-prefix-v5.3.0",
@@ -798,6 +801,30 @@ def validate_source_contract(
         problems,
     )
     require(driver_text, "flag_unavailable", "driver must classify v5.3 explicit v1 as flag_unavailable", problems)
+    require(
+        driver_text,
+        "profile init --output v0-profile.yaml --name historical-retention",
+        "driver must initialize the v5.3 evidence profile through the published CLI",
+        problems,
+    )
+    require(
+        driver_text,
+        "profile update --profile v0-profile.yaml",
+        "driver must update the v5.3 evidence profile through the published CLI",
+        problems,
+    )
+    require(
+        driver_text,
+        "--input profile-events.jsonl --run-id v5.3.0-initial --strict",
+        "driver must populate the v5.3 evidence profile from the retained event",
+        problems,
+    )
+    require(
+        driver_text,
+        "evidence export --profile v0-profile.yaml",
+        "driver must export the initialized v5.3 evidence profile",
+        problems,
+    )
     if "value_rejected" in driver_text:
         problems.append("v5.3 explicit v1 must not be classified as value_rejected")
     require(driver_text, '"migration_required": False', "driver must record migration_required false", problems)

--- a/scripts/ci/fixtures/published-release-historical-retention/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-historical-retention/v1/harness-manifest.json
@@ -26,7 +26,10 @@
   "command_classes": {
     "state_producing": [
       "create-journey-canary",
+      "create-profile-event-v5.3",
       "init",
+      "profile-init-v5.3",
+      "profile-update-v5.3",
       "export-v0-bundle",
       "import-v1-bundle",
       "stage-prefix-v5.3.0",
@@ -53,6 +56,8 @@
     "home/.config/assay/config.toml",
     "session/policy.yaml",
     "session/eval.yaml",
+    "session/profile-events.jsonl",
+    "session/v0-profile.yaml",
     "session/traces/hello.jsonl",
     "results/v0.bundle",
     "results/v1.bundle"
@@ -64,7 +69,7 @@
     },
     {
       "path": "scripts/ci/published-release-historical-retention.sh",
-      "sha256": "af4facc845b2c76450e263d81cf475ae0a89b25e67dc78fd671e97cb670b942b"
+      "sha256": "618e21de5f8f049adfebab6c561ce2e23db76f40b586e2ce87c7f2cbbeb9276e"
     },
     {
       "path": "scripts/ci/release_attestation_enforce.sh",

--- a/scripts/ci/published-release-historical-retention.sh
+++ b/scripts/ci/published-release-historical-retention.sh
@@ -398,8 +398,20 @@ run_capture "init" "state_producing" 0 "$results/init.json" "$results/init.stder
   "$active_link/bin/assay" init --preset dev --hello-trace --format json
 run_capture "migrate-check-v5.3" "observe" 0 "$results/migrate-v53.txt" "$results/migrate-v53.stderr" \
   "$active_link/bin/assay" migrate --check --config eval.yaml
+run_capture "create-profile-event-v5.3" "state_producing" 0 \
+  "$results/create-profile-event-v53.stdout" "$results/create-profile-event-v53.stderr" \
+  "$canary_python" -c \
+  'import pathlib,sys; pathlib.Path(sys.argv[1]).write_text("{\"type\":\"file_open\",\"path\":\"retained-v5.3-profile-event\",\"timestamp\":1}\n", encoding="utf-8")' \
+  profile-events.jsonl
+run_capture "profile-init-v5.3" "state_producing" 0 \
+  "$results/profile-init-v53.stdout" "$results/profile-init-v53.stderr" \
+  "$active_link/bin/assay" profile init --output v0-profile.yaml --name historical-retention
+run_capture "profile-update-v5.3" "state_producing" 0 \
+  "$results/profile-update-v53.stdout" "$results/profile-update-v53.stderr" \
+  "$active_link/bin/assay" profile update --profile v0-profile.yaml \
+  --input profile-events.jsonl --run-id v5.3.0-initial --strict
 run_capture "export-v0-bundle" "state_producing" 0 "$results/export-v0.stdout" "$results/export-v0.stderr" \
-  "$active_link/bin/assay" evidence export --profile eval.yaml -o "$results/v0.bundle"
+  "$active_link/bin/assay" evidence export --profile v0-profile.yaml -o "$results/v0.bundle"
 explicit_status=0
 "$active_link/bin/assay" evidence verify-privileged-mcp-action "$results/v0.bundle" --format json --profile-version v1 \
   >"$results/explicit-v1.json" 2>"$results/explicit-v1.stderr" || explicit_status=$?

--- a/scripts/ci/test-published-release-historical-retention-contract.sh
+++ b/scripts/ci/test-published-release-historical-retention-contract.sh
@@ -117,7 +117,10 @@ case "\$cmd" in
         ;;
       update)
         [[ -f "\$profile" && -f "\$input" ]] || exit 2
-        printf 'updated: true\n' >>"\$profile"
+        event_type="\$(python3 -c 'import json,sys; print(json.loads(open(sys.argv[1], encoding="utf-8").readline())["type"])' "\$input")" || exit 2
+        event_path="\$(python3 -c 'import json,sys; print(json.loads(open(sys.argv[1], encoding="utf-8").readline())["path"])' "\$input")" || exit 2
+        [[ "\$event_type" == "file_open" && -n "\$event_path" ]] || exit 2
+        printf 'updated: true\nprofile_entry: %s\n' "\$event_path" >>"\$profile"
         ;;
       *)
         exit 2
@@ -143,6 +146,7 @@ case "\$cmd" in
         [[ -n "\$out" && -f "\$profile" ]] || exit 2
         grep -F 'version: "1.0"' "\$profile" >/dev/null || exit 2
         grep -F 'updated: true' "\$profile" >/dev/null || exit 2
+        grep -F 'profile_entry: retained-v5.3-profile-event' "\$profile" >/dev/null || exit 2
         printf 'v0-bundle\\n' >"\$out"
         ;;
       verify)
@@ -172,6 +176,22 @@ build_fixture_root() {
   local fixture="$1"
   write_stub_assay "$fixture/v5.3.0/bin/assay" "5.3.0"
   write_stub_assay "$fixture/v5.4.0/bin/assay" "5.4.0"
+}
+
+expect_fixture_rejects_unknown_profile_event() {
+  local case_root="$scratch/unknown-profile-event"
+  local assay="$case_root/bin/assay"
+  mkdir -p "$case_root/run"
+  write_stub_assay "$assay" "5.3.0"
+  (
+    cd "$case_root/run"
+    printf '%s\n' '{"type":"unknown_event","path":"retained-v5.3-profile-event","timestamp":1}' >profile-events.jsonl
+    "$assay" profile init --output v0-profile.yaml --name historical-retention
+    if "$assay" profile update --profile v0-profile.yaml --input profile-events.jsonl \
+        --run-id v5.3.0-initial --strict; then
+      fail "fixture accepted an unknown profile event"
+    fi
+  )
 }
 
 run_driver() {
@@ -711,6 +731,7 @@ PY
 
 fixture="$scratch/fixture"
 build_fixture_root "$fixture"
+expect_fixture_rejects_unknown_profile_event
 good_root="$scratch/good"
 run_driver "$good_root" "$fixture"
 check_results "$good_root"
@@ -1372,6 +1393,11 @@ expect_source_failure \
   "evidence export --profile v0-profile.yaml" \
   "evidence export --profile eval.yaml" \
   "driver must export the initialized v5.3 evidence profile"
+expect_source_failure \
+  "profile-event-type-drift" "driver.sh" \
+  '{\"type\":\"file_open\",\"path\":\"retained-v5.3-profile-event\"' \
+  '{\"type\":\"unknown_event\",\"path\":\"retained-v5.3-profile-event\"' \
+  "driver must create the declared v5.3 profile event"
 
 while IFS= read -r helper; do
   expect_precommit_helper_decoy "$helper"

--- a/scripts/ci/test-published-release-historical-retention-contract.sh
+++ b/scripts/ci/test-published-release-historical-retention-contract.sh
@@ -96,20 +96,53 @@ case "\$cmd" in
     echo "Config eval.yaml is clean (already migrated)."
     exit 0
     ;;
+  profile)
+    sub="\${1:-}"
+    shift || true
+    profile=""
+    input=""
+    prev=""
+    for arg in "\$@"; do
+      if [[ "\$prev" == "--output" || "\$prev" == "--profile" ]]; then
+        profile="\$arg"
+      elif [[ "\$prev" == "--input" || "\$prev" == "-i" ]]; then
+        input="\$arg"
+      fi
+      prev="\$arg"
+    done
+    case "\$sub" in
+      init)
+        [[ -n "\$profile" ]] || exit 2
+        printf 'version: "1.0"\nname: historical-retention\ntotal_runs: 0\nentries: {}\n' >"\$profile"
+        ;;
+      update)
+        [[ -f "\$profile" && -f "\$input" ]] || exit 2
+        printf 'updated: true\n' >>"\$profile"
+        ;;
+      *)
+        exit 2
+        ;;
+    esac
+    ;;
   evidence)
     sub="\${1:-}"
     shift || true
     out=""
+    profile=""
     prev=""
     for arg in "\$@"; do
       if [[ "\$prev" == "-o" || "\$prev" == "--out" || "\$prev" == "--bundle-out" ]]; then
         out="\$arg"
+      elif [[ "\$prev" == "--profile" ]]; then
+        profile="\$arg"
       fi
       prev="\$arg"
     done
     case "\$sub" in
       export)
-        [[ -n "\$out" ]] || exit 2
+        [[ -n "\$out" && -f "\$profile" ]] || exit 2
+        grep -F 'version: "1.0"' "\$profile" >/dev/null || exit 2
+        grep -F 'updated: true' "\$profile" >/dev/null || exit 2
         printf 'v0-bundle\\n' >"\$out"
         ;;
       verify)
@@ -1324,6 +1357,21 @@ expect_source_failure \
   '"executable": true' \
   '"executable": "true"' \
   "invalid executable flag"
+expect_source_failure \
+  "profile-init-target-drift" "driver.sh" \
+  "profile init --output v0-profile.yaml --name historical-retention" \
+  "profile init --output eval.yaml --name historical-retention" \
+  "driver must initialize the v5.3 evidence profile through the published CLI"
+expect_source_failure \
+  "profile-update-target-drift" "driver.sh" \
+  "profile update --profile v0-profile.yaml" \
+  "profile update --profile eval.yaml" \
+  "driver must update the v5.3 evidence profile through the published CLI"
+expect_source_failure \
+  "profile-export-target-drift" "driver.sh" \
+  "evidence export --profile v0-profile.yaml" \
+  "evidence export --profile eval.yaml" \
+  "driver must export the initialized v5.3 evidence profile"
 
 while IFS= read -r helper; do
   expect_precommit_helper_decoy "$helper"

--- a/scripts/ci/test-published-release-historical-retention-contract.sh
+++ b/scripts/ci/test-published-release-historical-retention-contract.sh
@@ -117,9 +117,7 @@ case "\$cmd" in
         ;;
       update)
         [[ -f "\$profile" && -f "\$input" ]] || exit 2
-        event_type="\$(python3 -c 'import json,sys; print(json.loads(open(sys.argv[1], encoding="utf-8").readline())["type"])' "\$input")" || exit 2
-        event_path="\$(python3 -c 'import json,sys; print(json.loads(open(sys.argv[1], encoding="utf-8").readline())["path"])' "\$input")" || exit 2
-        [[ "\$event_type" == "file_open" && -n "\$event_path" ]] || exit 2
+        event_path="\$(python3 -c 'import json,sys; row=json.loads(open(sys.argv[1], encoding="utf-8").readline()); timestamp=row.get("timestamp", 0); valid=row.get("type") == "file_open" and isinstance(row.get("path"), str) and bool(row["path"]) and type(timestamp) is int and 0 <= timestamp <= 2**64 - 1; sys.exit(2) if not valid else print(row["path"])' "\$input")" || exit 2
         printf 'updated: true\nprofile_entry: %s\n' "\$event_path" >>"\$profile"
         ;;
       *)
@@ -178,18 +176,19 @@ build_fixture_root() {
   write_stub_assay "$fixture/v5.4.0/bin/assay" "5.4.0"
 }
 
-expect_fixture_rejects_unknown_profile_event() {
-  local case_root="$scratch/unknown-profile-event"
+expect_fixture_rejects_profile_event() {
+  local name="$1" event="$2"
+  local case_root="$scratch/$name"
   local assay="$case_root/bin/assay"
   mkdir -p "$case_root/run"
   write_stub_assay "$assay" "5.3.0"
   (
     cd "$case_root/run"
-    printf '%s\n' '{"type":"unknown_event","path":"retained-v5.3-profile-event","timestamp":1}' >profile-events.jsonl
+    printf '%s\n' "$event" >profile-events.jsonl
     "$assay" profile init --output v0-profile.yaml --name historical-retention
     if "$assay" profile update --profile v0-profile.yaml --input profile-events.jsonl \
         --run-id v5.3.0-initial --strict; then
-      fail "fixture accepted an unknown profile event"
+      fail "fixture accepted an invalid profile event: $name"
     fi
   )
 }
@@ -731,7 +730,21 @@ PY
 
 fixture="$scratch/fixture"
 build_fixture_root "$fixture"
-expect_fixture_rejects_unknown_profile_event
+expect_fixture_rejects_profile_event \
+  "unknown-profile-event" \
+  '{"type":"unknown_event","path":"retained-v5.3-profile-event","timestamp":1}'
+expect_fixture_rejects_profile_event \
+  "string-profile-timestamp" \
+  '{"type":"file_open","path":"retained-v5.3-profile-event","timestamp":"1"}'
+expect_fixture_rejects_profile_event \
+  "negative-profile-timestamp" \
+  '{"type":"file_open","path":"retained-v5.3-profile-event","timestamp":-1}'
+expect_fixture_rejects_profile_event \
+  "boolean-profile-timestamp" \
+  '{"type":"file_open","path":"retained-v5.3-profile-event","timestamp":true}'
+expect_fixture_rejects_profile_event \
+  "overflow-profile-timestamp" \
+  '{"type":"file_open","path":"retained-v5.3-profile-event","timestamp":18446744073709551616}'
 good_root="$scratch/good"
 run_driver "$good_root" "$fixture"
 check_results "$good_root"
@@ -1395,8 +1408,13 @@ expect_source_failure \
   "driver must export the initialized v5.3 evidence profile"
 expect_source_failure \
   "profile-event-type-drift" "driver.sh" \
-  '{\"type\":\"file_open\",\"path\":\"retained-v5.3-profile-event\"' \
-  '{\"type\":\"unknown_event\",\"path\":\"retained-v5.3-profile-event\"' \
+  '{\"type\":\"file_open\",\"path\":\"retained-v5.3-profile-event\",\"timestamp\":1}' \
+  '{\"type\":\"unknown_event\",\"path\":\"retained-v5.3-profile-event\",\"timestamp\":1}' \
+  "driver must create the declared v5.3 profile event"
+expect_source_failure \
+  "profile-event-timestamp-drift" "driver.sh" \
+  '{\"type\":\"file_open\",\"path\":\"retained-v5.3-profile-event\",\"timestamp\":1}' \
+  '{\"type\":\"file_open\",\"path\":\"retained-v5.3-profile-event\",\"timestamp\":\"1\"}' \
   "driver must create the declared v5.3 profile event"
 
 while IFS= read -r helper; do


### PR DESCRIPTION
## Summary

Repair the hosted historical-retention journey so the published v5.3.0 CLI builds the input type that `assay evidence export --profile` actually accepts.

- create one bounded synthetic profile event
- run published v5.3.0 `profile init` and `profile update`
- export `v0-profile.yaml`, never `eval.yaml`
- retain the event/profile and record all three steps as exact-once state producers
- pin the route with three target-drift mutations

Closes the precondition defect observed under #2487; it does not close #2487 until a fresh hosted dispatch and consumer-checker pass.

## Hosted RED

Run [33272843369](https://github.com/Rul1an/assay/actions/runs/33272843369), exact `main` `7d16a3a779c001e1b66b166bea8031c6a83aee1e`:

```
export-v0-bundle exited 2, expected 0
fatal: failed to load profile from eval.yaml
Caused by: missing field version
```

Retained artifact id `9720609096`, archive digest `sha256:e2d40829535ee8fbe64db483ac1ce090441d96d8082d647e71b4251027999740`.

## Local RED -> GREEN

- RED: realistic fixture export rejects `eval.yaml`; focused contract exits 1 at `export-v0-bundle`
- GREEN: focused contract passes the complete journey and negative matrix
- mutations: init target, update target, and export target drifted independently to `eval.yaml`; each is rejected by its named contract guard
- `bash -n`, `shellcheck`, Python compile, manifest driver digest, `git diff --check`, and targeted pre-commit pass
- pre-push historical-retention contract, workspace clippy, and Linux cross-target compile pass

## Non-claims

No historical compatibility result exists yet. The prior hosted run failed before the consumer checker. This PR changes the harness only; a fresh exact-main hosted dispatch is required before any upgrade/rollback statement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Historical-retention evidence exports now use an initialized and updated v5.3 profile.
  * Added profile event creation, profile initialization, and profile update steps to the release workflow.
  * Evidence bundles now include the generated profile and profile event artifacts.

* **Bug Fixes**
  * Strengthened validation to ensure profile data is populated and exported correctly before bundle creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->