### PR TITLE
fix(ci): create retained home config explicitly

### DIFF
--- a/scripts/ci/check-published-release-historical-retention-contract.py
+++ b/scripts/ci/check-published-release-historical-retention-contract.py
@@ -29,6 +29,7 @@ V1_EXECUTABLE_PATHS = ["scripts/ci/release_archive_inventory.sh"]
 V1_RELEASE_PAIR = ("v5.3.0", "v5.4.0")
 V1_COMMAND_CLASSES = {
     "state_producing": [
+        "create-home-config",
         "create-journey-canary",
         "create-profile-event-v5.3",
         "init",

--- a/scripts/ci/check-published-release-historical-retention-contract.py
+++ b/scripts/ci/check-published-release-historical-retention-contract.py
@@ -27,6 +27,11 @@ HEAD_SHA = re.compile(r"^[0-9a-f]{40}$")
 DRIVER_REL = "scripts/ci/published-release-historical-retention.sh"
 V1_EXECUTABLE_PATHS = ["scripts/ci/release_archive_inventory.sh"]
 V1_RELEASE_PAIR = ("v5.3.0", "v5.4.0")
+HOME_CONFIG_SCRIPT = (
+    'import pathlib,sys; path=pathlib.Path(sys.argv[1]); '
+    'path.parent.mkdir(parents=True, exist_ok=True); '
+    'path.write_text("# historical-retention harness input\\n", encoding="utf-8")'
+)
 V1_COMMAND_CLASSES = {
     "state_producing": [
         "create-home-config",
@@ -1047,6 +1052,31 @@ def validate_results(results: Path, manifest_path: Path, expected_head_sha: str)
         str(part) for part in canary_cmd[0].get("argv", [])
     ):
         problems.append("canary row must record the argv that actually ran")
+
+    home_config_cmd = [row for row in commands if row.get("name") == "create-home-config"]
+    if len(home_config_cmd) != 1:
+        problems.append("create-home-config must be recorded exactly once")
+    elif len(canary_cmd) == 1:
+        canary_argv = canary_cmd[0].get("argv")
+        interpreter = canary_argv[0] if isinstance(canary_argv, list) and canary_argv else None
+        canary_path = (
+            PurePosixPath(canary_argv[-1])
+            if isinstance(canary_argv, list) and canary_argv and isinstance(canary_argv[-1], str)
+            else PurePosixPath()
+        )
+        run_root = canary_path.parents[1] if canary_path.is_absolute() and len(canary_path.parents) > 1 else None
+        expected_home_config_argv = [
+            interpreter,
+            "-c",
+            HOME_CONFIG_SCRIPT,
+            str(run_root / "home/.config/assay/config.toml") if run_root is not None else None,
+        ]
+        if home_config_cmd[0].get("argv") != expected_home_config_argv:
+            problems.append("home config row must record the exact argv that actually ran")
+        if home_config_cmd[0].get("executed_binary_sha256") != canary_cmd[0].get(
+            "executed_binary_sha256"
+        ):
+            problems.append("home config row must bind the same interpreter as the canary")
 
     explicit = [row for row in commands if row.get("name") == "explicit-v1-v5.3"]
     if len(explicit) != 1:

--- a/scripts/ci/fixtures/published-release-historical-retention/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-historical-retention/v1/harness-manifest.json
@@ -25,6 +25,7 @@
   },
   "command_classes": {
     "state_producing": [
+      "create-home-config",
       "create-journey-canary",
       "create-profile-event-v5.3",
       "init",
@@ -69,7 +70,7 @@
     },
     {
       "path": "scripts/ci/published-release-historical-retention.sh",
-      "sha256": "8081b121120f3d0ed38605994d3c1509d7e6f8e20e6f8c7de9d52f2ce77ac424"
+      "sha256": "96d96f7fa39a244697f6575f16c924721503f2cfa7415d13f863a4da0308916b"
     },
     {
       "path": "scripts/ci/release_attestation_enforce.sh",

--- a/scripts/ci/published-release-historical-retention.sh
+++ b/scripts/ci/published-release-historical-retention.sh
@@ -389,6 +389,15 @@ export PATH="$active_link/bin:/usr/bin:/bin"
 
 canary_python="$(command -v "$PYTHON_BIN")"
 [[ -n "$canary_python" ]] || fail "python interpreter is missing"
+home_config="$HOME/.config/assay/config.toml"
+home_config_argv=(
+  "$canary_python" -c \
+  'import pathlib,sys; path=pathlib.Path(sys.argv[1]); path.parent.mkdir(parents=True, exist_ok=True); path.write_text("# historical-retention harness input\n", encoding="utf-8")' \
+  "$home_config"
+)
+"${home_config_argv[@]}"
+record_command "create-home-config" "state_producing" 0 /dev/null /dev/null "" \
+  "${home_config_argv[@]}"
 "$canary_python" -c 'import os,pathlib,sys; pathlib.Path(sys.argv[1]).write_bytes(os.urandom(32))' "$canary_path"
 record_command "create-journey-canary" "state_producing" 0 /dev/null /dev/null "" \
   "$canary_python" -c 'import os,pathlib,sys; pathlib.Path(sys.argv[1]).write_bytes(os.urandom(32))' "$canary_path"

--- a/scripts/ci/test-published-release-historical-retention-contract.sh
+++ b/scripts/ci/test-published-release-historical-retention-contract.sh
@@ -109,8 +109,7 @@ case "\$cmd" in
     printf '%s\\n' "\$VERSION"
     ;;
   init)
-    mkdir -p "\$HOME/.config/assay" traces
-    printf 'home-config\\n' >"\$HOME/.config/assay/config.toml"
+    mkdir -p traces
     printf 'policy\\n' >policy.yaml
     printf 'config\\n' >eval.yaml
     printf 'trace\\n' >traces/hello.jsonl
@@ -888,6 +887,20 @@ expect_fixture_rejects_profile_event \
   '{"type":"file_open","path":"retained-v5.3-profile-event","timestamp":18446744073709551616}'
 good_root="$scratch/good"
 run_driver "$good_root" "$fixture"
+[[ -f "$good_root/home/.config/assay/config.toml" ]] \
+  || fail "driver did not create the retained home config independently of assay init"
+python3 - "$good_root/results/commands.ndjson" <<'PY' \
+  || fail "driver did not record the retained home config creation exactly once"
+import json, pathlib, sys
+rows = [
+    json.loads(line)
+    for line in pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+    if line
+]
+matches = [row for row in rows if row.get("name") == "create-home-config"]
+if len(matches) != 1 or matches[0].get("class") != "state_producing":
+    raise SystemExit(1)
+PY
 check_results "$good_root"
 expect_materialized_helper_modes
 "$V54_ASSAY" evidence verify-privileged-mcp-action \

--- a/scripts/ci/test-published-release-historical-retention-contract.sh
+++ b/scripts/ci/test-published-release-historical-retention-contract.sh
@@ -1154,6 +1154,16 @@ for row in commands:
     paraphrased_rows.append(item)
 dump(paraphrased / "commands.ndjson", paraphrased_rows)
 
+false_home_config_argv = scratch / "false-home-config-argv"
+shutil.copytree(src, false_home_config_argv)
+false_home_config_rows = []
+for row in commands:
+    item = dict(row)
+    if item.get("name") == "create-home-config":
+        item["argv"] = ["-c", 'print("decoy")', item.get("argv", ["", "", ""])[-1]]
+    false_home_config_rows.append(item)
+dump(false_home_config_argv / "commands.ndjson", false_home_config_rows)
+
 undeclared = scratch / "undeclared-command"
 shutil.copytree(src, undeclared)
 dump(
@@ -1225,6 +1235,8 @@ expect_results_failure "empty-workflow-run-id" "$scratch/empty-workflow-run-id" 
 expect_results_failure "zero-workflow-run-attempt" "$scratch/zero-workflow-run-attempt" \
   "run-pin harness.workflow_run_attempt must be a positive integer"
 expect_results_failure "paraphrased-canary" "$scratch/paraphrased-canary" "canary row must record the argv that actually ran"
+expect_results_failure "false-home-config-argv" "$scratch/false-home-config-argv" \
+  "home config row must record the exact argv that actually ran"
 expect_results_failure "undeclared-command" "$scratch/undeclared-command" "undeclared command: arbitrary-undeclared"
 expect_results_failure "class-mismatch" "$scratch/class-mismatch" "command init class observe does not match manifest class state_producing"
 expect_results_failure "deleted-required-v0-bundle" "$scratch/deleted-required-results_v0.bundle" "required retained artifact missing: results/v0.bundle"


### PR DESCRIPTION
## Summary
- stop the fixture binary from pretending `assay init` creates a global home config
- create the retained home config explicitly as a harness-owned input
- record that creation as an exact-once `state_producing` command

## Evidence
- hosted run `33277373954` on merged `main` (`4684eefedde1d55d7515ab16a05740bea96f396f`) completed the journey but the independent checker failed with `required retained artifact missing: home/.config/assay/config.toml`
- RED: after removing the false stub side effect, the focused suite failed with `driver did not create the retained home config independently of assay init`
- GREEN: `bash scripts/ci/test-published-release-historical-retention-contract.sh`
- GREEN: source checker, `bash -n`, `shellcheck`, scoped pre-commit, and `git diff --check`

## Claim boundary
This repairs harness ownership and retention evidence. It is not a supported upgrade/rollback claim; that still requires a fresh hosted dispatch on the merged final head.
