### PR TITLE
test(release): make changelog history fixture idempotent

### DIFF
--- a/scripts/ci/test-check-assay-action-pin.sh
+++ b/scripts/ci/test-check-assay-action-pin.sh
@@ -286,16 +286,17 @@ import sys
 path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
 needle = "## [Unreleased]\n\n### Changed"
-if text.count(needle) != 1:
-    raise SystemExit("expected one Unreleased Changed heading")
-path.write_text(
-    text.replace(
-        needle,
-        "## [Unreleased]\n\n## [5.5.0] - 2026-08-30\n\n### Changed",
-        1,
-    ),
-    encoding="utf-8",
-)
+released = "## [99.99.99-test] - 2099-12-31"
+for _ in range(2):
+    if text.count(needle) == 1:
+        text = text.replace(
+            needle,
+            f"## [Unreleased]\n\n{released}\n\n### Changed",
+            1,
+        )
+    elif text.count(released) != 1:
+        raise SystemExit("expected active or already released CHANGELOG history")
+path.write_text(text, encoding="utf-8")
 PY
 expect_ok "consumer-compat-released-history" check_consumer_compat \
   "${DEPENDABOT}" "${PINNED_ACTIONS}" "${scratch}/CHANGELOG-released.md"


### PR DESCRIPTION
## Summary
- make the released-history fixture valid before and after a release heading already exists
- exercise the transformation twice so idempotence is part of the contract

## Why
The first prerequisite correctly changed the authority from `Unreleased` to changelog history, but its fixture constructor only accepted the pre-release shape. The real v5.5 candidate therefore failed before testing the intended invariant.

## Verification
- RED: v5.5 candidate failed with `expected one Unreleased Changed heading`
- GREEN: `bash scripts/ci/test-check-assay-action-pin.sh`
- GREEN: `bash scripts/ci/check-assay-action-pin.sh`
- GREEN: scoped commit and pre-push hooks
- `git diff --check`
