### PR TITLE
ci(release): retain Claude host claims across releases

### DIFF
--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -1347,6 +1347,17 @@ def assert_changelog_history_self_test() -> None:
         pass
     else:
         fail("changelog_self_test", "non-version heading stayed green", "require dated semver history")
+    invalid_owner = released.replace(
+        "## [99.99.99] - 2099-12-31\n",
+        "## [99.99.99] - 2099-12-31\n\n## [Migration Notes]\n",
+        1,
+    )
+    try:
+        _changelog_claim_section(invalid_owner)
+    except WorkflowError:
+        pass
+    else:
+        fail("changelog_self_test", "non-version owner stayed green", "require an eligible claim owner")
     print("changelog_history_self_test=pass")
 
 

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -1168,7 +1168,11 @@ RELEASE_HEADING = re.compile(
 
 
 def _changelog_claim_section(text: str) -> str:
-    """Return the one active or released section carrying every Claude claim."""
+    """Return the section carrying the newest occurrence of every Claude claim.
+
+    The changelog is newest-first. Older releases may repeat a tool name; they
+    cannot substitute for a newest claim that moves out of its owner section.
+    """
     headings = list(re.finditer(r"^## .+$", text, re.MULTILINE))
     unreleased = [match for match in headings if match.group(0) == "## [Unreleased]"]
     if len(unreleased) != 1:
@@ -1185,6 +1189,7 @@ def _changelog_claim_section(text: str) -> str:
 
     owners: list[int] = []
     for marker in CHANGELOG_CLAIM_MARKERS:
+        # The first occurrence is the newest one in this newest-first history.
         position = text.find(marker)
         if position < 0:
             fail(
@@ -1256,8 +1261,29 @@ def assert_changelog_contract() -> None:
 
 def assert_changelog_history_self_test() -> None:
     """Pin active, released, split, preamble, and non-version section bounds."""
-    active = (SOURCE_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
-    _changelog_claim_section(active)
+    source = (SOURCE_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    _changelog_claim_section(source)
+    headings = list(re.finditer(r"^## .+$", source, re.MULTILINE))
+    unreleased = next(match for match in headings if match.group(0) == "## [Unreleased]")
+    owner_position = source.find(CHANGELOG_CLAIM_MARKERS[0])
+    owner_index = next(
+        index for index in range(len(headings) - 1, -1, -1) if headings[index].start() < owner_position
+    )
+    if owner_index == headings.index(unreleased):
+        active = source
+    else:
+        owner = headings[owner_index]
+        owner_end = headings[owner_index + 1].start() if owner_index + 1 < len(headings) else len(source)
+        unreleased_body = source.find("\n", unreleased.start()) + 1
+        owner_body = source.find("\n", owner.start()) + 1
+        active = (
+            source[:unreleased_body]
+            + source[owner_body:owner_end]
+            + source[unreleased_body:owner.start()]
+            + source[owner.start():owner_body]
+            + source[owner_end:]
+        )
+        _changelog_claim_section(active)
     headings = list(re.finditer(r"^## .+$", active, re.MULTILINE))
     unreleased = next(match for match in headings if match.group(0) == "## [Unreleased]")
     first_release = headings[headings.index(unreleased) + 1]
@@ -1282,6 +1308,27 @@ def assert_changelog_history_self_test() -> None:
         else:
             fail("changelog_self_test", f"split marker stayed green: {marker}", "restore section closure")
 
+        older_duplicate = active.replace(
+            first_release.group(0), f"{first_release.group(0)}\n{marker}", 1
+        )
+        _changelog_claim_section(older_duplicate)
+        newest_removed = (
+            active[: first_release.start()].replace(marker, "")
+            + active[first_release.start() :]
+        ).replace(
+            first_release.group(0), f"{first_release.group(0)}\n{marker}", 1
+        )
+        try:
+            _changelog_claim_section(newest_removed)
+        except WorkflowError:
+            pass
+        else:
+            fail(
+                "changelog_self_test",
+                f"older duplicate replaced the newest owner: {marker}",
+                "keep newest-first claim ownership",
+            )
+
     preamble = released
     for marker in CHANGELOG_CLAIM_MARKERS:
         preamble = preamble.replace(marker, "", 1)
@@ -1293,9 +1340,7 @@ def assert_changelog_history_self_test() -> None:
     else:
         fail("changelog_self_test", "preamble claims stayed green", "restore section lower bound")
 
-    nonversion = active.replace(
-        "## [Unreleased]\n", "## [Unreleased]\n\n## [Migration Notes]\n", 1
-    )
+    nonversion = active[: first_release.start()] + "## [Migration Notes]" + active[first_release.end() :]
     try:
         _changelog_claim_section(nonversion)
     except WorkflowError:

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -994,6 +994,7 @@ def self_test() -> None:
     # surface as an unexplained fixture mismatch instead of the design error.
     assert_transcript_probe_is_not_denied()
     assert_transcript_prompt_contract()
+    assert_changelog_history_self_test()
     assert_changelog_contract()
     assert_hook_files_include_changelog()
     assert_stream_fixture_table()
@@ -1154,54 +1155,154 @@ STREAM_FIXTURE_EXPECTATIONS = (
 )
 
 
-def _unreleased_changelog() -> str:
-    """The current Unreleased section. One reader for the changelog contract."""
-    text = (SOURCE_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
-    start = text.find("## [Unreleased]")
-    if start < 0:
-        fail("changelog", "CHANGELOG.md has no Unreleased section", "restore the Unreleased heading")
-    rest = text[start:]
-    nxt = rest.find("\n## [", 1)
-    return rest if nxt < 0 else rest[:nxt]
+CHANGELOG_CLAIM_MARKERS = (
+    DECIDE_TOOL_PROJECT,
+    DECIDE_TOOL_PLUGIN,
+    "observed_route",
+    "wrong Assay tool",
+)
+RELEASE_HEADING = re.compile(
+    r"## \[(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\]"
+    r" - [0-9]{4}-[0-9]{2}-[0-9]{2}"
+)
+
+
+def _changelog_claim_section(text: str) -> str:
+    """Return the one active or released section carrying every Claude claim."""
+    headings = list(re.finditer(r"^## .+$", text, re.MULTILINE))
+    unreleased = [match for match in headings if match.group(0) == "## [Unreleased]"]
+    if len(unreleased) != 1:
+        fail("changelog", "CHANGELOG.md must have one Unreleased section", "restore the Unreleased heading")
+    unreleased_index = headings.index(unreleased[0])
+    if unreleased_index + 1 >= len(headings) or RELEASE_HEADING.fullmatch(
+        headings[unreleased_index + 1].group(0)
+    ) is None:
+        fail(
+            "changelog",
+            "CHANGELOG Unreleased is not followed by a dated semver release",
+            "restore numbered release history immediately after Unreleased",
+        )
+
+    owners: list[int] = []
+    for marker in CHANGELOG_CLAIM_MARKERS:
+        position = text.find(marker)
+        if position < 0:
+            fail(
+                "changelog",
+                f"CHANGELOG history does not name {marker!r}",
+                "record the two exact decide names, observed_route, and wrong-tool class",
+            )
+        owner = next(
+            (index for index in range(len(headings) - 1, -1, -1) if headings[index].start() < position),
+            -1,
+        )
+        owners.append(owner)
+    if len(set(owners)) != 1 or owners[0] < 0:
+        fail(
+            "changelog",
+            "CHANGELOG Claude host claims are split across sections",
+            "keep the complete claim set in one active or released section",
+        )
+    owner = owners[0]
+    heading = headings[owner].group(0)
+    if heading != "## [Unreleased]" and RELEASE_HEADING.fullmatch(heading) is None:
+        fail(
+            "changelog",
+            "CHANGELOG Claude host claims are outside active or released history",
+            "move the complete claim set under Unreleased or a dated semver release",
+        )
+    end = headings[owner + 1].start() if owner + 1 < len(headings) else len(text)
+    return text[headings[owner].start() : end]
 
 
 def assert_changelog_contract() -> None:
-    """Unreleased text must match the two-name union and wrong-tool class.
+    """Active or released text must match the two-name union and wrong-tool class.
 
     The classifier accepts exactly the project and plugin decide names and
     treats a wrong Assay tool as ``not_exercised``. The changelog is the
     public contract; a one-name or wrong-tool-unavailable sentence is a
     contradiction, not a comment.
     """
-    unreleased = _unreleased_changelog()
+    section = _changelog_claim_section((SOURCE_ROOT / "CHANGELOG.md").read_text(encoding="utf-8"))
     for needle in (DECIDE_TOOL_PROJECT, DECIDE_TOOL_PLUGIN, "observed_route"):
-        if needle not in unreleased:
+        if needle not in section:
             fail(
                 "changelog",
-                f"CHANGELOG Unreleased does not name {needle!r}",
+                f"CHANGELOG claim section does not name {needle!r}",
                 "record the two exact decide names and observed_route",
             )
-    if "wrong-tool," in unreleased and "stay `unavailable`" in unreleased:
+    if "wrong-tool," in section and "stay `unavailable`" in section:
         fail(
             "changelog",
             "CHANGELOG Unreleased still lists wrong-tool among unavailable shapes",
             "record the not_exercised reclassification for a wrong Assay tool",
         )
     marker = "wrong Assay tool"
-    idx = unreleased.find(marker)
+    idx = section.find(marker)
     if idx < 0:
         fail(
             "changelog",
-            "CHANGELOG Unreleased does not name the wrong Assay tool reclassification",
+            "CHANGELOG claim section does not name the wrong Assay tool reclassification",
             "say a wrong Assay tool stays not_exercised",
         )
-    if "not_exercised" not in unreleased[idx : idx + 240]:
+    if "not_exercised" not in section[idx : idx + 240]:
         fail(
             "changelog",
             "CHANGELOG Unreleased does not classify a wrong Assay tool as not_exercised",
             "land the reclassification next to the wrong Assay tool wording",
         )
     print("changelog_contract=pass")
+
+
+def assert_changelog_history_self_test() -> None:
+    """Pin active, released, split, preamble, and non-version section bounds."""
+    active = (SOURCE_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    _changelog_claim_section(active)
+    headings = list(re.finditer(r"^## .+$", active, re.MULTILINE))
+    unreleased = next(match for match in headings if match.group(0) == "## [Unreleased]")
+    first_release = headings[headings.index(unreleased) + 1]
+    body_start = active.find("\n", unreleased.start()) + 1
+    body = active[body_start : first_release.start()]
+    released = (
+        active[:body_start]
+        + "\n## [99.99.99] - 2099-12-31\n"
+        + body
+        + active[first_release.start() :]
+    )
+    _changelog_claim_section(released)
+
+    for marker in CHANGELOG_CLAIM_MARKERS:
+        split = released.replace(marker, "", 1).replace(
+            "## [Unreleased]\n", f"## [Unreleased]\n\n{marker}\n", 1
+        )
+        try:
+            _changelog_claim_section(split)
+        except WorkflowError:
+            pass
+        else:
+            fail("changelog_self_test", f"split marker stayed green: {marker}", "restore section closure")
+
+    preamble = released
+    for marker in CHANGELOG_CLAIM_MARKERS:
+        preamble = preamble.replace(marker, "", 1)
+    preamble = "\n".join(CHANGELOG_CLAIM_MARKERS) + "\n" + preamble
+    try:
+        _changelog_claim_section(preamble)
+    except WorkflowError:
+        pass
+    else:
+        fail("changelog_self_test", "preamble claims stayed green", "restore section lower bound")
+
+    nonversion = active.replace(
+        "## [Unreleased]\n", "## [Unreleased]\n\n## [Migration Notes]\n", 1
+    )
+    try:
+        _changelog_claim_section(nonversion)
+    except WorkflowError:
+        pass
+    else:
+        fail("changelog_self_test", "non-version heading stayed green", "require dated semver history")
+    print("changelog_history_self_test=pass")
 
 
 CLAUDE_PLUGIN_HOOK_ID = "claude-plugin-install-workflow-self-test"


### PR DESCRIPTION
## Summary
- keep Claude host-workflow claims valid after release prep moves them into numbered history
- parse one bounded changelog H2 section instead of scanning `Unreleased` forever
- self-test active, released, split, preamble, and non-version-heading states

## Why
The v5.5 candidate correctly moves the Claude host contract into `[5.5.0]`, but the owner check required it to remain in `Unreleased`, blocking every release.

## Verification
- RED: v5.5 push hook failed because `Unreleased` no longer named the exact decide route
- GREEN: `python3 scripts/ci/claude_plugin_install_workflow.py --self-test` on current main shape
- GREEN: the same patched self-test against the real v5.5 candidate changelog
- GREEN: scoped hooks, clippy, Linux compile gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved changelog validation so release claims are associated with the correct release section.
  * Added checks for incomplete, duplicated, misplaced, or incorrectly structured changelog entries.
  * Improved handling of active and completed releases, including claims split across sections.

* **Tests**
  * Expanded automated coverage for active releases, completed releases, older duplicates, preamble content, and invalid headings.
  * Added validation for non-version headings and other ambiguous changelog structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Final-head closeout
Reviewed head: `ad81a344dc037492c454ccfd5db6d6f38c0e6d65`.
Independent READY and final-head self-test/mutation verification: https://github.com/Rul1an/assay/pull/2701#issuecomment-5466889321 . Technical disposition: https://github.com/Rul1an/assay/pull/2701#issuecomment-5466878847 . All required checks pass. The newest occurrences own the claim section; older historical duplicates are permitted. This does not add a file-size ceiling.
