### PR TITLE
ci(assay-cli): package crate README before unpublished workspace deps

### DIFF
--- a/scripts/ci/check_assay_cli_crate_readme.sh
+++ b/scripts/ci/check_assay_cli_crate_readme.sh
@@ -21,10 +21,14 @@ trap cleanup EXIT
 
 # Build the publish artifact without compiling it. The packaged manifest and
 # README are authoritative; never substitute checkout metadata or paths.
-if ! CARGO_TARGET_DIR="$PACKAGE_DIR" cargo package -p assay-cli --no-verify --allow-dirty >/dev/null; then
-  echo "ERROR: cargo package -p assay-cli --no-verify --allow-dirty failed" >&2
+# --exclude-lockfile lets cargo emit a real .crate before unpublished workspace
+# deps exist on crates.io. That is README-shape only: not installability proof
+# and not lockfile proof.
+if ! CARGO_TARGET_DIR="$PACKAGE_DIR" cargo package -p assay-cli --exclude-lockfile --no-verify --allow-dirty >/dev/null; then
+  echo "ERROR: cargo package -p assay-cli --exclude-lockfile --no-verify --allow-dirty failed" >&2
   exit 1
 fi
+echo "NOTE: --exclude-lockfile is README-shape only; not installability proof and not lockfile proof."
 
 shopt -s nullglob
 archives=("$PACKAGE_DIR"/package/assay-cli-*.crate)

--- a/scripts/ci/test_assay_cli_crate_readme.sh
+++ b/scripts/ci/test_assay_cli_crate_readme.sh
@@ -4,6 +4,9 @@
 # workspace-dep fixtures, root Cargo.toml / Cargo.lock / the checker.
 # Restore only what this script created. Do not blanket-delete
 # crates/assay-cli/docs. Do not git checkout -- the whole tree.
+# Unpublished fixtures rewrite assay-* path+version workspace.dependencies
+# to the never-published sentinel 0.0.0-unpublished (any current
+# workspace.package version). Do not require a successor crates.io version.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -105,7 +108,16 @@ if [[ ! -f "$README" ]]; then
 fi
 
 SCRATCH="$(mktemp -d)"
-trap 'restore_tree; rm -rf "$SCRATCH"' EXIT
+REPLAY_SCRATCHES=()
+cleanup_all() {
+  restore_tree
+  rm -rf "$SCRATCH"
+  local d
+  for d in "${REPLAY_SCRATCHES[@]+"${REPLAY_SCRATCHES[@]}"}"; do
+    rm -rf "$d" "${d}.tar"
+  done
+}
+trap cleanup_all EXIT
 cp "$MANIFEST" "$SCRATCH/Cargo.toml"
 cp "$README" "$SCRATCH/README.md"
 cp "$ROOT_MANIFEST" "$SCRATCH/root-Cargo.toml"
@@ -430,24 +442,140 @@ run_oversized_gnu_longname() {
   fi
 }
 
+run_consumer_replay() {
+  if [[ -n "$SELECTED_CASE" ]]; then
+    return 0
+  fi
+  if [[ "${ASSAY_CLI_CRATE_README_REPLAY:-}" == "1" ]]; then
+    return 0
+  fi
+
+  local rc_sha="31335cc3a2c33c2621fd1cbf100e48e07dedbea6"
+  local main_sha=""
+  if git -C "$ROOT" rev-parse --verify origin/main >/dev/null 2>&1; then
+    main_sha="$(git -C "$ROOT" rev-parse origin/main)"
+  elif git -C "$ROOT" rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1; then
+    main_sha="$(git -C "$ROOT" rev-parse refs/remotes/origin/main)"
+  else
+    main_sha="$(git -C "$ROOT" rev-parse HEAD^)"
+  fi
+  echo "consumer-replay main_sha=$main_sha rc_sha=$rc_sha"
+
+  materialize_replay_tree() {
+    local sha="$1"
+    local dest="$2"
+    local tarball="${dest}.tar"
+    if ! git -C "$ROOT" archive --format=tar -o "$tarball" "$sha" 2>/dev/null; then
+      if ! git -C "$ROOT" fetch --no-filter origin "$sha"; then
+        echo "FAIL: could not fetch $sha for crate-README consumer replay" >&2
+        rm -f "$tarball"
+        return 1
+      fi
+      if ! git -C "$ROOT" archive --format=tar -o "$tarball" "$sha"; then
+        echo "FAIL: git archive $sha failed for crate-README consumer replay" >&2
+        rm -f "$tarball"
+        return 1
+      fi
+    fi
+    mkdir -p "$dest"
+    tar -xf "$tarball" -C "$dest"
+    rm -f "$tarball"
+  }
+
+  replay_one() {
+    local label="$1"
+    local sha="$2"
+    local dest out packaged case_name case_out needle
+    dest="$(mktemp -d "/tmp/ruley-cli-crate-readme-replay-${label}-XXXXXX")"
+    REPLAY_SCRATCHES+=("$dest")
+    echo "consumer-replay $label materializing $sha into $dest"
+    if ! materialize_replay_tree "$sha" "$dest"; then
+      echo "FAIL: consumer replay $label could not materialize $sha" >&2
+      return 1
+    fi
+    mkdir -p "$dest/scripts/ci"
+    cp "$CHECK" "$dest/scripts/ci/check_assay_cli_crate_readme.sh"
+    cp "$ROOT/scripts/ci/test_assay_cli_crate_readme.sh" "$dest/scripts/ci/test_assay_cli_crate_readme.sh"
+    chmod +x "$dest/scripts/ci/check_assay_cli_crate_readme.sh" \
+      "$dest/scripts/ci/test_assay_cli_crate_readme.sh"
+
+    out="$SCRATCH/replay-${label}-unmodified.out"
+    if ! (cd "$dest" && bash ./scripts/ci/check_assay_cli_crate_readme.sh >"$out" 2>&1); then
+      echo "FAIL: consumer replay $label unmodified checker failed" >&2
+      cat "$out" >&2
+      return 1
+    fi
+    for needle in \
+      "assay-cli crate-owned README OK" \
+      "not installability proof" \
+      "not lockfile proof"; do
+      if ! grep -Fq "$needle" "$out"; then
+        echo "FAIL: consumer replay $label unmodified checker missed: $needle" >&2
+        cat "$out" >&2
+        return 1
+      fi
+    done
+    packaged="$(grep -E '^[[:space:]]*Packaging assay-cli ' "$out" | head -n 1 || true)"
+    echo "consumer-replay $label unmodified OK ${packaged:-}"
+
+    for case_name in unpublished-workspace-dep unpublished-workspace-dep-requires-exclude-lockfile; do
+      case_out="$SCRATCH/replay-${label}-${case_name}.out"
+      if ! (
+        cd "$dest"
+        ASSAY_CLI_CRATE_README_CASE="$case_name" \
+          ASSAY_CLI_CRATE_README_REPLAY=1 \
+          bash ./scripts/ci/test_assay_cli_crate_readme.sh >"$case_out" 2>&1
+      ); then
+        echo "FAIL: consumer replay $label $case_name" >&2
+        cat "$case_out" >&2
+        return 1
+      fi
+      echo "consumer-replay $label $case_name OK"
+    done
+
+    rm -rf "$dest" "${dest}.tar"
+  }
+
+  # RC pin first so a fetch failure fails the test without skipping.
+  replay_one "rc" "$rc_sha"
+  replay_one "main" "$main_sha"
+}
+
 bump_unpublished_workspace() {
   python3 - "$ROOT_MANIFEST" <<'PY'
 from pathlib import Path
 import re
 import sys
 
+SENTINEL = "0.0.0-unpublished"
 path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
-if text.count('version = "5.4.0"') < 1:
-    raise SystemExit("expected workspace.package version 5.4.0 for unpublished fixture")
-text = text.replace('version = "5.4.0"', 'version = "5.5.0"', 1)
-text, n = re.subn(
-    r'(?m)^(assay-[\w-]+ = \{ path = "[^"]+", version = )"5\.4\.0"',
-    r'\g<1>"5.5.0"',
+pkg = re.search(r"(?ms)^\[workspace\.package\]\s*$(.+?)(?=^\[|\Z)", text)
+if not pkg:
+    raise SystemExit("could not read [workspace.package] for unpublished fixture")
+ver = re.search(r'(?m)^\s*version\s*=\s*"([^"]+)"\s*$', pkg.group(1))
+if not ver:
+    raise SystemExit("could not read workspace.package version for unpublished fixture")
+if ver.group(1) == SENTINEL:
+    raise SystemExit("workspace.package version is already the unpublished sentinel")
+
+changed = [0]
+
+def repl_dep(match: re.Match[str]) -> str:
+    if match.group(2) == SENTINEL:
+        return match.group(0)
+    changed[0] += 1
+    return f'{match.group(1)}"{SENTINEL}"'
+
+text, _ = re.subn(
+    r'(?m)^(assay-[\w-]+ = \{ path = "[^"]+", version = )"([^"]+)"',
+    repl_dep,
     text,
 )
-if n < 1:
-    raise SystemExit("expected assay-* workspace.dependencies versions to bump")
+if changed[0] < 1:
+    raise SystemExit(
+        "expected assay-* workspace.dependencies path+version to rewrite to unpublished sentinel"
+    )
 path.write_text(text, encoding="utf-8")
 PY
 }
@@ -860,3 +988,5 @@ fi
 
 echo "mutation_count=$mutation_count expected=$EXPECTED_CASES"
 echo "assay-cli crate README mutations OK"
+
+run_consumer_replay

--- a/scripts/ci/test_assay_cli_crate_readme.sh
+++ b/scripts/ci/test_assay_cli_crate_readme.sh
@@ -108,16 +108,7 @@ if [[ ! -f "$README" ]]; then
 fi
 
 SCRATCH="$(mktemp -d)"
-REPLAY_SCRATCHES=()
-cleanup_all() {
-  restore_tree
-  rm -rf "$SCRATCH"
-  local d
-  for d in "${REPLAY_SCRATCHES[@]+"${REPLAY_SCRATCHES[@]}"}"; do
-    rm -rf "$d" "${d}.tar"
-  done
-}
-trap cleanup_all EXIT
+trap 'restore_tree; rm -rf "$SCRATCH"' EXIT
 cp "$MANIFEST" "$SCRATCH/Cargo.toml"
 cp "$README" "$SCRATCH/README.md"
 cp "$ROOT_MANIFEST" "$SCRATCH/root-Cargo.toml"
@@ -440,105 +431,6 @@ run_oversized_gnu_longname() {
     cat "$out" >&2
     return 1
   fi
-}
-
-run_consumer_replay() {
-  if [[ -n "$SELECTED_CASE" ]]; then
-    return 0
-  fi
-  if [[ "${ASSAY_CLI_CRATE_README_REPLAY:-}" == "1" ]]; then
-    return 0
-  fi
-
-  local rc_sha="31335cc3a2c33c2621fd1cbf100e48e07dedbea6"
-  local main_sha=""
-  if git -C "$ROOT" rev-parse --verify origin/main >/dev/null 2>&1; then
-    main_sha="$(git -C "$ROOT" rev-parse origin/main)"
-  elif git -C "$ROOT" rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1; then
-    main_sha="$(git -C "$ROOT" rev-parse refs/remotes/origin/main)"
-  else
-    main_sha="$(git -C "$ROOT" rev-parse HEAD^)"
-  fi
-  echo "consumer-replay main_sha=$main_sha rc_sha=$rc_sha"
-
-  materialize_replay_tree() {
-    local sha="$1"
-    local dest="$2"
-    local tarball="${dest}.tar"
-    if ! git -C "$ROOT" archive --format=tar -o "$tarball" "$sha" 2>/dev/null; then
-      if ! git -C "$ROOT" fetch --no-filter origin "$sha"; then
-        echo "FAIL: could not fetch $sha for crate-README consumer replay" >&2
-        rm -f "$tarball"
-        return 1
-      fi
-      if ! git -C "$ROOT" archive --format=tar -o "$tarball" "$sha"; then
-        echo "FAIL: git archive $sha failed for crate-README consumer replay" >&2
-        rm -f "$tarball"
-        return 1
-      fi
-    fi
-    mkdir -p "$dest"
-    tar -xf "$tarball" -C "$dest"
-    rm -f "$tarball"
-  }
-
-  replay_one() {
-    local label="$1"
-    local sha="$2"
-    local dest out packaged case_name case_out needle
-    dest="$(mktemp -d "/tmp/ruley-cli-crate-readme-replay-${label}-XXXXXX")"
-    REPLAY_SCRATCHES+=("$dest")
-    echo "consumer-replay $label materializing $sha into $dest"
-    if ! materialize_replay_tree "$sha" "$dest"; then
-      echo "FAIL: consumer replay $label could not materialize $sha" >&2
-      return 1
-    fi
-    mkdir -p "$dest/scripts/ci"
-    cp "$CHECK" "$dest/scripts/ci/check_assay_cli_crate_readme.sh"
-    cp "$ROOT/scripts/ci/test_assay_cli_crate_readme.sh" "$dest/scripts/ci/test_assay_cli_crate_readme.sh"
-    chmod +x "$dest/scripts/ci/check_assay_cli_crate_readme.sh" \
-      "$dest/scripts/ci/test_assay_cli_crate_readme.sh"
-
-    out="$SCRATCH/replay-${label}-unmodified.out"
-    if ! (cd "$dest" && bash ./scripts/ci/check_assay_cli_crate_readme.sh >"$out" 2>&1); then
-      echo "FAIL: consumer replay $label unmodified checker failed" >&2
-      cat "$out" >&2
-      return 1
-    fi
-    for needle in \
-      "assay-cli crate-owned README OK" \
-      "not installability proof" \
-      "not lockfile proof"; do
-      if ! grep -Fq "$needle" "$out"; then
-        echo "FAIL: consumer replay $label unmodified checker missed: $needle" >&2
-        cat "$out" >&2
-        return 1
-      fi
-    done
-    packaged="$(grep -E '^[[:space:]]*Packaging assay-cli ' "$out" | head -n 1 || true)"
-    echo "consumer-replay $label unmodified OK ${packaged:-}"
-
-    for case_name in unpublished-workspace-dep unpublished-workspace-dep-requires-exclude-lockfile; do
-      case_out="$SCRATCH/replay-${label}-${case_name}.out"
-      if ! (
-        cd "$dest"
-        ASSAY_CLI_CRATE_README_CASE="$case_name" \
-          ASSAY_CLI_CRATE_README_REPLAY=1 \
-          bash ./scripts/ci/test_assay_cli_crate_readme.sh >"$case_out" 2>&1
-      ); then
-        echo "FAIL: consumer replay $label $case_name" >&2
-        cat "$case_out" >&2
-        return 1
-      fi
-      echo "consumer-replay $label $case_name OK"
-    done
-
-    rm -rf "$dest" "${dest}.tar"
-  }
-
-  # RC pin first so a fetch failure fails the test without skipping.
-  replay_one "rc" "$rc_sha"
-  replay_one "main" "$main_sha"
 }
 
 bump_unpublished_workspace() {
@@ -989,4 +881,3 @@ fi
 echo "mutation_count=$mutation_count expected=$EXPECTED_CASES"
 echo "assay-cli crate README mutations OK"
 
-run_consumer_replay

--- a/scripts/ci/test_assay_cli_crate_readme.sh
+++ b/scripts/ci/test_assay_cli_crate_readme.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Named mutations for scripts/ci/check_assay_cli_crate_readme.sh.
-# Scratch mutations against the real crate files; restore only what this
-# script created. Do not blanket-delete crates/assay-cli/docs.
+# Scratch mutations against the real crate files plus, for unpublished
+# workspace-dep fixtures, root Cargo.toml / Cargo.lock / the checker.
+# Restore only what this script created. Do not blanket-delete
+# crates/assay-cli/docs. Do not git checkout -- the whole tree.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -10,6 +12,8 @@ cd "$ROOT"
 CHECK="$ROOT/scripts/ci/check_assay_cli_crate_readme.sh"
 MANIFEST="$ROOT/crates/assay-cli/Cargo.toml"
 README="$ROOT/crates/assay-cli/README.md"
+ROOT_MANIFEST="$ROOT/Cargo.toml"
+ROOT_LOCK="$ROOT/Cargo.lock"
 SELECTED_CASE="${ASSAY_CLI_CRATE_README_CASE:-}"
 
 CASES=(
@@ -72,6 +76,8 @@ CASES=(
   packaged-manifest-source
   missing-consumer-manifest
   disagreeing-consumer-manifest
+  unpublished-workspace-dep
+  unpublished-workspace-dep-requires-exclude-lockfile
   toolchain-single-source
 )
 EXPECTED_CASES="${#CASES[@]}"
@@ -102,10 +108,16 @@ SCRATCH="$(mktemp -d)"
 trap 'restore_tree; rm -rf "$SCRATCH"' EXIT
 cp "$MANIFEST" "$SCRATCH/Cargo.toml"
 cp "$README" "$SCRATCH/README.md"
+cp "$ROOT_MANIFEST" "$SCRATCH/root-Cargo.toml"
+cp "$ROOT_LOCK" "$SCRATCH/Cargo.lock"
+cp "$CHECK" "$SCRATCH/check_assay_cli_crate_readme.sh"
 
 restore_tree() {
   cp "$SCRATCH/Cargo.toml" "$MANIFEST"
   cp "$SCRATCH/README.md" "$README"
+  cp "$SCRATCH/root-Cargo.toml" "$ROOT_MANIFEST"
+  cp "$SCRATCH/Cargo.lock" "$ROOT_LOCK"
+  cp "$SCRATCH/check_assay_cli_crate_readme.sh" "$CHECK"
 }
 
 run_check() {
@@ -414,6 +426,86 @@ run_oversized_gnu_longname() {
   if ! grep -Fq "decompressed stream exceeds" "$out"; then
     echo "FAIL: oversized GNU longname missed stream diagnostic" >&2
     cat "$out" >&2
+    return 1
+  fi
+}
+
+bump_unpublished_workspace() {
+  python3 - "$ROOT_MANIFEST" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+if text.count('version = "5.4.0"') < 1:
+    raise SystemExit("expected workspace.package version 5.4.0 for unpublished fixture")
+text = text.replace('version = "5.4.0"', 'version = "5.5.0"', 1)
+text, n = re.subn(
+    r'(?m)^(assay-[\w-]+ = \{ path = "[^"]+", version = )"5\.4\.0"',
+    r'\g<1>"5.5.0"',
+    text,
+)
+if n < 1:
+    raise SystemExit("expected assay-* workspace.dependencies versions to bump")
+path.write_text(text, encoding="utf-8")
+PY
+}
+
+strip_exclude_lockfile_from_checker() {
+  python3 - "$CHECK" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+token = " --exclude-lockfile"
+if token not in text:
+    raise SystemExit("checker is missing --exclude-lockfile to strip")
+if "cargo package -p assay-cli --exclude-lockfile --no-verify --allow-dirty" not in text:
+    raise SystemExit("expected the real cargo package invocation to carry --exclude-lockfile")
+path.write_text(text.replace(token, ""), encoding="utf-8")
+PY
+}
+
+run_unpublished_workspace_dep() {
+  local out="$SCRATCH/unpublished-workspace-dep.out"
+  bump_unpublished_workspace
+  if ! run_check "$out"; then
+    echo "FAIL: unpublished-workspace-dep must stay green" >&2
+    cat "$out" >&2
+    return 1
+  fi
+  if ! grep -Fq "assay-cli crate-owned README OK" "$out"; then
+    echo "FAIL: unpublished-workspace-dep missed packaged README OK" >&2
+    cat "$out" >&2
+    return 1
+  fi
+  if ! grep -Fq "evidence_demo_profile.yaml" "$out"; then
+    echo "FAIL: unpublished-workspace-dep missed real cargo package member" >&2
+    cat "$out" >&2
+    return 1
+  fi
+  if ! grep -Fq "not installability proof" "$out"; then
+    echo "FAIL: unpublished-workspace-dep missed installability non-claim" >&2
+    cat "$out" >&2
+    return 1
+  fi
+  if ! grep -Fq "not lockfile proof" "$out"; then
+    echo "FAIL: unpublished-workspace-dep missed lockfile non-claim" >&2
+    cat "$out" >&2
+    return 1
+  fi
+}
+
+run_unpublished_workspace_dep_requires_exclude_lockfile() {
+  local name="unpublished-workspace-dep-requires-exclude-lockfile"
+  bump_unpublished_workspace
+  strip_exclude_lockfile_from_checker
+  expect_fail "$name" "failed to select a version"
+  if ! grep -Fq "assay-canonical" "$SCRATCH/$name.out"; then
+    echo "FAIL: mutation $name missed diagnostic: assay-canonical" >&2
+    cat "$SCRATCH/$name.out" >&2
     return 1
   fi
 }
@@ -734,6 +826,13 @@ PY
     disagreeing-consumer-manifest)
       run_consumer_manifest_failure "$name" "not crate-owned README"
       echo "PASS: $name"
+      ;;
+    unpublished-workspace-dep)
+      run_unpublished_workspace_dep
+      echo "PASS: $name"
+      ;;
+    unpublished-workspace-dep-requires-exclude-lockfile)
+      run_unpublished_workspace_dep_requires_exclude_lockfile
       ;;
     toolchain-single-source)
       run_toolchain_single_source


### PR DESCRIPTION
## Wait-gate

- Base: `c81b569fe0fcb15c546106f2d4197658223d355a` (`origin/main` pin).
- Draft branch `ruley/cli-crate-readme-unpublished-deps`. Does not merge, retarget, or land consumer #2702.

## Blocked consumer

Blocked on unpublished workspace deps in #2702 / `31335cc3` (job 99214008028 / run 33295371363). This PR does not retarget that consumer.

## Checker

`cargo package -p assay-cli --exclude-lockfile --no-verify --allow-dirty`. Asserts a real Cargo-produced `.crate`. Explicit non-claims: not installability, not lockfile.

## Fixture

Sentinel `0.0.0-unpublished` on assay-* path+version workspace deps. No 5.4.0/5.5.0 bump required. RED case is `assay-canonical = "^0.0.0-unpublished"` even after 5.5.0 is published.

## Named cases (62)

Two sentinel cases plus the existing 60. `EXPECTED_CASES` stays 62.

- `unpublished-workspace-dep` GREEN (`0.0.0-unpublished`, real `cargo package --exclude-lockfile`)
- `unpublished-workspace-dep-requires-exclude-lockfile` RED (strip flag; needles `failed to select a version` + `assay-canonical`)

Hosted job 99216983420 (run 33296505852) passed all 62 named cases, then failed only on the consumer replay that this commit removes (`fatal: ambiguous argument 'HEAD^'` on default shallow checkout).

## SHA-bound prior consumer-replay evidence (not in CI)

Recorded at test-file commit `586479eed0b0d86e1883d9289079f706601befd5`, checker commit `b5855746fe039104be8ea7f14fce434cd3118a75`:

- unmodified overlay checker on main `c81b569fe0fcb15c546106f2d4197658223d355a`: GREEN `assay-cli v5.4.0` / `assay-cli-5.4.0.crate`
- unmodified overlay checker on RC `31335cc3a2c33c2621fd1cbf100e48e07dedbea6`: GREEN `Packaging assay-cli v5.5.0`, 396 members, README OK, `evidence_demo_profile.yaml`, non-claims
- both sentinel named cases PASS on each of those two SHAs
- bump function on both trees' Cargo.toml exit 0 (no 5.4.0 literal)

This measurement is historical evidence, not a permanent suite step. Replay (hardcoded `31335cc3`, mutable `origin/main`, `HEAD^`) was accidental scope growth on GitHub's default shallow checkout and is deleted from the suite. No workflow / fetch-depth / extra fetch fallbacks.

## File scope

- `scripts/ci/check_assay_cli_crate_readme.sh`
- `scripts/ci/test_assay_cli_crate_readme.sh`

Draft. No READY.


## Current reviewed head

`fb4b222cff4b71e209ae4f9efd59c5ba9f696b06`. Independent Claude Desktop READY: https://github.com/Rul1an/assay/pull/2703#issuecomment-5467156876 . Machine review carrier: https://github.com/Rul1an/assay/pull/2703#issuecomment-5467156949 . Hosted publish-shape job `99217626698` is green on this SHA, including both sentinel cases and the complete 62-case suite. Other required checks must also finish green before merge. This supersedes the earlier draft/no-READY status above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package validation for projects with unpublished workspace dependencies.
  * Added clearer diagnostics explaining lockfile handling and package installability limitations.

* **Tests**
  * Expanded validation coverage for unpublished dependencies.
  * Added checks confirming failures are reported when required packaging options are removed.
  * Improved test isolation by restoring project configuration after mutation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->