### PR TITLE
fix(release): emit assembled README as UTF-8 on any stdout encoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,12 +512,19 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
       - name: Verify portable checksum production and flat download layout
         shell: bash
         run: |
           set -euo pipefail
           bash scripts/ci/test-write-sha256-sidecar.sh
           bash scripts/ci/test-release-assets.sh
+      - name: Verify release README renderer contract
+        shell: bash
+        run: python3 scripts/ci/test_release_quickstart.py
 
   mcp-registry-foundation:
     name: MCP Registry foundation smoke

--- a/scripts/ci/release_readme.py
+++ b/scripts/ci/release_readme.py
@@ -279,6 +279,17 @@ def render_release_readme(
     return rendered
 
 
+def emit_utf8(text: str) -> None:
+    """Write complete UTF-8 regardless of inherited stdout encoding."""
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is None:
+        sys.stdout.write(text)
+        return
+    sys.stdout.flush()
+    buffer.write(text.encode("utf-8"))
+    buffer.flush()
+
+
 def main(argv: list[str] | None = None) -> int:
     args = sys.argv[1:] if argv is None else argv
     if len(args) not in {1, 2}:
@@ -300,7 +311,7 @@ def main(argv: list[str] | None = None) -> int:
     rendered = render_release_readme(
         (ROOT / "README.md").read_text(encoding="utf-8"), tag.group(1), members=members
     )
-    sys.stdout.write(rendered)
+    emit_utf8(rendered)
     return 0
 
 

--- a/scripts/ci/test_release_quickstart.py
+++ b/scripts/ci/test_release_quickstart.py
@@ -94,6 +94,7 @@ Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0)
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
         )
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertIn("--version 5.5.0", completed.stdout)
@@ -106,6 +107,7 @@ Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0)
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
         )
         self.assertEqual(completed.returncode, 2)
 
@@ -116,6 +118,7 @@ Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0)
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
         )
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertIn("--version 5.5.0-rc.1", completed.stdout)
@@ -128,6 +131,7 @@ Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0)
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
         )
         self.assertEqual(completed.returncode, 2)
 
@@ -575,6 +579,51 @@ class ReleaseArchiveReadmeFollowOn(unittest.TestCase):
         self.assertIn('"README.md"', paths)
 
 
+# Present in the source README and outside Latin-1 / cp1252.
+OUTSIDE_LATIN1 = ("—", "✅", "📋")
+
+
+def _assemble_packed_cwd(directory: Path) -> Path:
+    for relative in load_module().PACKED_SOURCE_PATHS:
+        source = ROOT / relative
+        destination = directory / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(source.read_bytes())
+    return directory
+
+
+def _render_assembled_readme(encoding: str) -> tuple[int, bytes, bytes]:
+    with tempfile.TemporaryDirectory() as raw:
+        assembled = _assemble_packed_cwd(Path(raw))
+        readme = assembled / "README.md"
+        env = os.environ.copy()
+        env["PYTHONIOENCODING"] = encoding
+        env["PYTHONUTF8"] = "0"
+        with readme.open("wb") as stdout:
+            completed = subprocess.run(
+                [sys.executable, str(MODULE_PATH), "v5.5.0", "--assembled-cwd"],
+                cwd=assembled,
+                env=env,
+                stdout=stdout,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+        return completed.returncode, readme.read_bytes(), completed.stderr
+
+
+class ReleaseReadmeStdoutEncoding(unittest.TestCase):
+    def test_assembled_cwd_emits_complete_utf8_under_inherited_stdout_encodings(self):
+        for encoding in ("cp1252", "ascii", "utf-8"):
+            with self.subTest(encoding=encoding):
+                code, raw, stderr = _render_assembled_readme(encoding)
+                self.assertEqual(code, 0, stderr)
+                self.assertGreater(len(raw), 0)
+                rendered = raw.decode("utf-8")
+                self.assertIn(ARCHIVE_ROOT_CLAIM, rendered)
+                self.assertIn(QUICKSTART_COMMAND, rendered)
+                for marker in OUTSIDE_LATIN1:
+                    self.assertIn(marker, rendered)
+                self.assertNotIn("\ufffd", rendered)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Forces `release_readme.py` to emit complete UTF-8 at the stdout boundary so Windows packaging no longer dies on inherited cp1252 after a successful Rust build (#2705).
- Adds a real assembled-cwd subprocess regression (required packed members, `PYTHONIOENCODING=cp1252`/`ascii` plus a UTF-8 control, strict UTF-8 decode, non-ASCII preserved). Existing CLI captures now decode the child as UTF-8; `StringIO` in-process `main()` stays on the text fallback.
- Wires `scripts/ci/test_release_quickstart.py` into the existing Ubuntu/Windows `release-asset-contract` job (that job previously ran only sidecar/asset scripts). Reuses the already-pinned `setup-python` SHA. No new workflow.

Closes #2705.

## Test plan
- [x] TDD RED: assembled-cwd under cp1252 and ascii failed at `sys.stdout.write` (`UnicodeEncodeError`); UTF-8 control passed
- [x] GREEN: `python3 scripts/ci/test_release_quickstart.py` — 35 tests, 0 skipped
- [x] Mutation: remove `emit_utf8` (restore `stdout.write`) → named encoding test RED; no-op extra `return None` after flush → GREEN
- [x] GitHub Actions release-asset-contract on Windows (job 99233757873) and Ubuntu (job 99233757880), run 33302739796 at 467a3d83219dc0dfc459e1e144e764593938243e
- Independent Claude Code Desktop review READY at 467a3d83219dc0dfc459e1e144e764593938243e; findings and dispositions: https://github.com/Rul1an/assay/pull/2706#issuecomment-5467799774.

## Non-claims
- Does not move the immutable `v5.5.0` tag (`230afd2eba934dd0e598002d089a998035686792`)
- Does not publish crates.io / PyPI, create a GitHub Release, or promote the published install pin (remains v5.4.0)
- Windows renderer tests ran successfully; actual release packaging and downloaded archive bytes are not yet verified
- Does not change Rust, crate versions, or action pin versions


Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release README generation to consistently preserve UTF-8 content, including em dashes, checkmarks, and other non-ASCII characters.
  * Prevented character corruption or replacement symbols when generating release documentation in different environment encodings.

* **Tests**
  * Added automated checks covering README output across multiple system encoding settings.
  * Release verification now confirms that rendered quickstart documentation remains complete and correctly encoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->