### PR TITLE
fix(release): bind README platform coverage to release version

### DIFF
--- a/scripts/ci/check-release-surface.sh
+++ b/scripts/ci/check-release-surface.sh
@@ -223,17 +223,17 @@ check_contains_fixed() {
   fi
 }
 
-check_current_release_link() {
-  local file="$1" expected="$2"
+check_single_claim() {
+  local file="$1" expected="$2" marker="$3" label="$4"
   local claim_count expected_count
   if [ ! -f "$file" ]; then
     fail "$file: checked outward document is missing"
     return
   fi
-  claim_count="$(grep -Fc 'Current release:' "$file" || true)"
+  claim_count="$(grep -Fc -- "$marker" "$file" || true)"
   expected_count="$(grep -Fc -- "$expected" "$file" || true)"
   if [ "$claim_count" -ne 1 ] || [ "$expected_count" -ne 1 ]; then
-    fail "$file: current release link drift"
+    fail "$file: $label"
   fi
 }
 
@@ -365,8 +365,10 @@ check_rust_cli_installs docs/AIcontext/user-flows.md 1
 check_rust_cli_installs docs/use-cases/ci-gate.md 1
 
 release_link="Current release: [\`$PUBLISHED_TAG\`](https://github.com/Rul1an/assay/releases/tag/$PUBLISHED_TAG)"
-check_current_release_link README.md "$release_link"
-check_current_release_link docs/index.md "$release_link"
+check_single_claim README.md "$release_link" 'Current release:' 'current release link drift'
+check_single_claim README.md "- Published $PUBLISHED_TAG CLI archives cover " \
+  'CLI archives cover' 'platform-coverage version drift'
+check_single_claim docs/index.md "$release_link" 'Current release:' 'current release link drift'
 check_rge_bench_claims
 
 check_absent_regex SECURITY.md '@assay\.dev' \

--- a/scripts/ci/release_readme.py
+++ b/scripts/ci/release_readme.py
@@ -16,6 +16,7 @@ RELEASE_RE = re.compile(
     r"\(https://github\.com/Rul1an/assay/releases/tag/v\1\)\."
 )
 VERSION_RE = re.compile(rf"^{VERSION_PATTERN}$")
+COVERAGE_RE = re.compile(rf"^- Published v({VERSION_PATTERN}) CLI archives cover ", re.MULTILINE)
 TAG_RE = re.compile(rf"^v({VERSION_PATTERN})$")
 CHECKOUT_RE = re.compile(
     r"For v5\.5\.1, run the last command from a source checkout or an extracted published CLI archive\.\s+"
@@ -261,6 +262,8 @@ def render_release_readme(
     checkouts = CHECKOUT_RE.findall(source)
     if len(checkouts) != 1:
         raise ValueError("README must carry exactly one published-checkout sentence")
+    if len(COVERAGE_RE.findall(source)) != 1:
+        raise ValueError("README must carry exactly one platform-coverage sentence")
 
     rendered = INSTALL_RE.sub(
         f"cargo install assay-cli --version {version} --locked", source, count=1
@@ -271,6 +274,7 @@ def render_release_readme(
         count=1,
     )
     rendered = CHECKOUT_RE.sub(ARCHIVE_QUICKSTART, rendered, count=1)
+    rendered = COVERAGE_RE.sub(f"- Published v{version} CLI archives cover ", rendered, count=1)
     rendered = _rewrite_repo_links(rendered, version, assembled)
     if INSTALL_RE.findall(rendered) != [version] or RELEASE_RE.findall(rendered) != [version]:
         raise ValueError("rendered README release claims did not converge")

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -112,6 +112,8 @@ broad_rge_claim='neutral, externally reproduced conformance kit for evidence rev
 cat > "$TMP/README.md" <<'DOC'
 cargo install assay-cli --version 5.1.0 --locked
 Current release: [`v5.1.0`](https://github.com/Rul1an/assay/releases/tag/v5.1.0)
+- Published v5.1.0 CLI archives cover Linux x86_64/arm64.
+Historical note: v5.0.0 shipped earlier.
 Claude and Cursor config-path only.
 DOC
 printf '%s\n' "- [RGE-Bench](https://github.com/rge-bench/rge-bench) — $rge_claim" >> "$TMP/README.md"
@@ -176,6 +178,12 @@ if ! run_check >"$TMP/baseline.out" 2>&1; then
   exit 1
 fi
 check_release_hook_selector
+
+# Non-claim prose must not change the active published-version decision.
+cp "$TMP/README.md" "$TMP/readme-noop.backup"
+printf '\n<!-- release coverage control: no active claim changed -->\n' >> "$TMP/README.md"
+run_check >"$TMP/noop.out" 2>&1
+mv "$TMP/readme-noop.backup" "$TMP/README.md"
 
 mutation_count=0
 mutate_and_expect_failure() {
@@ -253,6 +261,15 @@ mutate_rge_pair_and_expect_failure() {
   mutation_count=$((mutation_count + 1))
   echo "PASS: $name"
 }
+
+mutate_and_expect_failure stale-platform-coverage README.md \
+  's/Published v5.1.0 CLI/Published v5.0.0 CLI/' 'platform-coverage version drift'
+mutate_and_expect_failure workspace-platform-coverage README.md \
+  's/Published v5.1.0 CLI/Published v5.2.0 CLI/' 'platform-coverage version drift'
+mutate_and_expect_failure missing-platform-coverage README.md \
+  '/CLI archives cover/d' 'platform-coverage version drift'
+append_and_expect_failure duplicate-platform-coverage README.md \
+  '- Published v5.0.0 CLI archives cover Linux x86_64/arm64.' 'platform-coverage version drift'
 
 mutate_and_expect_failure wrong-python-package docs/getting-started/index.md \
   's/pip install assay-it/pip install assay/' 'unsupported Python package'
@@ -466,8 +483,8 @@ mutate_and_expect_failure stale-codespaces-host demo/CODESPACES-PLAYBOOK.md \
   's#https://getassay.dev/install.sh#https://assay.dev/install.sh#' \
   'unrelated assay.dev onboarding URL'
 
-if [ "$mutation_count" -ne 64 ]; then
-  echo "FAIL: expected 64 release-surface mutations, observed $mutation_count" >&2
+if [ "$mutation_count" -ne 68 ]; then
+  echo "FAIL: expected 68 release-surface mutations, observed $mutation_count" >&2
   exit 1
 fi
 echo "release-surface mutations: $mutation_count observed"

--- a/scripts/ci/test_release_quickstart.py
+++ b/scripts/ci/test_release_quickstart.py
@@ -2,6 +2,7 @@
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -53,6 +54,36 @@ def fenced_block_after(document: str, marker: str) -> str:
 
 
 class ReleaseReadmeTruth(unittest.TestCase):
+    def test_platform_coverage_tracks_archive_version_not_source_pin(self):
+        module = load_module()
+        source = (ROOT / "README.md").read_text(encoding="utf-8")
+        source = re.sub(
+            r"Published v[^ ]+ CLI archives cover",
+            "Published v5.4.0 CLI archives cover",
+            source,
+        )
+        source += "\nHistorical note: v5.4.0 shipped earlier.\n"
+        for version in ("5.5.1", "5.6.0-rc.1"):
+            with self.subTest(version=version):
+                rendered = module.render_release_readme(source, version)
+                self.assertIn(f"Published v{version} CLI archives cover", rendered)
+                self.assertNotIn("Published v5.4.0 CLI archives cover", rendered)
+                self.assertIn("Historical note: v5.4.0 shipped earlier.", rendered)
+                self.assertEqual(
+                    module.render_release_readme(source + "\n", version), rendered + "\n"
+                )
+
+    def test_renderer_refuses_missing_or_duplicate_platform_coverage(self):
+        module = load_module()
+        source = (ROOT / "README.md").read_text(encoding="utf-8")
+        coverage = next(
+            line for line in source.splitlines(True) if " CLI archives cover " in line
+        )
+        for altered in (source.replace(coverage, ""), source + coverage):
+            with self.subTest(altered=altered[-120:]):
+                with self.assertRaisesRegex(ValueError, "exactly one platform-coverage sentence"):
+                    module.render_release_readme(altered, "5.6.0")
+
     def test_renderer_moves_only_active_release_claims_to_assembled_version(self):
         module = load_module()
         source = """# Assay
@@ -62,6 +93,7 @@ cargo install assay-cli --version 5.4.0 --locked
 ```
 
 Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0).
+- Published v5.4.0 CLI archives cover Linux x86_64/arm64.
 
 For v5.5.1, run the last command from a source checkout or an extracted published CLI archive.
 The installer is binary-only and does not carry the bounded quickstart assets.
@@ -82,6 +114,7 @@ Historical note: v5.3.0 shipped earlier.
         source = """cargo install assay-cli --version 5.4.0 --locked
 cargo install assay-cli --version 5.4.0 --locked
 Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0).
+- Published v5.4.0 CLI archives cover Linux x86_64/arm64.
 """
         with self.assertRaisesRegex(ValueError, "exactly one release-pinned install command"):
             module.render_release_readme(source, "5.5.0")
@@ -98,6 +131,7 @@ Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0)
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertIn("--version 5.5.0", completed.stdout)
         self.assertIn("releases/tag/v5.5.0", completed.stdout)
+        self.assertIn("Published v5.5.0 CLI archives cover", completed.stdout)
 
     def test_cli_refuses_a_bare_version_that_the_release_contract_never_emits(self):
         completed = subprocess.run(
@@ -334,6 +368,7 @@ cargo install assay-cli --version 5.4.0 --locked
 ```
 
 Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0).
+- Published v5.4.0 CLI archives cover Linux x86_64/arm64.
 
 For v5.5.1, run the last command from a source checkout or an extracted published CLI archive.
 The installer is binary-only and does not carry the bounded quickstart assets.
@@ -353,6 +388,7 @@ See [scope](docs/concepts/scope.md) and [license](LICENSE) and [quickstart](exam
         module = load_module()
         source = """cargo install assay-cli --version 5.4.0 --locked
 Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0).
+- Published v5.4.0 CLI archives cover Linux x86_64/arm64.
 """
         with self.assertRaisesRegex(ValueError, "exactly one published-checkout sentence"):
             rendered = module.render_release_readme(source, "5.5.0")
@@ -363,6 +399,7 @@ Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0)
         module = load_module()
         source = """cargo install assay-cli --version 5.4.0 --locked
 Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0).
+- Published v5.4.0 CLI archives cover Linux x86_64/arm64.
 For v5.5.1, run the last command from a source checkout or an extracted published CLI archive.
 The installer is binary-only and does not carry the bounded quickstart assets.
 For v5.5.1, run the last command from a source checkout or an extracted published CLI archive.
@@ -382,6 +419,7 @@ The installer is binary-only and does not carry the bounded quickstart assets.
         source = (
             "cargo install assay-cli --version 5.4.0 --locked\n"
             "Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0).\n"
+            "- Published v5.4.0 CLI archives cover Linux x86_64/arm64.\n"
             "For v5.5.1, run the last command from a source checkout or an extracted published CLI archive.\n"
             "The installer is binary-only and does not carry the bounded quickstart assets.\n"
             + hostile
@@ -414,6 +452,7 @@ The installer is binary-only and does not carry the bounded quickstart assets.
 PINNED_SOURCE = (
     "cargo install assay-cli --version 5.4.0 --locked\n"
     "Current release: [`v5.4.0`](https://github.com/Rul1an/assay/releases/tag/v5.4.0).\n"
+    "- Published v5.4.0 CLI archives cover Linux x86_64/arm64.\n"
     "For v5.5.1, run the last command from a source checkout or an extracted published CLI archive.\n"
     "The installer is binary-only and does not carry the bounded quickstart assets.\n"
 )


### PR DESCRIPTION
## Summary

Fixes #2708; release-integrity follow-up under #2667.

- Render the platform-coverage version from the archive's requested release version.
- Check the source README against the published installation pin, not the workspace version.
- Refuse missing/duplicate coverage sentences, preserve historical references, and exercise the existing renderer CLI.

## Verification

Candidate: `7bbf2e491296ddab4861783c482418e71bcad4f6`; base: `09e56b5d775b4a3527998b60fdafbf87ef1b268f`.
Writer worktree: `/Users/roelschuurkes/wt-codex-release-v5.5.0`. Python 3.14.3, macOS arm64.

RED before production edits: renderer tests failed on unchanged stale coverage and missing/duplicate acceptance; source fixture guard reported `FAIL: mutation stale-platform-coverage was not observed`. Tests reached the production behavior, not a missing file/setup failure.

GREEN: 37 release quickstart/renderer tests; 68 source-surface mutations detected (including stale, missing, duplicate, and workspace-leading-published coverage). The source fixture uses workspace 5.2.0 with published pin v5.1.0; unchanged/historical prose and comment-only no-op controls pass. Full selected pre-commit hooks pass, including shellcheck and cargo fmt; diff check clean. Focused renderer suite rerun on the committed SHA. No Rust or dependency changes. The existing pre-push hooks additionally ran workspace Clippy and the Linux cross-target compile gate; both hooks returned success. The Linux hook can report incomplete cross-compile coverage, so this is not a full Linux compilation claim.

Existing CI path: `ci.yml` runs `test_release_quickstart.py` in the Linux/Windows `release-asset-contract` matrix, required by the `CI` aggregator. The source fixture suite is additionally called from `test-git-fixture-env-isolation.sh` in the existing perf job. No new workflow/gate or broader trigger claim.

## Boundaries

This prevents version-attribution drift; it does not verify the stated platform inventory. No v5.5.1 asset replacement, tag change, host-discovery proof, or changes to release/install pins. Published v5.5.1 archive wording remains disclosed in the release notes.

Independent non-building exact-head review: READY, no actionable findings; six implementation mutants detected and no-op controls pass. Hosted Linux/Windows release-contract jobs pass; aggregate CI passed. Merged as 4fcf532c0c4301407c87f59b2e6759e83de34a0d after all four required contexts passed.

## Final dispositions

All four required contexts are green at the unchanged head, including CI run 33306942515. Independent review record: https://github.com/Rul1an/assay/pull/2710#issuecomment-5468207487; substantive review: https://github.com/Rul1an/assay/pull/2710#issuecomment-5468202337.

CodeRabbit's minor same-line duplicate finding was reproduced and deferred to #2711, native subissue of #2667. This guard handles the canonical single-bullet form, not arbitrary compound prose. The static VERSION_PATTERN is not attacker-controlled; the generic regex warning is inapplicable. Generic docstring-coverage advice is not a repository requirement or behavioral defect. Copilot reported quota exhaustion and does not count as review.
