### PR TITLE
docs(agent): align entrypoint authority and explain recovery

### DIFF
--- a/docs/AIcontext/codebase-overview.md
+++ b/docs/AIcontext/codebase-overview.md
@@ -1,21 +1,20 @@
 # Assay Codebase Overview
 
-> **Version**: 3.9.0 (April 2026)
-> **SOTA Status**: Trust Compiler line (MCP governance, Trust Basis, receipt portability)
+> **Authority**: [ADR-042](../architecture/ADR-042-evidence-first-positioning.md) defines product scope; [Product Support](../reference/product-support.md) records capability status. This page is a navigation map, not release proof.
 
 ## What is Assay?
 
-**Assay** is a CI-native evidence and trust compiler for agent systems. It
-compiles agent runtime signals and selected external outcomes into verifiable
-evidence and bounded Trust Basis claims. It provides:
+**Assay** publishes an open evidence profile for privileged MCP tool actions.
+The enforcing proxy is its reference producer. Decisions, observations and
+external outcomes retain their distinct evidence boundaries. Supporting surfaces include:
 
 - **Protocol policy enforcement**: Deterministic MCP tool decisions without LLM calls in CI
 - **Evidence bundles**: Offline-verifiable artifacts for audit, review, and replay
 - **Trust compiler artifacts**: Trust Basis and Trust Card outputs with explicit evidence levels
 - **External receipt lanes**: Bounded receipt imports for selected eval, decision, inventory, and score-event surfaces
 
-Policy-as-code remains an important wedge, but the current product surface is
-broader: verified evidence, bounded claims, and portable receipt contracts.
+Derived reports and imported receipts do not establish provider-side execution,
+an aggregate trust score, compliance or a safe-agent claim.
 
 ## High-Level Architecture
 
@@ -28,7 +27,7 @@ Assay is a **Rust monorepo** with multiple crates, a **Python SDK**, and compreh
 | `assay-core` | Central evaluation engine | Runner, storage, metrics API, MCP integration, trace handling, baseline/quarantine, providers |
 | `assay-cli` | Command line interface | Config loading, Runner construction, test suite execution, reporting |
 | `assay-metrics` | Standard metrics library | MustContain, SemanticSimilarity, RegexMatch, JsonSchema, ArgsValid, SequenceValid, ToolBlocklist |
-| `assay-mcp-server` | MCP server/proxy | Streaming/online policy enforcement via JSON-RPC over stdio |
+| `assay-mcp-server` | MCP server/proxy | Plain stdio exposes five review tools; separate proxy modes mediate upstream traffic. Installing the server alone does not enforce target calls. |
 | `assay-monitor` | Runtime monitoring | eBPF/LSM integration, kernel-level enforcement |
 | `assay-policy` | Policy compilation | Compiles policies into Tier 1 (kernel/LSM) and Tier 2 (userspace) |
 | `assay-evidence` | Evidence management | Generates verifiable evidence artifacts for audit/compliance (CloudEvents v1.0, JCS canonicalization, content-addressed IDs) |
@@ -209,23 +208,19 @@ Report (console/JSON/JUnit/SARIF; SARIF truncation at 25k results by default, wi
 
 ## Key Design Principles
 
-1. **Determinism**: Same input + same policy = same result (zero flakiness)
+1. **Deterministic policy**: Explicit policy evaluation is separate from judge, host and provider variability
 2. **Statelessness**: Validation requires only policy file + trace list
 3. **Deterministic policy**: Uses explicit logic, not LLMs, for policy decisions
 4. **Separation of Concerns**: CLI handles UX/config, core handles evaluation logic
 5. **Extensibility**: Metrics, providers, and policies are pluggable via traits
 
-## SOTA Features (January 2026)
+## Capability Status
 
-| Feature | Status | Description |
-|---------|--------|-------------|
-| **Judge Reliability** | ✅ Audit Grade | Randomized order default, borderline band [0.4-0.6], Adaptive Majority (2-of-3), per-suite policies, E7 Audit Evidence |
-| **E2.3 SARIF limits** | ✅ PR #160 | Deterministic truncation (default 25k), runs[0].properties.assay, sarif.omitted in run/summary; consumers use summary/run for counts |
-| **MCP Auth Hardening** | 🔄 P1 | RFC 8707 resource indicators, alg/typ/crit JWT hardening, JWKS rotation, DPoP (optional) |
-| **OTel GenAI** | 🔄 P1 | Semconv version gating, low-cardinality metrics, composable redaction policies |
-| **Replay Bundle** | ✅ In Progress (E9.1–E9.3) | Manifest, container writer, toolchain capture, path validation, provenance. Module: `assay-core/src/replay/` |
-| **CI Optimization** | ✅ Implemented | Skip kernel matrix for pure dep bumps, auto-cancel superseded runs |
-| **Self-Healing Runner** | ✅ Implemented | Health check with cache auto-heal, stale job cleanup, PR prioritization |
+Use the [support reference](../reference/product-support.md), rather than a second
+roadmap table here. The local stdio server and proxies reject unsupported
+transport-auth configuration; a historical OAuth/JWKS plan is not a supported mode.
+See the [editor recipe](../guides/editor-mcp-recipe.md) before choosing between
+review-tool installation and enforcement of a target server.
 
 ## Exit Codes & Reason Codes
 

--- a/docs/AIcontext/decision-trees.md
+++ b/docs/AIcontext/decision-trees.md
@@ -1,7 +1,7 @@
 # Decision Trees
 
 > **Purpose**: Help AI agents decide which command, approach, or pattern to use.
-> **Version**: 3.9.0 (April 2026)
+> **Authority**: [Product Support](../reference/product-support.md) for capabilities; the selected command's [CLI reference](../reference/cli/index.md) for its result contract.
 
 ## Decision Tree 1: Which Command Should I Use?
 
@@ -35,6 +35,13 @@ flowchart TD
 
 ## Decision Tree 2: Exit Code Handling
 
+Use this for evaluation commands, not as a universal interpretation of MCP
+request results or `doctor` capability reports. Process exit zero alone is not a
+policy-allow, executed action, or enforcement claim. A trace explanation requires
+both `--trace` and `--policy`; it does not accept a positional test ID.
+Use inputs compatible with the explanation parser, not an assumed conversion of
+an arbitrary wrapper policy. See the [quick-reference limitation](quick-reference.md).
+
 ```mermaid
 flowchart TD
     EXIT[Exit code?] --> E0{Code 0?}
@@ -44,8 +51,8 @@ flowchart TD
     E1 -->|Yes| TEST_FAIL[Test/Policy or Judge uncertain]
     TEST_FAIL --> REASON{reason_code?}
     REASON -->|E_JUDGE_UNCERTAIN| JUDGE_ABSTAIN[Judge abstain — review borderline / adjust threshold]
-    REASON -->|Other| EXPLAIN[Run: assay explain]
-    JUDGE_ABSTAIN --> EXPLAIN
+    REASON -->|Other| EXPLAIN[For trace decisions: assay explain --trace traces.jsonl --policy policy.yaml]
+    JUDGE_ABSTAIN --> FIX_AGENT
     EXPLAIN --> FIX_AGENT[Fix agent or relax policy]
 
     E1 -->|No| E2{Code 2?}
@@ -137,7 +144,7 @@ flowchart TD
     SYNTAX -->|Yes| PATHS[Check file paths]
 
     TYPE -->|Test failure| TEST_DEBUG[Test failure]
-    TEST_DEBUG --> EXPLAIN[assay explain]
+    TEST_DEBUG --> EXPLAIN[For trace decisions: assay explain --trace traces.jsonl --policy policy.yaml]
     EXPLAIN --> VIOLATION{Violation type?}
     VIOLATION -->|Policy| POLICY_FIX[Adjust policy or fix agent]
     VIOLATION -->|Metric| METRIC_FIX[Adjust threshold or fix output]

--- a/docs/AIcontext/index.md
+++ b/docs/AIcontext/index.md
@@ -1,20 +1,24 @@
 # AI Context Documentation
 
-> **Version**: 3.9.0 (April 2026)
-> **Last Updated**: 2026-04-29
-> **SOTA Status**: Trust Compiler line with Trust Basis, receipt portability, and schema registry
+This directory helps agents navigate the Assay codebase. It is not a release
+support matrix or an execution ledger. Start with the checked-in
+[agent contract](../../AGENTS.md), then the
+[evidence-first scope](../architecture/ADR-042-evidence-first-positioning.md) and
+[integrity boundaries](../architecture/ADR-043-evidence-chain-integrity-invariants.md).
 
-This directory contains documentation designed specifically for AI agents
-(LLMs) to understand and work with the Assay codebase. The highest-priority
-files now describe Assay as a CI-native evidence and trust compiler, not just
-as the older policy-as-code wedge.
+Assay's contract is the open evidence profile for privileged MCP tool actions.
+Its enforcing proxy is a reference producer. Policy decisions, observations and
+provider outcomes remain distinct; installation or a successful command does not
+prove that an external action occurred.
 
 ## Quick Start for AI Agents
 
 **Most Important Files to Read First:**
-1. [Quick Reference](quick-reference.md) - Command cheat sheet and common patterns
-2. [Decision Trees](decision-trees.md) - Which command/approach to use when
-3. [Codebase Overview](codebase-overview.md) - What Assay is and how it works
+1. [Product Support](../reference/product-support.md) - Capability status and explicit limits
+2. [Agent Golden Path](../guides/agent-golden-path.md) - Install-to-evidence journey
+3. [Quick Reference](quick-reference.md) - Command cheat sheet and common patterns
+4. [Decision Trees](decision-trees.md) - Which command/approach to use when
+5. [Codebase Overview](codebase-overview.md) - What Assay is and how it works
 
 ## Purpose
 
@@ -42,19 +46,17 @@ These documents provide:
 | [CI Infrastructure](ci-infrastructure.md) | **NEW** Self-hosted runner, health checks, CI optimization | Low |
 | [Run Output](run-output.md) | **NEW** run.json / summary.json contract: seeds, judge_metrics, reason_code (PR gate) | Medium |
 
-## SOTA Features (January 2026)
+## Capability And Release Truth
 
-| Feature | Status | Description |
-|---------|--------|-------------|
-| **Generate Decomposition** | ✅ Complete (RFC-003) | G1-G6 all merged. `generate.rs` split into args/model/ingest/profile/diff modules. |
-| **Code Health** | ✅ Complete (RFC-002) | E1-E5 all delivered. Store, metrics, registry, comments cleaned up. |
-| **Judge Reliability** | ✅ Audit Grade (PR #159) | E_JUDGE_UNCERTAIN (exit 1), seeds (string\|null) in run/summary/console, judge_metrics (flip_rate, abstain_rate). Randomized order, 2-of-3, per-suite policies. |
-| **E2.3 SARIF limits** | ✅ PR #160 | Deterministic truncation (default 25k results); runs[0].properties.assay when truncated; sarif.omitted in run.json/summary.json. Consumers use summary/run for authoritative counts. |
-| **MCP Auth Hardening** | 🔄 P1 | RFC 8707, alg/typ/crit, JWKS rotation, DPoP (optional) |
-| **OTel GenAI** | 🔄 P1 | Semconv versioning, low-cardinality metrics, composable redaction |
-| **Replay Bundle** | ✅ In Progress (E9.1–E9.3) | Manifest, container writer, toolchain capture, path validation, provenance |
-| **CI Optimization** | ✅ Implemented | Skip matrix tests for pure dep bumps, auto-cancel superseded runs |
-| **Self-Healing Runner** | ✅ Implemented | Health check, cache auto-heal, stale job cleanup |
+Use [Product Support](../reference/product-support.md) for capability status,
+[installation](../getting-started/installation.md) for the published install pin,
+and [Cargo.toml](../../Cargo.toml) for the workspace version. A release-preparation
+tree can legitimately lead the published version; do not duplicate those values here.
+
+The [editor recipe](../guides/editor-mcp-recipe.md) distinguishes the five local
+MCP review tools from wrapping a target server for enforcement. Plain stdio mode
+does not implement transport authentication. Host discovery and authenticated
+model use require their own evidence; static manifests do not prove either.
 
 ## Best Practices Applied
 
@@ -94,14 +96,13 @@ This documentation follows 2026 best practices for AI codebase understanding:
 - Check [User Flows](user-flows.md) Flow 2 for CI integration
 - See [Entry Points](entry-points.md) for GitHub Action configuration
 
-## Exit Code Quick Reference
+## Command Results
 
-| Code | Meaning | Common Causes |
-|------|---------|---------------|
-| 0 | Success | All tests pass |
-| 1 | Test failure | Policy violation, metric failure; **judge uncertain** → `E_JUDGE_UNCERTAIN` |
-| 2 | Config error | Invalid YAML, missing file, parse error |
-| 3 | Infra error | Judge unavailable, rate limit, timeout |
+Use the selected command's [CLI reference](../reference/cli/index.md) and typed
+output contract. Exit zero is not a universal policy-allow or enforcement result:
+`doctor` may report unavailable capabilities, and an MCP server can exit cleanly
+after returning a request-level error. Do not apply the evaluation exit table to
+every command or infer a successful provider action from process completion.
 
 **Run output (PR #159, #160):** `run.json` and `summary.json` include `seeds` (order_seed, judge_seed as string or null), `judge_metrics`, `reason_code`, and when SARIF was truncated `sarif.omitted`. Console: `Seeds: seed_version=1 order_seed=… judge_seed=…`. See [Run Output](run-output.md).
 

--- a/docs/AIcontext/quick-reference.md
+++ b/docs/AIcontext/quick-reference.md
@@ -1,14 +1,14 @@
 # Quick Reference
 
 > **Purpose**: Fast lookup for AI agents - commands, patterns, exit codes, and common operations.
-> **Version**: 3.9.0 (April 2026)
+> **Support and version authority**: [Product Support](../reference/product-support.md) and [installation](../getting-started/installation.md).
 
 ## TL;DR - What is Assay?
 
-**Assay** = CI-native evidence and trust compiler for agent systems
-- **Input**: Agent runtime signals, evidence bundles, and bounded external receipt inputs
-- **Output**: Evidence bundles, Trust Basis, Trust Card, SARIF/JUnit/CI projections
-- **Key insight**: deterministic policy and bounded evidence claims, not trust scores or dashboards
+**Assay** = an open evidence profile for privileged MCP tool actions, with a reference enforcing proxy.
+- **Input**: Policy decisions, observations, evidence bundles and bounded external receipts
+- **Output**: Offline-verifiable evidence and derived Trust Basis/Card, SARIF/JUnit/CI projections
+- **Boundary**: An allow is not proof of a provider action; imported claims do not become verified outcomes. See [ADR-042](../architecture/ADR-042-evidence-first-positioning.md).
 
 ## Most Common Commands
 
@@ -35,7 +35,16 @@ assay doctor                  # Diagnose common issues
 assay explain --trace traces.jsonl --policy policy.yaml  # Explain violations
 ```
 
-## Exit Codes
+The `explain` example requires inputs accepted by that command's trace and policy
+parser. It is not a drop-in recovery for every wrapper policy: the MCP quickstart
+policy's `schemas` section is not accepted by `explain`. Do not remove constraints
+to make a policy parse or infer that this reproduces the wrapper's decision.
+
+## Evaluation Exit Codes
+
+This is an evaluation-oriented summary, not a universal interpretation of every
+command's process status. Read the command's typed result as well: `doctor` can
+exit zero with unavailable capabilities; MCP request errors are not process exits.
 
 | Code | Name | Reason Code Pattern | When |
 |------|------|---------------------|------|
@@ -74,8 +83,8 @@ caller-controlled path elements into a shell command.
 ### Test Failures (exit 1)
 | Code | Meaning | Next Step |
 |------|---------|-----------|
-| `E_TEST_FAILED` | Test assertion failed | `assay explain <test-id>` |
-| `E_JUDGE_UNCERTAIN` | Judge returned abstain (could not decide) | Review borderline result; `assay explain <test-id>`; adjust threshold |
+| `E_TEST_FAILED` | Test assertion failed | Inspect the test result; for a trace decision use `assay explain --trace traces.jsonl --policy policy.yaml` |
+| `E_JUDGE_UNCERTAIN` | Judge returned abstain (could not decide) | Review the judge result and uncertainty; `explain` evaluates trace/policy decisions, not a positional test ID |
 | `E_POLICY_VIOLATION` | Policy rule violated | Review policy or fix agent |
 | `E_SEQUENCE_VIOLATION` | Wrong tool call order | Check sequence rules |
 


### PR DESCRIPTION
## Summary

Fixes #2712.

- Route the four highest-priority agent navigation pages to the existing agent contract, ADRs, support matrix and install-to-evidence journey.
- Remove duplicated April release/status tables without inventing another version source or removing real Trust Basis/Card commands.
- Correct invalid positional-test-ID recovery; distinguish explanation input compatibility, evaluation exits, MCP request results and capability observations.

## Verification

Candidate: `299381f74fbfa291d4812dfabe2a43150bf9fccd`, based on `4fcf532c0c4301407c87f59b2e6759e83de34a0d`.
Writer worktree: `/Users/roelschuurkes/wt-codex-release-v5.5.0`, branch `codex/aicontext-launch-navigation`.

Published macOS arm64 Assay 5.5.1 executable SHA-256 `903c22c2b32d9976535a56c200a422cecfd8f5deae1d69a5ac6382ebf443cd27`; Python 3.14.3 for the bounded scratch probe and link-check workflow logic.

- Original `explain fixture-test-id`: exit 2, empty stdout, unexpected argument.
- Correct `--trace` / `--policy` call on compatible synthetic input: exit 1 with exactly one allowed and one blocked row. This is expected denial, not a process-test failure.
- Allow-only control: exit 0, zero blocked rows.
- Shipped MCP quickstart policy: exit 2 on unsupported `schemas`, no JSON result. The docs disclose this compatibility limit; no policy constraints were removed.
- Fresh-directory `init --format json`: exit 0 and both policy.yaml/eval.yaml created. This refutes the suspected missing-file defect.
- Existing `.github/workflows/docs-link-check.yml` local-link logic passes over all four changed files.
- `scripts/ci/check-release-surface.sh` passes. `git diff --check` passes. Normal commit hooks pass, including cargo fmt.

No Rust implementation changed; no Cargo build or crate/clippy suite was started for this docs-only patch. Pre-push uses the repository's normal lightweight-diff policy, not a bypass.

## Boundaries

This is not a complete audit of every AIcontext page, a parser/schema fix, authenticated host proof, performance measurement, new transport support or a release. No new guard framework or generated file changed.

- [ ] Independent non-building final-head review.
- [ ] Required hosted CI green.

Remain draft until both are satisfied. No auto-merge or admin bypass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI Context materials with authoritative links for product support, capability status, installation pins, and version information.
  * Clarified Assay’s role as an evidence profile for privileged MCP tool actions with a reference enforcing proxy.
  * Documented supported and unsupported capabilities, including transport authentication configuration.
  * Clarified exit-code semantics and updated decision trees and examples to use `assay explain --trace traces.jsonl --policy policy.yaml`.
  * Added Quick Start guidance for Product Support and Agent Golden Path resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->