### PR TITLE
test(release): run doctor preflight before initialization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -186,7 +186,7 @@ repos:
         entry: bash scripts/ci/test-published-release-golden-path-contract.sh
         language: system
         pass_filenames: false
-        files: ^(scripts/ci/(published-release-golden-path\.sh|published_release_proxy_phase\.py|test_published_release_proxy_phase\.py|check-published-release-golden-path-contract\.py|test-published-release-golden-path-contract\.sh|safe_extract_release_archive\.py|test_safe_extract_release_archive\.py|bounded_download\.py|test_bounded_download\.py|release_attestation_enforce\.sh|release_archive_inventory\.sh|test-release-attestation-enforce\.sh|fixtures/published-release-golden-path/.*)|examples/privileged-action-gate/(mock_github_mcp\.py|baseline-approved\.json|policies/no-allowance\.yaml|run\.sh)|\.github/workflows/(published-release-golden-path|release)\.yml|\.pre-commit-config\.yaml)$
+        files: ^(scripts/ci/(published-release-golden-path\.sh|published_release_proxy_phase\.py|test_published_release_proxy_phase\.py|lib/published-release-capture\.sh|test_published_release_session_phase\.py|check-published-release-golden-path-contract\.py|test-published-release-golden-path-contract\.sh|safe_extract_release_archive\.py|test_safe_extract_release_archive\.py|bounded_download\.py|test_bounded_download\.py|release_attestation_enforce\.sh|release_archive_inventory\.sh|test-release-attestation-enforce\.sh|fixtures/published-release-golden-path/.*)|examples/privileged-action-gate/(mock_github_mcp\.py|baseline-approved\.json|policies/no-allowance\.yaml|run\.sh)|\.github/workflows/(published-release-golden-path|release)\.yml|\.pre-commit-config\.yaml)$
 
       - id: published-release-historical-retention-contract
         name: Published-release historical-retention contract

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -125,6 +125,7 @@ def validate_manifest(
         ".github/workflows/published-release-golden-path.yml",
         ".github/workflows/release.yml",
         "scripts/ci/published-release-golden-path.sh",
+        "scripts/ci/lib/published-release-capture.sh",
         "scripts/ci/published_release_proxy_phase.py",
         "scripts/ci/release_attestation_enforce.sh",
         "scripts/ci/release_archive_inventory.sh",
@@ -363,9 +364,20 @@ def validate_contract(
         "tamper failure code": 'reason_code == "E_EVIDENCE_INTEGRITY"',
         "artifact manifest": '"assay.published_release_golden_path.artifacts.v1"',
         "claim ceiling": "the harness is not a shipped release asset",
+        "diagnostic claim boundary": "Doctor reports host capabilities, not kernel enforcement performed by this journey.",
     }
     for label, fragment in required_driver_fragments.items():
         require(driver_text, fragment, f"driver lost {label}", problems)
+    session_lines = lines_between(
+        driver_text, 'pushd "$session_root"', 'run_capture "policy-validate"', problems
+    )
+    if (
+        session_lines != ['pushd "$session_root" >/dev/null', 'run_published_release_session_product']
+        or driver_lines.count('run_published_release_session_product') != 1
+    ):
+        problems.append("driver must execute the tested pre-init session in the session cwd")
+    if driver_lines.count('source "$harness_root/scripts/ci/lib/published-release-capture.sh"') != 1:
+        problems.append("driver must source the manifest-verified capture library exactly once")
     if "unset GH_TOKEN GITHUB_TOKEN PYTHONPATH" not in driver_lines:
         problems.append("release binaries must not inherit GitHub credentials")
     if "|| true" in driver_text or "set +e" in driver_text:
@@ -500,6 +512,7 @@ def validate_contract(
     required_artifacts = [
         "run-pin.json",
         "commands.ndjson",
+        "doctor.json",
         "produced.bundle.tar.gz",
         "decisions.ndjson",
         "inspect.json",

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -23,7 +23,11 @@
     },
     {
       "path": "scripts/ci/published-release-golden-path.sh",
-      "sha256": "98308c2305e037ce50bb448708690edde4dd7dd4bad6f782827fc18189dbfb00"
+      "sha256": "2ab22cec7503be0950fbc529a5a87b3b1036c617c4fd32c6090981111dbc0864"
+    },
+    {
+      "path": "scripts/ci/lib/published-release-capture.sh",
+      "sha256": "1306f274c73561c9d23932d477cb558c13af3aab579c3105587f657baec068ad"
     },
     {
       "path": "scripts/ci/published_release_proxy_phase.py",

--- a/scripts/ci/lib/published-release-capture.sh
+++ b/scripts/ci/lib/published-release-capture.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Shared by the published-release driver and its credential-free session tests.
+# Caller supplies PYTHON_BIN, JQ_BIN, commands_file, results, version and fail().
+# shellcheck disable=SC2016,SC2154
+
+record_command() {
+  local name="$1" status="$2"
+  shift 2
+  "$PYTHON_BIN" - "$commands_file" "$name" "$status" "$@" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+record = {"name": sys.argv[2], "exit_code": int(sys.argv[3]), "argv": sys.argv[4:]}
+with path.open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+PY
+}
+
+run_capture() {
+  local name="$1" expected="$2" stdout_path="$3" stderr_path="$4"
+  shift 4
+  local status=0
+  "$@" >"$stdout_path" 2>"$stderr_path" || status=$?
+  record_command "$name" "$status" "$@"
+  [[ "$status" -eq "$expected" ]] || {
+    cat "$stderr_path" >&2
+    fail "$name exited $status, expected $expected"
+  }
+}
+
+run_published_release_session_product() {
+  run_capture "doctor" 0 "$results/doctor.json" "$results/doctor.stderr" assay doctor --format json
+  "$JQ_BIN" -se --arg version "$version" '
+    length == 1 and (.[0] |
+    .schema == "assay.doctor_report.v0" and .assay_version == $version and
+    (.platform | type == "string") and
+    (.status | . == "Ready" or . == "Degraded" or . == "Unsupported") and
+    (.backend | (.selected | type == "string") and (.mode | type == "string")) and
+    (.config_check | .status == "skipped" and (.reason | type == "string")) and
+    (.landlock | ([.available, .fs_enforce, .net_enforce] | all(type == "boolean")) and
+      (.abi_probe_status | type == "string") and (.net_connect_ruleset_probe | type == "string")) and
+    (.bpf_lsm.available | type == "boolean") and
+    (.helper | [.exists, .socket_exists] | all(type == "boolean")) and
+    (.sandbox_features | [.env_scrubbing, .scoped_tmp, .fork_safe_preexec, .deny_conflict_detection] |
+      all(type == "boolean")))
+  ' "$results/doctor.json" >/dev/null || fail "doctor preflight output identity or fields drifted"
+  run_capture "init" 0 "$results/init.json" "$results/init.stderr" assay init --preset dev --hello-trace --format json
+  "$JQ_BIN" -e '.schema == "assay.init_report.v0"' "$results/init.json" >/dev/null || fail "init output identity drifted"
+}

--- a/scripts/ci/published-release-golden-path.sh
+++ b/scripts/ci/published-release-golden-path.sh
@@ -78,30 +78,6 @@ mkdir -p "$downloads" "$install_root/bin" "$harness_root" "$session_root" "$resu
 commands_file="$results/commands.ndjson"
 : >"$commands_file"
 
-record_command() {
-  local name="$1" status="$2"
-  shift 2
-  "$PYTHON_BIN" - "$commands_file" "$name" "$status" "$@" <<'PY'
-import json, pathlib, sys
-path = pathlib.Path(sys.argv[1])
-record = {"name": sys.argv[2], "exit_code": int(sys.argv[3]), "argv": sys.argv[4:]}
-with path.open("a", encoding="utf-8") as handle:
-    handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
-PY
-}
-
-run_capture() {
-  local name="$1" expected="$2" stdout_path="$3" stderr_path="$4"
-  shift 4
-  local status=0
-  "$@" >"$stdout_path" 2>"$stderr_path" || status=$?
-  record_command "$name" "$status" "$@"
-  [[ "$status" -eq "$expected" ]] || {
-    cat "$stderr_path" >&2
-    fail "$name exited $status, expected $expected"
-  }
-}
-
 # Stage only manifest-listed harness bytes, verify each digest first, and retain what was used.
 "$PYTHON_BIN" - "$HARNESS_MANIFEST" "$ROOT" "$harness_root" "$results/harness-files.json" <<'PY'
 import hashlib, json, pathlib, shutil, sys
@@ -137,6 +113,10 @@ report_path.write_text(
     encoding="utf-8",
 )
 PY
+
+# Source only the manifest-verified copy, not an unrecorded helper.
+# shellcheck source=scripts/ci/lib/published-release-capture.sh
+source "$harness_root/scripts/ci/lib/published-release-capture.sh"
 
 version="${release_tag#v}"
 release_api="$results/release-api.json"
@@ -238,8 +218,7 @@ run_capture "mcp-version" 0 "$results/mcp-version.txt" "$results/mcp-version.std
   || fail "assay-mcp-server version differs from pinned release"
 
 pushd "$session_root" >/dev/null
-run_capture "init" 0 "$results/init.json" "$results/init.stderr" assay init --preset dev --hello-trace --format json
-"$JQ_BIN" -e '.schema == "assay.init_report.v0"' "$results/init.json" >/dev/null || fail "init output identity drifted"
+run_published_release_session_product
 run_capture "policy-validate" 0 "$results/policy-validate.json" "$results/policy-validate.stderr" \
   assay policy validate --input policy.yaml --format json
 "$JQ_BIN" -e '.schema == "assay.run_summary.v1"' "$results/policy-validate.json" >/dev/null || fail "policy validation output identity drifted"
@@ -346,7 +325,8 @@ document = {
     "commands": commands,
     "claim_ceiling": (
         "The attested release binaries completed the bounded Linux x86_64 journey under the "
-        "recorded harness head and fixture digests; the harness is not a shipped release asset."
+        "recorded harness head and fixture digests; the harness is not a shipped release asset. "
+        "Doctor reports host capabilities, not kernel enforcement performed by this journey."
     ),
 }
 pathlib.Path(output_path).write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -356,7 +336,7 @@ PY
 import hashlib, json, pathlib, sys
 root, output = map(pathlib.Path, sys.argv[1:])
 required = [
-    "run-pin.json", "commands.ndjson", "produced.bundle.tar.gz", "decisions.ndjson",
+    "run-pin.json", "commands.ndjson", "doctor.json", "produced.bundle.tar.gz", "decisions.ndjson",
     "inspect.json", "verify.json", "tamper-verify.json", "enforcement.sarif",
     "release-api.json", "tag-ref.json", "attestation-summary.json",
 ]

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -33,6 +33,7 @@ bash "$ROOT/scripts/ci/test-release-attestation-enforce.sh"
 PYTHONPATH="$ROOT/scripts/ci" python3 "$ROOT/scripts/ci/test_safe_extract_release_archive.py"
 PYTHONPATH="$ROOT/scripts/ci" python3 "$ROOT/scripts/ci/test_bounded_download.py"
 PYTHONPATH="$ROOT/scripts/ci" python3 "$ROOT/scripts/ci/test_published_release_proxy_phase.py"
+PYTHONPATH="$ROOT/scripts/ci" python3 "$ROOT/scripts/ci/test_published_release_session_phase.py"
 
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
@@ -126,6 +127,19 @@ PY
     fail "proxy helper mutation stayed green: $name"
   fi
 }
+
+expect_mutation_failure \
+  "preflight-call-commented" "driver.sh" \
+  'run_published_release_session_product' '# run_published_release_session_product' \
+  "driver must execute the tested pre-init session in the session cwd" \
+  "scripts/ci/published-release-golden-path.sh"
+
+expect_mutation_failure \
+  "preflight-uses-unverified-library" "driver.sh" \
+  'source "$harness_root/scripts/ci/lib/published-release-capture.sh"' \
+  'source "$ROOT/scripts/ci/lib/published-release-capture.sh"' \
+  "driver must source the manifest-verified capture library exactly once" \
+  "scripts/ci/published-release-golden-path.sh"
 
 expect_mutation_failure \
   "attestation-removed" "driver.sh" \

--- a/scripts/ci/test_published_release_session_phase.py
+++ b/scripts/ci/test_published_release_session_phase.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Drive the release session with a CLI-observed invocation oracle, without downloads."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LIBRARY = ROOT / "scripts/ci/lib/published-release-capture.sh"
+DRIVER = ROOT / "scripts/ci/published-release-golden-path.sh"
+
+
+def doctor_report() -> dict:
+    return {
+        "schema": "assay.doctor_report.v0",
+        "assay_version": "5.5.1",
+        "platform": "linux x86_64",
+        "status": "Degraded",
+        "backend": {"selected": "Landlock", "mode": "Enforcement", "reason": "probe"},
+        "config_check": {"status": "skipped", "reason": "fresh project"},
+        "landlock": {"available": True, "fs_enforce": True, "net_enforce": True,
+                     "abi_probe_status": "ok", "net_connect_ruleset_probe": "usable"},
+        "bpf_lsm": {"available": True},
+        "helper": {"exists": False, "socket_exists": False},
+        "sandbox_features": {"env_scrubbing": True, "scoped_tmp": True,
+                             "fork_safe_preexec": True, "deny_conflict_detection": True},
+    }
+
+
+class PublishedReleaseSessionTests(unittest.TestCase):
+    def run_phase(self, *, report=None, output=None, doctor_exit=0, library=None):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory(prefix="session phase ")))
+        results = root / "results"
+        results.mkdir()
+        session = root / "session"
+        session.mkdir()
+        bindir = root / "bin"
+        bindir.mkdir()
+        (root / "control.json").write_text(json.dumps({
+            "output": output if output is not None else json.dumps(
+                doctor_report() if report is None else report),
+            "exit": doctor_exit,
+        }))
+        fake = bindir / "assay"
+        fake.write_text(f"#!{sys.executable}\n" + '''
+import json, os, pathlib, sys
+root = pathlib.Path(os.environ["TEST_ROOT"])
+with (root / "observed.jsonl").open("a") as handle:
+    handle.write(json.dumps({"argv": sys.argv[1:], "cwd": str(pathlib.Path.cwd()),
+                            "config_exists": pathlib.Path("eval.yaml").exists()}) + "\\n")
+if sys.argv[1:] == ["doctor", "--format", "json"]:
+    control = json.loads((root / "control.json").read_text())
+    print(control["output"], end="")
+    raise SystemExit(control["exit"])
+if sys.argv[1:] == ["init", "--preset", "dev", "--hello-trace", "--format", "json"]:
+    pathlib.Path("eval.yaml").write_text("created")
+    print('{"schema":"assay.init_report.v0"}')
+else:
+    raise SystemExit(92)
+''')
+        fake.chmod(0o755)
+        source = root / "capture.sh"
+        source.write_text(LIBRARY.read_text() if library is None else library)
+        script = '''set -euo pipefail
+fail() { echo "FAIL: $*" >&2; exit 1; }
+PYTHON_BIN=''' + shlex.quote(sys.executable) + '''
+JQ_BIN=/usr/bin/jq
+version=5.5.1
+results="$TEST_ROOT/results"
+session_root="$TEST_ROOT/session"
+commands_file="$results/commands.ndjson"
+: > "$commands_file"
+source ''' + shlex.quote(str(source)) + '''
+cd "$session_root"
+run_published_release_session_product
+'''
+        env = {**os.environ, "TEST_ROOT": str(root), "PATH": f"{bindir}:/usr/bin:/bin"}
+        result = subprocess.run(["bash", "-c", script], env=env, capture_output=True,
+                                text=True, timeout=15)
+        observed = [json.loads(line) for line in (root / "observed.jsonl").read_text().splitlines()]
+        recorded = [json.loads(line) for line in (results / "commands.ndjson").read_text().splitlines()]
+        return result, observed, recorded, results, session
+
+    def assert_session_contract(self, phase):
+        result, observed, recorded, results, session = phase
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual([row["argv"][0] for row in observed], ["doctor", "init"])
+        self.assertEqual([row["name"] for row in recorded], ["doctor", "init"])
+        self.assertEqual([row["argv"][1:] for row in recorded], [row["argv"] for row in observed])
+        self.assertTrue(all(row["cwd"] == str(session.resolve()) for row in observed))
+        self.assertTrue(all(not row["config_exists"] for row in observed))
+        self.assertEqual(json.loads((results / "doctor.json").read_text()), doctor_report())
+
+    def test_doctor_executes_before_init_and_preserves_observations(self):
+        self.assert_session_contract(self.run_phase())
+
+    def test_missing_reordered_and_comment_only_preflight_are_detected(self):
+        library = LIBRARY.read_text()
+        start = library.index('  run_capture "doctor"')
+        end = library.index('  run_capture "init"', start)
+        doctor = library[start:end]
+        missing = library[:start] + library[end:]
+        head, tail = missing.rsplit("}\n", 1)
+        variants = {
+            "missing": missing,
+            "after-init": head + doctor + "}\n" + tail,
+            "comment-only": library[:start] + '  # assay doctor --format json\n' + library[end:],
+        }
+        self.assert_session_contract(self.run_phase(library=library + "\n# unchanged control\n"))
+        for name, changed in variants.items():
+            with self.subTest(name=name):
+                phase = self.run_phase(library=changed)
+                self.assertEqual(phase[0].returncode, 0, phase[0].stderr)
+                with self.assertRaises(AssertionError):
+                    self.assert_session_contract(phase)
+
+    def test_invalid_or_empty_doctor_output_stops_before_init(self):
+        for output in ("", "{", "{}", "null", "[]", json.dumps(doctor_report()) * 2):
+            with self.subTest(output=output):
+                result, observed, _, _, _ = self.run_phase(output=output)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual([row["argv"][0] for row in observed], ["doctor"])
+
+    def run_recording(self, results, *, driver=None):
+        # Execute the production encoder/retention block with synthetic preceding artifacts.
+        # These placeholders are not release or attestation proof.
+        for name in ("produced.bundle.tar.gz", "decisions.ndjson", "inspect.json",
+                     "verify.json", "tamper-verify.json", "enforcement.sarif",
+                     "release-api.json", "tag-ref.json"):
+            (results / name).write_text("fixture")
+        (results / "attestation-summary.json").write_text('{"assets":[]}')
+        (results / "harness-files.json").write_text('{"files":[]}')
+        for directory, suffix in (("release-assets", ".tar.gz"), ("attestation-raw", ".json")):
+            folder = results / directory
+            folder.mkdir(exist_ok=True)
+            for name in ("cli", "mcp"):
+                (folder / (name + suffix)).write_text("fixture")
+        driver = DRIVER.read_text() if driver is None else driver
+        start = driver.index('"$PYTHON_BIN" - "$release_tag" "$source_digest"')
+        end = driver.index('echo "PASS: published release', start)
+        env = {**os.environ, "PYTHON_BIN": sys.executable, "results": str(results),
+               "commands_file": str(results / "commands.ndjson"), "release_tag": "v5.5.1",
+               "source_digest": "a" * 40, "harness_sha": "b" * 40, "workflow_run_id": "123",
+               "workflow_run_attempt": "1", "driver_digest": "c" * 64,
+               "harness_manifest_digest": "d" * 64}
+        return subprocess.run(["bash", "-euc", driver[start:end]], env=env,
+                              capture_output=True, text=True, timeout=15)
+
+    def test_doctor_is_required_retained_and_content_hashed(self):
+        result, _, _, results, _ = self.run_phase()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        recorded = self.run_recording(results)
+        self.assertEqual(recorded.returncode, 0, recorded.stderr)
+        rows = json.loads((results / "retained-artifacts.json").read_text())["files"]
+        row = next(row for row in rows if row["path"] == "doctor.json")
+        self.assertEqual(row["sha256"], hashlib.sha256((results / "doctor.json").read_bytes()).hexdigest())
+        for remove in (False, True):
+            with self.subTest(remove=remove):
+                if remove:
+                    (results / "doctor.json").unlink()
+                else:
+                    (results / "doctor.json").write_text("")
+                failed = self.run_recording(results)
+                self.assertNotEqual(failed.returncode, 0)
+                self.assertIn("required retained artifact is missing or empty: doctor.json", failed.stderr)
+
+    def test_capability_true_does_not_become_an_executed_enforcement_claim(self):
+        result, _, _, results, _ = self.run_phase()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        recorded = self.run_recording(results)
+        self.assertEqual(recorded.returncode, 0, recorded.stderr)
+        pin = json.loads((results / "run-pin.json").read_text())
+        self.assertIn("Doctor reports host capabilities, not kernel enforcement performed by this journey.",
+                      pin["claim_ceiling"])
+        self.assertEqual([row["name"] for row in pin["commands"]], ["doctor", "init"])
+
+    def test_nonzero_doctor_with_valid_json_stops_before_init(self):
+        result, observed, recorded, _, _ = self.run_phase(doctor_exit=2)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual([row["argv"][0] for row in observed], ["doctor"])
+        self.assertEqual(recorded[0]["exit_code"], 2)
+
+    def test_wrong_identity_or_mistyped_capability_is_not_a_preflight(self):
+        changes = (("schema", "other"), ("assay_version", "0.0.0"),
+                   ("status", 1), ("landlock", {}), ("bpf_lsm", {"available": "false"}),
+                   ("backend", {"selected": "Landlock", "mode": False}),
+                   ("config_check", {"status": "valid"}))
+        for key, value in changes:
+            with self.subTest(key=key):
+                report = doctor_report()
+                report[key] = value
+                result, observed, _, _, _ = self.run_phase(report=report)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual([row["argv"][0] for row in observed], ["doctor"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #2670 once hosted proof and independent review pass.

- Execute `assay doctor --format json` in the fresh session before initialization; require exactly one typed report for the selected release and preserve pre-init configuration `skipped`.
- Source shared capture/session functions from the manifest-verified harness copy. Keep current init/deny/evidence/tamper paths unchanged.
- Retain and hash `doctor.json`; explicitly separate capability observations from kernel enforcement performed by this journey.

## Verification

Candidate SHA: `c6f9f3cc06434696bc2e37469f730cc5addc9a4f`. Base: `81f054ccbcef3f4e47e1580087969c7c3eb9a90b`.
Writer worktree: `/Users/roelschuurkes/wt-codex-2670-doctor-preflight`; Codex sole writer. Python 3.14.3, macOS arm64.

RED before implementation: four initial behavioral tests failed in 14 assertions against the existing session (actual observed argv only init; malformed/missing doctor output did not prevent success). Additional retention/cardinality checks produced four assertion failures before the fix. These were assertion failures, not missing imports or harness setup failures.

GREEN: seven session-test methods including subcases. A fake CLI independently records argv, cwd and config existence while the real capture/session library executes. Tests reject removed/reordered/comment-only doctor steps, empty/malformed/multiple JSON, wrong identity/types, valid JSON with nonzero doctor exit, and missing/empty retained doctor output. A comment-only no-op passes. The real artifact encoder hashes retained doctor bytes. No synthetic fixture result is presented as a released binary run.

- Full `test-published-release-golden-path-contract.sh`, including its existing suite and structural mutation checks, passes.
- Full pre-commit hooks pass; shellcheck, `cargo fmt --all -- --check`, and `git diff --check` pass.
- Existing captured macOS report with Unsupported/NoopAudit/config_check=skipped accepted unchanged by the new library. This is report replay only, not new host proof.
- Lane classifier over the seven changed paths: `Gate.NONE`, no delegated kernel proof requested.

No Rust code changed. The normal pre-push hook nevertheless ran workspace clippy (excluding assay-it and assay-ebpf) with warnings denied because the changed scripts fall outside its lightweight-diff allowlist; it passed. No separate Rust test-suite run is claimed. Existing hook verification remains enabled.

## Outstanding Gates

- [x] Exact-head published v5.5.1 Linux x86_64 workflow run, retained commands proving doctor before init and matching doctor artifact digest.
- [x] Independent non-building final-head review.
- [ ] Required CI checks green.

Independent review completed; normal required checks must pass before landing. No bypass or new release. No editor/model-auth proof, provider-side effect verification, all-diagnostics coverage, or claim of kernel enforcement from doctor capability observations.

## Hosted verification history

Normal push hooks completed successfully at the candidate SHA, including workspace clippy and the Linux cross-target compile gate. No hook bypass was used. The published v5.5.1 journey was dispatched as [run 33325044048](https://github.com/Rul1an/assay/actions/runs/33325044048). Dispatch is not a successful result; artifact verification and independent review remain open.

Hosted artifact inspection completed: run 33325044048 succeeds at this head; artifact 9735976210 ZIP digest independently matches GitHub; all 41 retained hashes and 12 harness hashes verified. Doctor is command 5 immediately before init 6 (zero-based), with Degraded/Landlock/config skipped observations preserved. See the SHA-bound proof comment. Independent review remains missing.


## Final-Head Independent Review

Non-building Codex reviewer Ramanujan (`01a053fc-25f3-7352-a481-7877e3b8f72b`) returned READY, no actionable findings, on `c6f9f3cc06434696bc2e37469f730cc5addc9a4f` / base `81f054ccbcef3f4e47e1580087969c7c3eb9a90b`. The coordinating writer does not count toward quorum. [Executed independent review](https://github.com/Rul1an/assay/pull/2715#issuecomment-5470683786), [machine-readable record](https://github.com/Rul1an/assay/pull/2715#issuecomment-5470683896), and [hosted proof](https://github.com/Rul1an/assay/pull/2715#issuecomment-5470167898). The hosted-proof URL in one line of the relayed report incorrectly names issue2670; the correct PR2715 link is provided here (same comment ID and evidence).

Native suite and eleven behavioral failure probes plus no-op were independently executed, and all41 retained hashes/all12 harness hashes inspected. No kernel enforcement, fresh editor auth, or new release is claimed. Historical statements above about a missing review are superseded by this exact-head record. Readying the PR triggers the required review-record check; only green current-head checks permit landing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured capture of release-session commands, outputs, and exit statuses.
  * Added validated diagnostic reporting for host capabilities before session initialization.
  * Added `doctor.json` to retained release artifacts for easier troubleshooting.

* **Bug Fixes**
  * Release checks now stop safely when diagnostics are invalid, incomplete, or unsuccessful.
  * Improved verification of command order, execution context, and recorded results.

* **Tests**
  * Expanded automated coverage for session sequencing, artifact retention, diagnostic validation, and contract enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->