### PR TITLE
docs(adequacy): distinguish RFC dependency rules from wrapper control

### DIFF
--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -343,13 +343,17 @@ reproduction target. Whether that is answered by an addendum corpus at a second
 digest or by leaving v0 pinned and honest is a contract decision rather than a
 tooling one.
 
-### Why `rfc8785` has a control and no declared rules
+### RFC 8785: dependency rules and wrapper control
 
-`crates/assay-canonical/src/jcs.rs` is a thin wrapper: it delegates to `serde_jcs`
-and declares almost no rules of its own. Rule-deletion mutation therefore does not
-apply the way it does to a corpus with its own logic — there is nothing of ours to
-delete. The question for a delegating wrapper is different: **does the corpus catch
-a wrong delegate?**
+`crates/assay-canonical/src/jcs.rs` is a thin wrapper that delegates to `serde_jcs`.
+The wrapper declares no independent serialization rules. The measured rules belong
+to the pinned `serde_jcs` dependency: UTF-16 object-key ordering,
+ECMAScript-compatible number serialization, and section 3.2.2.2 Unicode string
+emission. The result row above reports that bounded declaration, not the wrapper
+or every rule in RFC 8785.
+
+The wrapper swap is a separate control, not a scored rule. It asks a different
+question: **does the corpus catch a wrong delegate?**
 
 That control was not invented for this measurement. `tests/rfc8785_conformance.rs`
 documents it in prose at the top of the file: swap `serde_jcs::to_vec` for
@@ -363,9 +367,10 @@ exactly: `8 of 31 RFC 8785 vectors diverged`, and the named vector is among them
 That is now executable rather than a paragraph.
 
 What the control does **not** establish is coverage of RFC 8785 itself. It shows
-the corpus bites against **one** wrong implementation. Whether it bites against the
-other plausible ones is a question about RFC coverage rather than about our code,
-and it is open.
+the corpus bites against **one** wrong implementation. The dependency measurement
+separately exercises its declared near-misses; neither result establishes RFC
+certification, full corpus coverage, or implementation-wide adequacy. Other
+plausible changes outside that declaration remain unmeasured.
 
 Every manifest must declare at least one **control** — a mutation on the same
 path that MUST be killed. All-survivors because a corpus is weak and

--- a/conformance/INDEX.md.in
+++ b/conformance/INDEX.md.in
@@ -343,13 +343,17 @@ reproduction target. Whether that is answered by an addendum corpus at a second
 digest or by leaving v0 pinned and honest is a contract decision rather than a
 tooling one.
 
-### Why `rfc8785` has a control and no declared rules
+### RFC 8785: dependency rules and wrapper control
 
-`crates/assay-canonical/src/jcs.rs` is a thin wrapper: it delegates to `serde_jcs`
-and declares almost no rules of its own. Rule-deletion mutation therefore does not
-apply the way it does to a corpus with its own logic — there is nothing of ours to
-delete. The question for a delegating wrapper is different: **does the corpus catch
-a wrong delegate?**
+`crates/assay-canonical/src/jcs.rs` is a thin wrapper that delegates to `serde_jcs`.
+The wrapper declares no independent serialization rules. The measured rules belong
+to the pinned `serde_jcs` dependency: UTF-16 object-key ordering,
+ECMAScript-compatible number serialization, and section 3.2.2.2 Unicode string
+emission. The result row above reports that bounded declaration, not the wrapper
+or every rule in RFC 8785.
+
+The wrapper swap is a separate control, not a scored rule. It asks a different
+question: **does the corpus catch a wrong delegate?**
 
 That control was not invented for this measurement. `tests/rfc8785_conformance.rs`
 documents it in prose at the top of the file: swap `serde_jcs::to_vec` for
@@ -363,9 +367,10 @@ exactly: `8 of 31 RFC 8785 vectors diverged`, and the named vector is among them
 That is now executable rather than a paragraph.
 
 What the control does **not** establish is coverage of RFC 8785 itself. It shows
-the corpus bites against **one** wrong implementation. Whether it bites against the
-other plausible ones is a question about RFC coverage rather than about our code,
-and it is open.
+the corpus bites against **one** wrong implementation. The dependency measurement
+separately exercises its declared near-misses; neither result establishes RFC
+certification, full corpus coverage, or implementation-wide adequacy. Other
+plausible changes outside that declaration remain unmeasured.
 
 Every manifest must declare at least one **control** — a mutation on the same
 path that MUST be killed. All-survivors because a corpus is weak and

--- a/conformance/tests/test_published_numbers_guard.py
+++ b/conformance/tests/test_published_numbers_guard.py
@@ -166,6 +166,17 @@ class ProjectionTemplateContract(unittest.TestCase):
         errata = REPO / "conformance/privileged-mcp-action-v0/ERRATA.md"
         self.assertEqual(rendered[errata], errata.read_text(encoding="utf-8"))
 
+    def test_rfc_dependency_rules_are_distinct_from_the_wrapper_control(self):
+        rendered = project.render_documents(REPO)[REPO / "conformance/INDEX.md"]
+        template = (REPO / "conformance/INDEX.md.in").read_text(encoding="utf-8")
+        for label, document in (("template", template), ("rendered", rendered)):
+            with self.subTest(document=label):
+                self.assertNotIn("### Why `rfc8785` has a control and no declared rules", document)
+                prose = " ".join(document.split())
+                self.assertIn("The wrapper declares no independent serialization rules.", prose)
+                self.assertIn("The measured rules belong to the pinned `serde_jcs` dependency", prose)
+                self.assertIn("The wrapper swap is a separate control, not a scored rule.", prose)
+
     def test_expression_dsl_does_not_return_through_templates_or_checker(self):
         sources = [
             REPO / "conformance/adequacy/check_published_numbers.py",


### PR DESCRIPTION
Closes #2666.

## Scope and pins

Head: `66f662b52b0549eb73894fc558346a209d2860a0`
Base: `2c3d203664b0808f359bf8a86216828b05c781fb`
Writer: Codex, `codex/2666-rfc-narrative`, `/Users/roelschuurkes/wt-codex-2666-rfc-narrative`.

Three paths only:
- `conformance/INDEX.md.in`: distinguish the pinned dependency's declared rules from Assay's thin wrapper and separate connectivity control.
- `conformance/INDEX.md`: regenerated by the existing projector, not independently edited.
- `conformance/tests/test_published_numbers_guard.py`: pin the distinction in both the source template and real rendered document.

The old heading said RFC 8785 had no declared rules even though the same page's result row reports three. This corrects that subject boundary; it adds no measurement or rule.

## Verification

Python 3.14.3, rustc 1.96.0 on macOS arm64. Final tree is committed at the head above.

- Baseline suite at base: 41 tests pass.
- RED: the new named regression test failed twice, on the old heading in template and rendered output. This was an assertion failure, not a missing fixture/import failure.
- GREEN: complete published-number guard suite 42 tests pass; the focused regression was also rerun after commit.
- Existing projector `--check` and `check_published_numbers.py` pass.
- Existing `adequacy_serde_jcs.py verify-vendor` and full `self-test` pass. The latter was run with one local Rust lane and `CARGO_BUILD_JOBS=2`.
- `cargo fmt --all -- --check` and `git diff --check` pass. Normal commit hooks pass/skip by their configured path scope.

Scratch mutations changed the actual template and regenerated output together, so a projection-drift failure could not substitute for the new semantic assertion:
- restored old no-rules heading: named regression fails;
- attributed rules to the wrapper: named regression fails;
- described the wrapper control as a scored rule: named regression fails;
- harmless comment control: passes;
- restored original scratch contents: passes.

`results.json`, manifests, vectors, subject/vendor bytes, RFC harness and crate sources are unchanged from base. Existing published 3/3 result is preserved, not re-scored by this PR. Public non-claims explicitly retain no RFC certification, full corpus coverage or implementation-wide adequacy.

## Landing

Draft pending one independent non-building exact-head review and required hosted checks. Builder verification is not quorum. No release/tag change is needed. Any push requires a fresh SHA-bound review or the contract's valid upstream-only equivalence record.

Normal pre-push hooks completed successfully, including workspace clippy and the configured Linux cross-target hook. This is not a Linux runtime/host proof; hosted CI remains separate. No hook was bypassed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified RFC 8785 conformance documentation to distinguish wrapper controls from rules measured in the pinned serialization dependency.
  * Documented the specific dependency rules covered, including key ordering, number serialization, and Unicode string emission.
  * Clarified that the measurements do not establish RFC certification or comprehensive implementation-wide adequacy.
* **Tests**
  * Added checks ensuring the updated conformance wording appears consistently in both source templates and published documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->