### PR TITLE
fix(release): reject same-line duplicate coverage claims

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -383,7 +383,7 @@ repos:
         pass_filenames: false
         # Triggers on the files it can be wrong about, plus itself. It does not need a binary: with
         # no `target/` build it still verifies source and published-release truth independently.
-        files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag)\.sh|\.github/assay-release-tag|Cargo\.toml|README\.md|SECURITY\.md|llms\.txt|mkdocs\.yml|examples/mcp-quickstart/README\.md|docs/(COMMUNITY\.md|index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.devcontainer/welcome\.sh|demo/CODESPACES-PLAYBOOK\.md|\.pre-commit-config\.yaml)$
+        files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag)\.sh|scripts/ci/(release_readme|test_release_quickstart)\.py|\.github/assay-release-tag|Cargo\.toml|README\.md|SECURITY\.md|llms\.txt|mkdocs\.yml|examples/mcp-quickstart/README\.md|docs/(COMMUNITY\.md|index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.devcontainer/welcome\.sh|demo/CODESPACES-PLAYBOOK\.md|\.pre-commit-config\.yaml)$
 
 
 

--- a/scripts/ci/check-release-surface.sh
+++ b/scripts/ci/check-release-surface.sh
@@ -366,8 +366,22 @@ check_rust_cli_installs docs/use-cases/ci-gate.md 1
 
 release_link="Current release: [\`$PUBLISHED_TAG\`](https://github.com/Rul1an/assay/releases/tag/$PUBLISHED_TAG)"
 check_single_claim README.md "$release_link" 'Current release:' 'current release link drift'
-check_single_claim README.md "- Published $PUBLISHED_TAG CLI archives cover " \
-  'CLI archives cover' 'platform-coverage version drift'
+if ! python3 - "$PUBLISHED_VERSION" <<'PY'
+from pathlib import Path
+import sys
+from scripts.ci.release_readme import platform_coverage_version
+
+try:
+    actual = platform_coverage_version(Path("README.md").read_text(encoding="utf-8"))
+    if actual != sys.argv[1]:
+        raise ValueError(f"coverage version {actual} differs from published {sys.argv[1]}")
+except (ValueError, OSError) as error:
+    print(error, file=sys.stderr)
+    raise SystemExit(1)
+PY
+then
+  fail 'README.md: platform-coverage version drift'
+fi
 check_single_claim docs/index.md "$release_link" 'Current release:' 'current release link drift'
 check_rge_bench_claims
 

--- a/scripts/ci/release_readme.py
+++ b/scripts/ci/release_readme.py
@@ -247,6 +247,17 @@ def _rewrite_repo_links(source: str, version: str, members: frozenset[str]) -> s
     return "".join(out)
 
 
+def platform_coverage_version(source: str) -> str:
+    """Require one canonical bullet and one reserved marker, including same-line occurrences.
+
+    This recognizes the literal 'CLI archives cover', not arbitrary prose claims.
+    """
+    versions = COVERAGE_RE.findall(source)
+    if len(versions) != 1 or source.count("CLI archives cover") != 1:
+        raise ValueError("README must carry exactly one platform-coverage sentence")
+    return versions[0]
+
+
 def render_release_readme(
     source: str, version: str, members: frozenset[str] | None = None
 ) -> str:
@@ -262,8 +273,7 @@ def render_release_readme(
     checkouts = CHECKOUT_RE.findall(source)
     if len(checkouts) != 1:
         raise ValueError("README must carry exactly one published-checkout sentence")
-    if len(COVERAGE_RE.findall(source)) != 1:
-        raise ValueError("README must carry exactly one platform-coverage sentence")
+    platform_coverage_version(source)
 
     rendered = INSTALL_RE.sub(
         f"cargo install assay-cli --version {version} --locked", source, count=1

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -13,6 +13,7 @@ mkdir -p "$TMP/scripts/ci" "$TMP/.github" "$TMP/docs/getting-started" "$TMP/docs
   "$TMP/examples/mcp-quickstart" "$TMP/crates/assay-x" "$TMP/bin" "$TMP/.devcontainer" \
   "$TMP/demo"
 cp "$ROOT/scripts/ci/check-release-surface.sh" "$TMP/scripts/ci/"
+cp "$ROOT/scripts/ci/release_readme.py" "$TMP/scripts/ci/"
 cp "$ROOT/scripts/ci/read-assay-release-tag.sh" "$TMP/scripts/ci/"
 cp "$ROOT/.pre-commit-config.yaml" "$TMP/"
 printf '%s\n' 'v5.1.0' > "$TMP/.github/assay-release-tag"
@@ -156,6 +157,8 @@ pattern = re.compile(files_lines[0])
 for path in (
     ".github/assay-release-tag",
     "scripts/ci/read-assay-release-tag.sh",
+    "scripts/ci/release_readme.py",
+    "scripts/ci/test_release_quickstart.py",
     "llms.txt",
     "examples/mcp-quickstart/README.md",
     "docs/getting-started/ci-integration.md",
@@ -182,6 +185,7 @@ check_release_hook_selector
 # Non-claim prose must not change the active published-version decision.
 cp "$TMP/README.md" "$TMP/readme-noop.backup"
 printf '\n<!-- release coverage control: no active claim changed -->\n' >> "$TMP/README.md"
+printf '\nHistorical note: v5.0.0 shipped earlier.\n' >> "$TMP/README.md"
 run_check >"$TMP/noop.out" 2>&1
 mv "$TMP/readme-noop.backup" "$TMP/README.md"
 
@@ -270,6 +274,10 @@ mutate_and_expect_failure missing-platform-coverage README.md \
   '/CLI archives cover/d' 'platform-coverage version drift'
 append_and_expect_failure duplicate-platform-coverage README.md \
   '- Published v5.0.0 CLI archives cover Linux x86_64/arm64.' 'platform-coverage version drift'
+mutate_and_expect_failure same-line-current-platform-coverage README.md \
+  '/CLI archives cover/s/$/ Published v5.1.0 CLI archives cover obsolete./' 'platform-coverage version drift'
+mutate_and_expect_failure same-line-stale-platform-coverage README.md \
+  '/CLI archives cover/s/$/ Published v5.0.0 CLI archives cover obsolete./' 'platform-coverage version drift'
 
 mutate_and_expect_failure wrong-python-package docs/getting-started/index.md \
   's/pip install assay-it/pip install assay/' 'unsupported Python package'
@@ -483,8 +491,8 @@ mutate_and_expect_failure stale-codespaces-host demo/CODESPACES-PLAYBOOK.md \
   's#https://getassay.dev/install.sh#https://assay.dev/install.sh#' \
   'unrelated assay.dev onboarding URL'
 
-if [ "$mutation_count" -ne 68 ]; then
-  echo "FAIL: expected 68 release-surface mutations, observed $mutation_count" >&2
+if [ "$mutation_count" -ne 70 ]; then
+  echo "FAIL: expected 70 release-surface mutations, observed $mutation_count" >&2
   exit 1
 fi
 echo "release-surface mutations: $mutation_count observed"

--- a/scripts/ci/test_release_quickstart.py
+++ b/scripts/ci/test_release_quickstart.py
@@ -101,7 +101,7 @@ class ReleaseReadmeTruth(unittest.TestCase):
                 (root / "README.md").write_text(control, encoding="utf-8")
                 result = subprocess.run(
                     [sys.executable, str(script), "v5.6.0", "--assembled-cwd"],
-                    cwd=root, capture_output=True, text=True, timeout=10,
+                    cwd=root, capture_output=True, text=True, encoding="utf-8", timeout=10,
                 )
                 self.assertEqual(result.returncode, 0, result.stderr)
                 self.assertIn("Published v5.6.0 CLI archives cover", result.stdout)
@@ -116,7 +116,7 @@ class ReleaseReadmeTruth(unittest.TestCase):
                     )
                     result = subprocess.run(
                         [sys.executable, str(script), "v5.6.0", "--assembled-cwd"],
-                        cwd=root, capture_output=True, text=True, timeout=10,
+                        cwd=root, capture_output=True, text=True, encoding="utf-8", timeout=10,
                     )
                     self.assertNotEqual(result.returncode, 0, result.stdout)
                     self.assertIn("exactly one platform-coverage sentence", result.stderr)

--- a/scripts/ci/test_release_quickstart.py
+++ b/scripts/ci/test_release_quickstart.py
@@ -84,6 +84,44 @@ class ReleaseReadmeTruth(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "exactly one platform-coverage sentence"):
                     module.render_release_readme(altered, "5.6.0")
 
+    def test_cli_refuses_two_coverage_claims_on_one_line(self):
+        source = (ROOT / "README.md").read_text(encoding="utf-8")
+        coverage = next(line for line in source.splitlines() if " CLI archives cover " in line)
+        current = re.search(r"Published v([^ ]+)", coverage).group(1)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            script = root / "scripts/ci/release_readme.py"
+            script.parent.mkdir(parents=True)
+            script.write_bytes(MODULE_PATH.read_bytes())
+            for relative in load_module().PACKED_SOURCE_PATHS:
+                target = root / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes((ROOT / relative).read_bytes())
+            for control in (source, source + "\nHistorical note: v5.0.0 shipped earlier.\n"):
+                (root / "README.md").write_text(control, encoding="utf-8")
+                result = subprocess.run(
+                    [sys.executable, str(script), "v5.6.0", "--assembled-cwd"],
+                    cwd=root, capture_output=True, text=True, timeout=10,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("Published v5.6.0 CLI archives cover", result.stdout)
+            for second_version in (current, "5.0.0"):
+                with self.subTest(second_version=second_version):
+                    (root / "README.md").write_text(
+                        source.replace(
+                            coverage,
+                            coverage + f" Published v{second_version} CLI archives cover obsolete.",
+                        ),
+                        encoding="utf-8",
+                    )
+                    result = subprocess.run(
+                        [sys.executable, str(script), "v5.6.0", "--assembled-cwd"],
+                        cwd=root, capture_output=True, text=True, timeout=10,
+                    )
+                    self.assertNotEqual(result.returncode, 0, result.stdout)
+                    self.assertIn("exactly one platform-coverage sentence", result.stderr)
+                    self.assertEqual(result.stdout, "")
+
     def test_renderer_moves_only_active_release_claims_to_assembled_version(self):
         module = load_module()
         source = """# Assay


### PR DESCRIPTION
## Summary

Closes #2711.

Reject a second literal `CLI archives cover` marker on the same physical Markdown line. The release archive renderer and source release-surface checker now call the same `platform_coverage_version()` function. Generic release-link checking is unchanged. Hook selection includes the shared helper and renderer tests.

## Scope and provenance

- Builder: Codex, `codex/2711-coverage-occurrences`.
- Final candidate: `41ab1c93c185c6e53c20e33dde7f7cdb387bd6df`.
- Base: `d93dbade8eadde3cb97189a914f360bca5076f9a`.
- Worktree: `/Users/roelschuurkes/wt-codex-2711-coverage-occurrences`.
- Exactly five three-dot paths: `.pre-commit-config.yaml`, `scripts/ci/release_readme.py`, `scripts/ci/check-release-surface.sh`, `scripts/ci/test_release_quickstart.py`, `scripts/ci/test-check-release-surface.sh`.
- Parent 67803ddf is an upstream merge; its first-parent includes main's CLAUDE.md pointer change. The final head adds only the encoding repair. Review scope is the five-file three-dot delta above. No source/installed version pin, README output, Rust code, or release artifact changes.

## RED then GREEN

RED before implementation: the new real-CLI test failed twice because same-line current+current and current+stale duplicate claims both returned 0. The shell fixture baseline and earlier checks passed before `same-line-current-platform-coverage` survived and stopped its battery. An initial incomplete CLI fixture failed during archive setup; that was corrected and is not counted as the behavioral RED.

Initial candidate verification at 67803ddf (Python 3.14.3, macOS arm64); final-head verification is below:

- `python3 scripts/ci/test_release_quickstart.py`: 38 tests, OK.
- `bash scripts/ci/test-check-release-surface.sh`: 70 observed mutation cases, pass.
- `cargo fmt --all -- --check`: pass; no Rust compilation.
- `shellcheck -x -S warning scripts/ci/check-release-surface.sh scripts/ci/test-check-release-surface.sh`: pass using the repository hook severity.
- `git diff --check`: pass.
- Normal commit hooks passed; normal pre-push verification runs without bypass.

## Sensitivity, at initial reviewed head 67803ddf

All deliberate faults were applied only in a disposable archive of `67803ddf13f3eabadbe4e16d6369811b288d1292`, never the writer tree. Clean baseline was green; restores and a comment-only no-op were green.

| Fault | Observation |
| --- | --- |
| Remove the shared occurrence-count condition | CLI test: exactly 2 failures; shell battery fails because same-line-current mutation was not observed |
| Remove the renderer's shared-function call | CLI test: exactly 2 failures |
| Restore source checking to the old line-counting `check_single_claim` | Shell battery fails because same-line-current mutation was not observed |

Existing missing/multiline checks remain. Positive controls include canonical current content and unrelated historical-version prose. Scratch production files were restored byte-for-byte after the experiment.

## Review and limits

Cursor independently reviewed 41ab1c93 and returned READY: https://github.com/Rul1an/assay/pull/2720#issuecomment-5476651225. The exact-head review record is retained separately. Hosted integration CI is still pending; no merge on local GREEN alone.

This recognizes one reserved literal marker plus one anchored canonical bullet. It is not a general Markdown parser or a guarantee about differently worded prose. Source coverage follows the published installation pin; archive coverage follows the assembled archive version. No Claude/Codex host authentication, skill discovery, installation, or MCP invocation claim.

## Windows follow-up

Hosted Windows on `67803ddf13f3eabadbe4e16d6369811b288d1292` correctly failed the new test: its implicit locale decoding used cp1252 while the renderer emits UTF-8. Cursor independently BLOCKED that head on the same defect; local macOS GREEN was not Windows proof.

Current head is `41ab1c93c185c6e53c20e33dde7f7cdb387bd6df`, same base. The only follow-up delta sets strict `encoding="utf-8"` on both subprocess calls in the new test, matching the existing CLI tests. A local forced-cp1252 decoding probe reproduced the original UnicodeDecodeError before repair and passes after it; all 38 renderer tests still pass. Normal commit and push hooks passed. This diagnostic is not a Windows run. Cursor's new exact-head review is READY and hosted Windows job 99447367154 on run 33379176974 passes all 38 renderer tests. Full required CI must still finish. The three scratch fault results above remain attributed to `67803ddf`, not silently relabeled as this newer head.
