### PR TITLE
ci: keep CodeRabbit summaries out of PR provenance

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+inheritance: true
+reviews:
+  high_level_summary_in_walkthrough: true


### PR DESCRIPTION
## Summary

Move automatic CodeRabbit summaries into its walkthrough comment, rather than the maintainer PR description. Keep inherited configuration, optional reviews, required checks, and the final-head body guard unchanged.

Related: #2704. Do not close that issue on this configuration change alone: it also requires a subsequent real-PR observation and resolved-configuration readback.

## Scope and provenance

- Head: `eb91cb8e2c34060a1f0dafeb41672e4e33e34a88`
- Base: `46d46d270bfea94f2ba1a2c2556e5cd1a9ff9e25`
- Writer: Codex, `/Users/roelschuurkes/wt-codex-2704-summary-walkthrough`
- Only changed file: `.coderabbit.yaml` (four lines).
- The earlier [resolved configuration export](https://github.com/Rul1an/assay/pull/2719#issuecomment-5476466430) showed defaults, automatic summaries enabled, walkthrough placement disabled, and automatic review enabled.

## Verification

- RED before adding the file: scoped configuration check rejected the missing repository configuration.
- GREEN at the head above: PyYAML 6.0.3 + jsonschema 4.26.0 validated against the fetched vendor schema, then checked inheritance and summary placement without additional review overrides.
- Scratch negative controls: placement false, inheritance false, and an added auto-review disable each rejected; unchanged control accepted. These check configuration intent, not CodeRabbit runtime behavior.
- Normal pre-commit and pre-push hooks passed, including formatting, workspace clippy and the Linux compile gate. No hooks bypassed.
- `git diff --check` clean; worktree clean after commit/push.
- Vendor schema SHA-256: `8b97de5ffa369607df632603bb830b6e8f1f470f58d2c4582cb5871a1a3c2bb7`.
- Configuration SHA-256: `de7f6b03273b9961a1eb4734251131920847e59fc69fef8baa4e3d650b447516`.

Primary semantics: [summary placement](https://docs.coderabbit.ai/pr-reviews/summaries), [configuration inheritance](https://docs.coderabbit.ai/configuration/configuration-inheritance).

## Remaining acceptance

One independent non-building exact-head review, all required checks, resolved-config readback, and one subsequent real PR showing the summary in the walkthrough without reverting the maintainer body. A single observation will not prove every future race impossible. No product release or runtime compatibility claim follows from this configuration change.
