### PR TITLE
docs(plugin): install and check CLI plus MCP prerequisites

### DIFF
--- a/docs/guides/editor-mcp-recipe.md
+++ b/docs/guides/editor-mcp-recipe.md
@@ -8,14 +8,18 @@ server command in the agent's standard MCP config.
 ## Install the Claude Code plugin
 
 The marketplace plugin packages Assay's five MCP review tools and the
-`assay-golden-path` skill. It does **not** package the server binary, invoke a target
-tool, or enforce another MCP server by itself.
+`assay-golden-path` skill. It does **not** package either required binary: the skill
+uses the `assay` CLI, and the review tools use `assay-mcp-server`. The plugin does
+not invoke a target tool or enforce another MCP server by itself.
 
 From the project where Claude Code should use Assay:
 
 ```bash
-# 1. Install the local stdio server prerequisite.
+# 1. Install both prerequisites and confirm they are on PATH.
+cargo install assay-cli --locked
 cargo install assay-mcp-server --locked
+assay version
+assay-mcp-server --version
 
 # 2. Add Assay's marketplace and install the plugin for this project.
 claude plugin marketplace add Rul1an/assay
@@ -54,6 +58,7 @@ shows old bytes, remove and reinstall `assay@assay` rather than modifying the ca
 | Observation | Layer | Next step |
 |---|---|---|
 | `assay@assay` is absent from `claude plugin list --json` | Plugin installation | Add/update the `assay` marketplace, then install the local-scope plugin. |
+| The skill cannot run `assay version` | CLI prerequisite | Run `command -v assay`, install `assay-cli` on `PATH`, then restart Claude Code. |
 | `claude mcp list` reports a spawn or command failure | Binary prerequisite | Run `command -v assay-mcp-server`, install it on `PATH`, then restart Claude Code. |
 | The server connects but reports a missing policy | Project policy root | Start Claude Code from the project or configure an explicit absolute `--policy-root`. |
 | `assay_policy_decide` returns `allowed=false` | Assay policy verdict | Inspect the matched rule and change the proposed action or the reviewed policy. This is not an installation failure. |

--- a/scripts/ci/check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/check-editor-mcp-recipe-truth.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# The executable editor MCP recipe may only describe the transport Assay actually ships.
+# The executable editor MCP recipe must retain its prerequisites and shipped transport boundary.
 #
 # WHY THIS EXISTS (#2360)
 #
@@ -115,9 +115,37 @@ fi
 require 'local stdio wrap claim retained' '(assay mcp wrap|`assay mcp wrap`)'
 require 'proxy-enforce claim retained' 'proxy-enforce'
 
+# Keep these as standalone commands in this recipe, not a general shell/Markdown grammar.
+# Comments, prose, and commands in a different H2 section cannot satisfy plugin prerequisites.
+plugin_commands="$(awk '
+  /^## / {
+    section = ($0 == "## Install the Claude Code plugin")
+    fence = 0
+    next
+  }
+  section && /^```/ {
+    if (fence) fence = 0
+    else if ($0 == "```bash") fence = 1
+    next
+  }
+  section && fence {
+    sub(/^[ \t]+/, "")
+    sub(/[ \t]+$/, "")
+    print
+  }
+' "$RECIPE")"
+for command in 'cargo install assay-cli --locked' 'cargo install assay-mcp-server --locked' \
+  'assay version' 'assay-mcp-server --version'; do
+  if printf '%s\n' "$plugin_commands" | grep -Fxq -- "$command"; then
+    ok "plugin prerequisite command present: $command"
+  else
+    fail "$RECIPE: plugin prerequisite command missing: $command"
+  fi
+done
+
 printf '\n'
 if [ "$failures" -gt 0 ]; then
-  printf 'editor MCP recipe truth: %s drift(s) from shipped transport\n' "$failures"
+  printf 'editor MCP recipe truth: %s prerequisite or shipped-transport drift(s)\n' "$failures"
   printf '\n'
   printf 'The executable recipe describes what a reader can run against a real editor today.\n'
   printf 'Assay ships the legacy stdio handshake; it does not ship remote HTTP, OAuth/OIDC or\n'

--- a/scripts/ci/check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/check-editor-mcp-recipe-truth.sh
@@ -37,6 +37,7 @@ set -euo pipefail
 cd "$(dirname "$0")/../.."
 
 RECIPE="${ASSAY_EDITOR_RECIPE:-docs/guides/editor-mcp-recipe.md}"
+MAX_RECIPE_BYTES=65536
 MODERN_REVISION='2026-07-28'
 IMPL_ISSUE='2358'
 
@@ -49,6 +50,12 @@ ok() { printf 'ok   %s\n' "$*"; }
 
 if [ ! -f "$RECIPE" ]; then
   printf 'FAIL: executable editor recipe missing: %s\n' "$RECIPE"
+  exit 1
+fi
+
+# Bound all subsequent captures, including grep diagnostics and extracted commands.
+if [ "$(wc -c < "$RECIPE")" -gt "$MAX_RECIPE_BYTES" ]; then
+  printf 'FAIL: recipe exceeds %s-byte limit: %s\n' "$MAX_RECIPE_BYTES" "$RECIPE"
   exit 1
 fi
 
@@ -118,17 +125,32 @@ require 'proxy-enforce claim retained' 'proxy-enforce'
 # Keep these as standalone commands in this recipe, not a general shell/Markdown grammar.
 # Comments, prose, and commands in a different H2 section cannot satisfy plugin prerequisites.
 plugin_commands="$(awk '
-  /^## / {
+  {
+    fence_line = $0
+    sub(/^ ? ? ?/, "", fence_line)
+  }
+  match(fence_line, /^(```+|~~~+)/) {
+    width = RLENGTH
+    mark = substr(fence_line, 1, 1)
+    rest = substr(fence_line, width + 1)
+    if (fence) {
+      if (mark == fence_mark && width >= fence_width && rest ~ /^[ \t]*$/) {
+        fence = 0
+        bash_fence = 0
+      }
+    } else {
+      fence = 1
+      fence_mark = mark
+      fence_width = width
+      bash_fence = (fence_line == "```bash")
+    }
+    next
+  }
+  !fence && /^## / {
     section = ($0 == "## Install the Claude Code plugin")
-    fence = 0
     next
   }
-  section && /^```/ {
-    if (fence) fence = 0
-    else if ($0 == "```bash") fence = 1
-    next
-  }
-  section && fence {
+  section && fence && bash_fence {
     sub(/^[ \t]+/, "")
     sub(/[ \t]+$/, "")
     print

--- a/scripts/ci/test-check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/test-check-editor-mcp-recipe-truth.sh
@@ -108,6 +108,34 @@ write_clean
 printf '\n<!-- unchanged executable recipe -->\n' >> "$TMP/recipe.md"
 expect_pass 'comment-only no-op preserves prerequisites'
 
+echo '== fenced examples cannot impersonate the plugin section =='
+for fence in '```' '````' '~~~' '   ~~~'; do
+  write_clean
+  awk -v fence="$fence" '
+    /^## Install the Claude Code plugin$/ { print fence "text" }
+    /^## The wrap command$/ { print fence }
+    { print }
+  ' "$TMP/recipe.md" > "$TMP/edited.md"
+  mv "$TMP/edited.md" "$TMP/recipe.md"
+  expect_fail "plugin section inside $fence example" \
+    'plugin prerequisite command missing: cargo install assay-cli --locked'
+done
+for heading in '## shell comment' '### subheading-shaped shell comment'; do
+  write_clean
+  awk -v heading="$heading" '{ print } /^```bash$/ { print heading }' \
+    "$TMP/recipe.md" > "$TMP/edited.md"
+  mv "$TMP/edited.md" "$TMP/recipe.md"
+  expect_pass "$heading does not end the bash fence"
+done
+
+echo '== recipe byte ceiling has an acceptance boundary =='
+write_clean
+bytes="$(wc -c < "$TMP/recipe.md")"
+printf '%*s' "$((65536 - bytes))" '' >> "$TMP/recipe.md"
+expect_pass 'recipe at 65536 bytes accepted'
+printf ' ' >> "$TMP/recipe.md"
+expect_fail 'recipe over 65536 bytes rejected' 'recipe exceeds 65536-byte limit'
+
 echo '== drift 1: stale release-candidate copy =='
 write_clean
 printf 'This section is provisional against the release candidate.\n' >> "$TMP/recipe.md"

--- a/scripts/ci/test-check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/test-check-editor-mcp-recipe-truth.sh
@@ -28,6 +28,15 @@ write_clean() {
   cat > "$TMP/recipe.md" <<'MD'
 # Editor MCP Recipe
 
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --locked
+cargo install assay-mcp-server --locked
+assay version
+assay-mcp-server --version
+```
+
 ## The wrap command
 
 Run `assay mcp wrap` to enforce policy at the protocol boundary.
@@ -74,6 +83,30 @@ expect_fail() {
 echo '== baseline: a truthful recipe passes =='
 write_clean
 expect_pass 'clean fixture passes'
+
+echo '== plugin prerequisites must be commands in the plugin installation section =='
+for command in 'cargo install assay-cli --locked' 'cargo install assay-mcp-server --locked' \
+  'assay version' 'assay-mcp-server --version'; do
+  for mode in delete comment prose elsewhere; do
+    write_clean
+    awk -v command="$command" -v mode="$mode" '
+      /^```bash$/ && mode == "prose" { print command }
+      $0 == command {
+        if (mode == "comment") print "# " $0
+        next
+      }
+      { print }
+      /^## The wrap command$/ {
+        if (mode == "elsewhere") print "\n```bash\n" command "\n```"
+      }
+    ' "$TMP/recipe.md" > "$TMP/edited.md"
+    mv "$TMP/edited.md" "$TMP/recipe.md"
+    expect_fail "$mode: $command" "plugin prerequisite command missing: $command"
+  done
+done
+write_clean
+printf '\n<!-- unchanged executable recipe -->\n' >> "$TMP/recipe.md"
+expect_pass 'comment-only no-op preserves prerequisites'
 
 echo '== drift 1: stale release-candidate copy =='
 write_clean


### PR DESCRIPTION
## Summary

Refs #2194; prerequisite repair only, not authenticated host-proof closure.

The plugin guide installed only `assay-mcp-server`, while the bundled skill begins with `assay version`. Install and version-check both packages, and distinguish CLI recovery from server recovery.

The existing recipe guard requires the four prescribed standalone commands inside the real plugin-install H2's bash fence. Code fences are tracked before headings: a section heading hidden in a non-Bash example is not an install section; a `##` shell comment is not a Markdown heading. Backtick/tilde fences and up to three-space indentation are covered. A 65536-byte file ceiling precedes diagnostic and command captures. This remains a scoped recipe check, not a general Markdown/shell execution validator.

## Exact provenance and scope

- Head: `178d88d8c6f0d69a9117b59e1d8fde723f6c20ce`
- Base: `c8063ddf8faada4b6c28900b98fa1bdf0210fffa`
- Branch: `codex/2194-plugin-cli-prerequisite`
- Writer worktree: `/Users/roelschuurkes/wt-codex-2194-plugin-cli-prerequisite`
- Three files only: guide, existing guard, existing self-test. No workflow, dependency, production/auth, generated skill, protocol or release-pin changes.
- macOS arm64; Bash 5.3.15 plus system Bash; Python 3.14.3 for scratch probes; Rust 1.96.0 for normal push hooks.

## Verification

- Initial RED: 16 new command-decoy failures against the base guard. The repaired guide then passed 32 cases at `48658cd9`.
- Optional bot feedback exposed a fence defect after that head's independent review. New RED: four misplaced-fence examples and a false rejection of a valid `##` shell comment; the over-limit fixture was also accepted before the ceiling. No merge occurred.
- Final head: 40/40 self-test cases in both Bash installations, real-guide guard, shell syntax, shellcheck, fmt and diff checks pass.
- Scratch sensitivity at final tree: omit CLI requirement -> 8 failed cases; remove section restriction -> 4; accept prose -> 4; restore old fence parser -> 5; interpret headings inside fences -> 1; raise byte ceiling by one -> 1; lower it by one -> 2. Unchanged and restored controls: 40/40 green. Scratch copies only.
- Exactly 65536 bytes accepted; 65537 rejected with the named limit diagnostic.
- Earlier Cursor READY at `48658cd9` does not carry. Fresh final-head independent review and hosted CI are tracked below; draft stays until revalidated. Normal hooks are not bypassed.

## Finding dispositions / non-claims

- Fenced-heading false-green: reproduced and fixed, with acceptance and rejection pairs.
- Unbounded capture: bounded before materialization; assumes the checked-out recipe is stable during the guard.
- Requested new release pins: not adopted in this slice. The pre-existing ordinary recipe installs latest published packages; it makes no same-version/atomic-install promise. Hardcoding the workspace release here would add a new release-coupling contract. Fixed-release installation and retained binary versions remain the separate #2194 host-proof route.
- No authenticated Claude session, fresh account, binary install, marketplace discovery or model-mediated invocation was performed. No new release or protocol acceptance is implied.
- Existing wiring test pins path selection, not deletion of the hook entry. The unchanged real-guide hook invocation was inspected and executed; no future-entry-removal coverage claim.

## Final-head independent disposition

Cursor Desktop independently returned **READY at `178d88d8c6f0d69a9117b59e1d8fde723f6c20ce`**, with no actionable blocker: https://github.com/Rul1an/assay/pull/2723#issuecomment-5479357751 . This supersedes, rather than carries, the old-head review. Its whole-old-guard probe fails 6/40; the writer's parser-only rollback retains the new ceiling and fails 5/40. A control-green rerun confirmed both.

Normal commit/push hooks passed, including workspace clippy and Linux cross-compile. Codex's plugin-install workflow self-test passed again on this head. All three optional bot findings have a recorded technical disposition; the bot confirmed both repairs and withdrew its version-pin request. No auth or host-proof claim. Awaiting final required CI before merge.
