### PR TITLE
test(mcp): bind closed protocol gate to public support claims

### DIFF
--- a/crates/assay-mcp-server/tests/modern_adapter_closed_gate.rs
+++ b/crates/assay-mcp-server/tests/modern_adapter_closed_gate.rs
@@ -20,6 +20,8 @@ use std::process::{Command, Output, Stdio};
 
 const SERVER_SRC: &str = include_str!("../src/server.rs");
 const LATEST_LEGACY_VERSION: &str = ACCEPTED_PROTOCOL_VERSIONS[2];
+const ACTIVATION_GUIDANCE: &str =
+    "#2483 requires release-bound activation evidence; preserve historical release observations";
 
 fn modern_params() -> Value {
     json!({
@@ -114,10 +116,175 @@ fn assert_cacheable(result: &Value) {
 
 #[test]
 fn shipping_accepted_set_excludes_the_modern_revision() {
-    assert!(!ACCEPTED_PROTOCOL_VERSIONS.is_empty());
-    assert!(!ACCEPTED_PROTOCOL_VERSIONS.contains(&MODERN_PROTOCOL_VERSION));
+    closed_gate(ACCEPTED_PROTOCOL_VERSIONS, &public_capabilities()).unwrap();
     assert_eq!(ERROR_UNSUPPORTED_PROTOCOL_VERSION, -32022);
     assert_eq!(ERROR_METHOD_NOT_FOUND, -32601);
+}
+
+fn public_capabilities() -> Value {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../docs/data/product-capabilities.v0.json");
+    let source = std::fs::read_to_string(path).unwrap_or_else(|error| {
+        panic!("checked-in public capability data: {error}; {ACTIVATION_GUIDANCE}")
+    });
+    serde_json::from_str(&source)
+        .unwrap_or_else(|error| panic!("public capability JSON: {error}; {ACTIVATION_GUIDANCE}"))
+}
+
+// Historical release evidence is a closed-era ceiling, not a mirror of future HEAD support.
+fn closed_gate(accepted: &[&str], capabilities: &Value) -> Result<(), String> {
+    let fail = |reason: &str| format!("{reason}; {ACTIVATION_GUIDANCE}");
+    if accepted.is_empty() || accepted.contains(&MODERN_PROTOCOL_VERSION) {
+        return Err(fail(
+            "production accepted-version set must be nonempty and exclude modern",
+        ));
+    }
+    let rows = capabilities
+        .get("capabilities")
+        .and_then(Value::as_array)
+        .ok_or_else(|| fail("capabilities must be an array"))?;
+    for id in ["published-mcp-server", "published-release-golden-path"] {
+        let mut matches = rows.iter().filter(|row| row["id"] == id);
+        let row = matches
+            .next()
+            .ok_or_else(|| fail(&format!("missing {id}")))?;
+        if matches.next().is_some() {
+            return Err(fail(&format!("duplicate {id}")));
+        }
+        let versions = row
+            .get("protocol_versions")
+            .and_then(Value::as_array)
+            .filter(|versions| !versions.is_empty())
+            .ok_or_else(|| fail(&format!("{id}: protocol_versions must be a nonempty array")))?;
+        for version in versions {
+            for field in ["protocol", "version", "transport"] {
+                if version
+                    .get(field)
+                    .and_then(Value::as_str)
+                    .filter(|s| !s.is_empty())
+                    .is_none()
+                {
+                    return Err(fail(&format!("{id}: {field} must be a nonempty string")));
+                }
+            }
+            if version["version"] == MODERN_PROTOCOL_VERSION {
+                return Err(fail(&format!("{id}: public support must exclude modern")));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn assert_closed_gate_rejects(accepted: &[&str], capabilities: &Value, reason: &str) {
+    let error = closed_gate(accepted, capabilities).expect_err("invalid closed-era claim accepted");
+    assert!(error.contains(reason), "{error}");
+    assert!(error.contains("#2483"), "{error}");
+    assert!(
+        error.contains("release-bound activation evidence"),
+        "{error}"
+    );
+}
+
+#[test]
+fn closed_gate_rejects_production_only_activation_with_owner_diagnostic() {
+    let mut accepted = ACCEPTED_PROTOCOL_VERSIONS.to_vec();
+    accepted.push(MODERN_PROTOCOL_VERSION);
+    assert_closed_gate_rejects(&accepted, &public_capabilities(), "production");
+    assert_closed_gate_rejects(&[], &public_capabilities(), "production");
+}
+
+#[test]
+fn closed_gate_rejects_public_only_activation_in_either_row() {
+    for id in ["published-mcp-server", "published-release-golden-path"] {
+        let mut capabilities = public_capabilities();
+        let row = capabilities["capabilities"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|row| row["id"] == id)
+            .unwrap();
+        row["protocol_versions"]
+            .as_array_mut()
+            .unwrap()
+            .push(json!({
+                "protocol": "mcp", "version": MODERN_PROTOCOL_VERSION, "transport": "stdio"
+            }));
+        assert_closed_gate_rejects(ACCEPTED_PROTOCOL_VERSIONS, &capabilities, id);
+    }
+}
+
+#[test]
+fn closed_gate_requires_each_public_row_and_typed_version_collection() {
+    for id in ["published-mcp-server", "published-release-golden-path"] {
+        let original = public_capabilities();
+        let mut missing = original.clone();
+        missing["capabilities"]
+            .as_array_mut()
+            .unwrap()
+            .retain(|row| row["id"] != id);
+        assert_closed_gate_rejects(ACCEPTED_PROTOCOL_VERSIONS, &missing, id);
+
+        let mut duplicate = original.clone();
+        let row = original["capabilities"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["id"] == id)
+            .unwrap()
+            .clone();
+        duplicate["capabilities"].as_array_mut().unwrap().push(row);
+        assert_closed_gate_rejects(ACCEPTED_PROTOCOL_VERSIONS, &duplicate, id);
+
+        let mut absent_versions = original.clone();
+        let row = absent_versions["capabilities"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|row| row["id"] == id)
+            .unwrap();
+        row.as_object_mut().unwrap().remove("protocol_versions");
+        assert_closed_gate_rejects(ACCEPTED_PROTOCOL_VERSIONS, &absent_versions, id);
+
+        for versions in [
+            Value::Null,
+            json!({}),
+            json!([]),
+            json!([{}]),
+            json!(["2025-11-25"]),
+            json!([{"protocol":"mcp","version":42,"transport":"stdio"}]),
+            json!([{"protocol":"mcp","version":"2025-11-25"}]),
+        ] {
+            let mut malformed = original.clone();
+            let row = malformed["capabilities"]
+                .as_array_mut()
+                .unwrap()
+                .iter_mut()
+                .find(|row| row["id"] == id)
+                .unwrap();
+            row["protocol_versions"] = versions;
+            assert_closed_gate_rejects(ACCEPTED_PROTOCOL_VERSIONS, &malformed, id);
+        }
+        for field in ["protocol", "version", "transport"] {
+            for value in [Value::Null, json!(42), json!(""), json!([])] {
+                let mut malformed = original.clone();
+                let row = malformed["capabilities"]
+                    .as_array_mut()
+                    .unwrap()
+                    .iter_mut()
+                    .find(|row| row["id"] == id)
+                    .unwrap();
+                row["protocol_versions"][0][field] = value;
+                assert_closed_gate_rejects(ACCEPTED_PROTOCOL_VERSIONS, &malformed, id);
+            }
+        }
+    }
+    for capabilities in [
+        json!({}),
+        json!({"capabilities":null}),
+        json!({"capabilities":{}}),
+    ] {
+        assert_closed_gate_rejects(ACCEPTED_PROTOCOL_VERSIONS, &capabilities, "capabilities");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #2671. Test/diagnostic-only prerequisite for #2483; **no protocol activation**.

The existing closed-gate integration test now calls one shared check over the actual accepted-version constant and the checked-in public capability data. During the closed era, production and the two relevant public support rows must omit the modern revision. Each required row must exist exactly once and carry a nonempty, typed protocol-version collection. Errors name #2483 and release-bound activation evidence, and explicitly preserve historical release observations.

This is a claim ceiling, not perpetual equality between moving HEAD support and v5.3.0 release evidence.

## Provenance and scope

- Candidate: `473348a08a52eebb5008fab00a7ac32e64e60d3c`
- Base: `4fefa91fb1ec917ebd94a5dcbef80c45985ca385`
- Branch: `codex/2671-public-support-closed-gate`
- Writer/worktree: Codex, `/Users/roelschuurkes/wt-codex-2671-public-support-closed-gate`
- Exactly one file: `crates/assay-mcp-server/tests/modern_adapter_closed_gate.rs`.
- Rust/cargo 1.96.0, macOS arm64; Python 3.14.3 orchestrated serialized counterprobes. One local Cargo lane, two jobs.
- Public capability data SHA-256 remains `7558519111dd830cd0db6dfac0b3cda27ed6f46cc04569ae5556762202e8938a`. Production, generated docs, fixtures, dependencies and workflows are unchanged.

## Verification

Rejection tests were run RED against a legacy-behavior scaffold before the check was implemented; this development RED preceded the candidate commit. Final and counterprobe results below are bound to the committed candidate above, with the stated temporary transformation.

- Focused integration suite: **12/12 passed**, including existing binary legacy negotiation and five-tool tests.
- Default-feature `cargo test -p assay-mcp-server`: **492 passed test executions**, summed across its reported test-result groups; no claim about unbuilt optional features.
- `cargo clippy -p assay-mcp-server --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `git diff --check`: pass. Normal commit hooks pass. Push-hook and hosted CI status remain separate.

### Real half-change counterprobes

Each negative runs the existing `shipping_accepted_set_excludes_the_modern_revision` test, not merely a helper fixture test. Each compiles and fails that one test with the relevant production/row diagnostic plus #2483 and release-bound evidence guidance.

| Temporary change to candidate | Result |
| --- | --- |
| Add modern to production `ACCEPTED_PROTOCOL_VERSIONS` only | test failure, exit 101 |
| Add modern to `published-mcp-server.protocol_versions` only | test failure, exit 101 |
| Add modern to `published-release-golden-path.protocol_versions` only | test failure, exit 101 |
| Remove `published-mcp-server` | test failure, exit 101 |
| Remove `published-release-golden-path` | test failure, exit 101 |
| Remove modern production exclusion from shared check | new production rejection test fails, exit 101 |
| Remove both public rows from shared check's iteration | new public rejection test fails, exit 101 |

Unchanged control, comment-only no-op, and restored control: **12/12 pass each**. All probes ran serially in the exclusively owned writer tree, with byte backups and guarded restoration after each probe; no hooks, commit, reviewer, or other writer ran concurrently. All three temporarily touched files were byte-restored, final HEAD unchanged and worktree clean. No production/data mutation is in this PR.

Missing/duplicate rows, absent/null/empty/malformed version collections and non-string/empty protocol, version and transport fields are covered by the new fixture matrix. The existing Python capability test's public-only rejection is not credited as new coverage here.

## Review / non-claims

Draft pending fresh independent exact-head review and required CI. Builder self-review is not quorum.

No new release; no accepted modern wire, remote transport, OAuth, MCP Apps, cache-policy, host-compatibility, marketplace or authenticated-model claim. Historical v5.3.0 evidence is unchanged and must not be rewritten to satisfy a future activation. This scoped check is not a complete capability-schema validator. Existing wire-process bounds are not changed by this slice.

Normal pre-push workspace clippy and Linux cross-target checks passed before publication. No hook bypass. The local crate build outputs were partially cleaned after verification to recover disk headroom; the measurements above are retained results, not a promise that every binary remains cached.
