### PR TITLE
docs(architecture): map the four names for what was in force, and unbreak the check that blocked it

### DIFF
--- a/.github/workflows/docs-auto-update.yml
+++ b/.github/workflows/docs-auto-update.yml
@@ -50,6 +50,11 @@ jobs:
           chmod +x scripts/docs/generate-module-map.sh
           scripts/docs/generate-module-map.sh
 
+      - name: Generate configuration vocabulary crosswalk
+        run: |
+          chmod +x scripts/docs/generate-configuration-vocabulary-crosswalk.py
+          scripts/docs/generate-configuration-vocabulary-crosswalk.py
+
       - name: Update architecture diagrams
         run: |
           chmod +x scripts/docs/update-architecture-docs.sh

--- a/docs/architecture/CONFIGURATION-VOCABULARY-CROSSWALK.md
+++ b/docs/architecture/CONFIGURATION-VOCABULARY-CROSSWALK.md
@@ -1,0 +1,56 @@
+# Configuration vocabulary crosswalk
+
+**Generated** by `scripts/docs/generate-configuration-vocabulary-crosswalk.py`. Do not
+hand-edit: re-run it instead, or the map goes stale silently, which is the failure it
+exists to prevent.
+
+Derived from the committed record corpus by that script. It deliberately records **no**
+commit stamp: this file is regenerated and committed by the docs workflow, so a stamp would
+name the commit before its own, making the file permanently stale against `--check`.
+Freshness is enforced by re-running, not by a date.
+
+Several record schemas here carry a digest or version pinning *what was in force* when a
+tool decision was made, under different field names. Nothing else says how they relate, so
+a reader who meets one of them can reasonably assume the others mean the same thing. They
+do not.
+
+**No claim in this codebase depends on configuration** — the claim gate knows
+`PositiveExistence`, `ExhaustiveSet` and `BoundedNegative`, all about observation coverage.
+This is a legibility map, not a correctness mechanism, and it justifies no code change.
+
+Field subjects below are read from the producing code, never inferred from the field name.
+Inferring from names is exactly the error this page prevents.
+
+## Schemas found in the corpus
+
+| schema | documents | configuration key | populated | what it is a statement about |
+|---|---|---|---|---|
+| `assay.tool_decision_surface.v0` | 10 | `server.declared_manifest_digest` | 10/10 | The MCP server's declared tool manifest — what the server advertised it could do. The server compares against it and can report `declared_manifest_digest_mismatch`. |
+| `assay.tool_decision_truth.otel_projection.v0` | 1 | `spans[].attributes.assay.tdt.declared_policy_digest` | 2/2 | The same fact as `assay.tool_decision_truth.v0`, carried as OpenTelemetry span attributes. |
+| `assay.tool_decision_truth.v0` | 1 | `declared_policy_digest` | 1/1 | The declared constraint set the decision was taken under: `McpPolicy::declared_constraint_digest_experimental`, binding tool name, args schema, identity, classes, approval, scope and redaction. Decision identity is the pair `(observed_input_digest, declared_policy_digest)`. |
+| `assay.tool_decision_truth.vectors.v0` | 1 | `policies.<name>.version` | 1/1 | A named policy variant a vector exercises. A version label, not a digest over content: comparable for identity between records sharing a naming scheme, not recomputable from bytes. |
+
+## How they relate
+
+Stated as relations with a **direction**, not as equality. Only one pair below earns
+"equivalent", and only one way.
+
+| pair | relation | direction | note |
+|---|---|---|---|
+| `assay.tool_decision_truth.v0` → `…otel_projection.v0` | projection | one way only | The span attributes carry the same fact. Reconstructing the carrier from the projection is **not** claimed: a projection may drop fields. |
+| `assay.tool_decision_surface.v0` ↔ `assay.tool_decision_truth.v0` | different subjects | no derivation either way | A server tool manifest is what the server advertised; a declared constraint set is the rule the decision was measured against. Both answer "what was in force", about different things. |
+| `assay.tool_decision_truth.vectors.v0` ↔ any digest field | different kind of statement | no derivation | A version names a variant; a digest commits to content. |
+
+## Declared in a type, instantiated nowhere
+
+**PayloadToolDecision (assay-evidence)** — `policy_digest, policy_snapshot_digest (+_alg/_canonicalization/_schema), tool_definition_digest (+_alg/_canonicalization/_schema/_source), args_schema_hash`
+
+All optional, no doc comments, and populated by no committed fixture. Semantics are stated nowhere and there is no instance to read them from, so **no relation to any field above can be asserted**. `policy_digest` reads like a shorter `declared_policy_digest`; that resemblance is a name, not evidence.
+
+## Rules this map follows
+
+- **Not stated is a finding, not a gap.** A schema with no curated subject is emitted as
+  such rather than omitted.
+- **A mapping is itself a claim.** Saying two fields are the same fact needs a stated
+  relation and a direction.
+- **No new vocabulary.** This map references what exists and mints nothing.

--- a/scripts/ci/check-assay-action-pin.sh
+++ b/scripts/ci/check-assay-action-pin.sh
@@ -329,15 +329,47 @@ def should_skip(rel: str) -> bool:
     return any(rel.startswith(prefix) for prefix in SKIP_PREFIXES)
 
 
+def tracked_paths() -> "set[str] | None":
+    """Paths git has under version control in TREE, or None if TREE is not a worktree.
+
+    None means "scan everything", which is what the self-test needs: it runs the checker against
+    a synthetic tree assembled in a scratch directory that is deliberately not a git repository.
+    Enumerating from git unconditionally would leave every planted violation there invisible and
+    quietly turn the negative cases green.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(TREE), "ls-files", "-z"],
+            capture_output=True,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return {name.decode("utf-8", "surrogateescape") for name in out.split(b"\0") if name}
+
+
 def walk_unlisted() -> None:
+    tracked = tracked_paths()
     for dirpath, dirnames, filenames in os.walk(TREE):
         dirnames[:] = [name for name in dirnames if name not in {".git", "target"}]
+        # A directory carrying its own .git is a nested checkout: a git worktree, a vendored
+        # clone. Its files are copies sitting at paths this tree does not own, so scanning them
+        # reports a violation nobody can fix here -- and because the self-test's green control
+        # runs the same walk, the failure surfaces as a broken control rather than as a finding.
+        dirnames[:] = [
+            name for name in dirnames if not (Path(dirpath) / name / ".git").exists()
+        ]
         for name in filenames:
             path = Path(dirpath) / name
             if path.suffix.lower() not in SCAN_SUFFIXES:
                 continue
             rel = rel_posix(path)
             if rel in OWNED or should_skip(rel):
+                continue
+            # Untracked working-tree files are not repository content. Local drafts and scratch
+            # survive pre-commit's stash, so scanning them charges the commit with a violation it
+            # is not introducing. Staged additions are in the index and still reach this check.
+            if tracked is not None and rel not in tracked:
                 continue
             data = bounded_read(path, allow_empty=True)
             if not data:

--- a/scripts/docs/generate-configuration-vocabulary-crosswalk.py
+++ b/scripts/docs/generate-configuration-vocabulary-crosswalk.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Generate the configuration-vocabulary crosswalk from the committed record corpus.
+
+Several record schemas in this workspace carry a digest or version pinning *what was in force*
+when a tool decision was made, under different field names. This emits a map of them.
+
+The split matters and the output states it:
+
+* **Discovered** — which schemas exist, which configuration-ish keys they carry, and how often those
+  keys are populated. Read from the tree on every run, so a new schema cannot go unnoticed.
+* **Curated** — what each field is a statement *about*, and how fields relate. That cannot be
+  derived from data; it is read from the producing code by a human and recorded in SUBJECTS below.
+
+A discovered schema with no curated entry is emitted as **semantics not stated**, which is a finding
+rather than a silent omission. That is the whole point: a hand-maintained list goes stale quietly.
+
+Usage: generate-configuration-vocabulary-crosswalk.py [--repo-root .] [--out docs/architecture/...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+
+# Keys that plausibly pin what was in force. Deliberately broad: the point is discovery, and a
+# false positive is visible in the output while a false negative is not.
+CONFIGISH = re.compile(r"(digest|policy|manifest|version|schema|source_class|identity)", re.I)
+# Keys describing the record's own format rather than the agent's configuration.
+NOT_CONFIG = {"schema", "schema_version", "specversion", "digest_alg", "canonicalization"}
+
+# CURATED. Each subject is read from the producing code, never inferred from the field name;
+# inferring from names is the error this document exists to prevent.
+SUBJECTS: dict[str, dict[str, str]] = {
+    "assay.tool_decision_surface.v0": {
+        "_field": "server.declared_manifest_digest",
+        "_subject": "The MCP server's declared tool manifest — what the server advertised it could "
+        "do. The server compares against it and can report `declared_manifest_digest_mismatch`.",
+    },
+    "assay.tool_decision_truth.v0": {
+        "_field": "declared_policy_digest",
+        "_subject": "The declared constraint set the decision was taken under: "
+        "`McpPolicy::declared_constraint_digest_experimental`, binding tool name, args schema, "
+        "identity, classes, approval, scope and redaction. Decision identity is the pair "
+        "`(observed_input_digest, declared_policy_digest)`.",
+    },
+    "assay.tool_decision_truth.otel_projection.v0": {
+        "_field": "spans[].attributes.assay.tdt.declared_policy_digest",
+        "_subject": "The same fact as `assay.tool_decision_truth.v0`, carried as OpenTelemetry span "
+        "attributes.",
+    },
+    "assay.tool_decision_truth.vectors.v0": {
+        "_field": "policies.<name>.version",
+        "_subject": "A named policy variant a vector exercises. A version label, not a digest over "
+        "content: comparable for identity between records sharing a naming scheme, not "
+        "recomputable from bytes.",
+    },
+}
+
+# CURATED. Relations carry a direction. A relation valid one way is not assumed to hold in reverse.
+RELATIONS = [
+    ("`assay.tool_decision_truth.v0` → `…otel_projection.v0`", "projection", "one way only",
+     "The span attributes carry the same fact. Reconstructing the carrier from the projection is "
+     "**not** claimed: a projection may drop fields."),
+    ("`assay.tool_decision_surface.v0` ↔ `assay.tool_decision_truth.v0`", "different subjects",
+     "no derivation either way",
+     "A server tool manifest is what the server advertised; a declared constraint set is the rule "
+     "the decision was measured against. Both answer \"what was in force\", about different things."),
+    ("`assay.tool_decision_truth.vectors.v0` ↔ any digest field", "different kind of statement",
+     "no derivation",
+     "A version names a variant; a digest commits to content."),
+]
+
+# CURATED. Declared in a type, instantiated nowhere. Regenerated warning if that ever changes.
+UNINSTANTIATED = {
+    "type": "PayloadToolDecision (assay-evidence)",
+    "fields": "policy_digest, policy_snapshot_digest (+_alg/_canonicalization/_schema), "
+    "tool_definition_digest (+_alg/_canonicalization/_schema/_source), args_schema_hash",
+    "note": "All optional, no doc comments, and populated by no committed fixture. Semantics are "
+    "stated nowhere and there is no instance to read them from, so **no relation to any field "
+    "above can be asserted**. `policy_digest` reads like a shorter `declared_policy_digest`; that "
+    "resemblance is a name, not evidence.",
+}
+
+
+def run(root: Path, *args: str) -> str:
+    return subprocess.run(["git", "-C", str(root), *args],
+                          capture_output=True, text=True, check=True).stdout
+
+
+def collect(node, prefix: str, out: dict[str, list]) -> None:
+    if isinstance(node, dict):
+        for k, v in node.items():
+            path = f"{prefix}.{k}" if prefix else k
+            if CONFIGISH.search(k) and k not in NOT_CONFIG:
+                out.setdefault(path, []).append(v)
+            collect(v, path, out)
+    elif isinstance(node, list):
+        for v in node:
+            collect(v, f"{prefix}[]", out)
+
+
+def discover(root: Path) -> dict[str, dict]:
+    found: dict[str, dict] = {}
+    for rel in run(root, "ls-tree", "-r", "--name-only", "HEAD").splitlines():
+        if not rel.endswith((".json", ".ndjson")):
+            continue
+        blob = run(root, "show", f"HEAD:{rel}")
+        if "tool_decision" not in blob and "ToolDecision" not in blob:
+            continue
+        for raw in ([blob] if rel.endswith(".json") else [x for x in blob.splitlines() if x.strip()]):
+            try:
+                doc = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(doc, dict):
+                continue
+            schema = doc.get("schema", "<no schema field>")
+            entry = found.setdefault(schema, {"files": set(), "keys": {}})
+            entry["files"].add(rel)
+            collect(doc, "", entry["keys"])
+    return found
+
+
+def render(root: Path, found: dict[str, dict]) -> str:
+    lines: list[str] = []
+    add = lines.append
+
+    add("# Configuration vocabulary crosswalk")
+    add("")
+    add("**Generated** by `scripts/docs/generate-configuration-vocabulary-crosswalk.py`. Do not")
+    add("hand-edit: re-run it instead, or the map goes stale silently, which is the failure it")
+    add("exists to prevent.")
+    add("")
+    add("Derived from the committed record corpus by that script. It deliberately records **no**")
+    add("commit stamp: this file is regenerated and committed by the docs workflow, so a stamp would")
+    add("name the commit before its own, making the file permanently stale against `--check`.")
+    add("Freshness is enforced by re-running, not by a date.")
+    add("")
+    add("Several record schemas here carry a digest or version pinning *what was in force* when a")
+    add("tool decision was made, under different field names. Nothing else says how they relate, so")
+    add("a reader who meets one of them can reasonably assume the others mean the same thing. They")
+    add("do not.")
+    add("")
+    add("**No claim in this codebase depends on configuration** — the claim gate knows")
+    add("`PositiveExistence`, `ExhaustiveSet` and `BoundedNegative`, all about observation coverage.")
+    add("This is a legibility map, not a correctness mechanism, and it justifies no code change.")
+    add("")
+    add("Field subjects below are read from the producing code, never inferred from the field name.")
+    add("Inferring from names is exactly the error this page prevents.")
+    add("")
+    add("## Schemas found in the corpus")
+    add("")
+    add("| schema | documents | configuration key | populated | what it is a statement about |")
+    add("|---|---|---|---|---|")
+    for schema in sorted(found):
+        entry = found[schema]
+        curated = SUBJECTS.get(schema)
+        keys = {k: v for k, v in entry["keys"].items() if "declared" in k or "polic" in k.lower()}
+        keyname = curated["_field"] if curated else (", ".join(sorted(keys)[:2]) or "—")
+        populated = "—"
+        for k, vals in entry["keys"].items():
+            if curated and curated["_field"].split(".")[-1] in k:
+                populated = f"{sum(1 for v in vals if v is not None)}/{len(vals)}"
+                break
+        subject = curated["_subject"] if curated else (
+            "**Semantics not stated.** This schema carries configuration-ish keys and has no curated "
+            "entry in the generator. Read the producing code and add one, or record why it does not "
+            "belong here.")
+        add(f"| `{schema}` | {len(entry['files'])} | `{keyname}` | {populated} | {subject} |")
+    add("")
+    add("## How they relate")
+    add("")
+    add("Stated as relations with a **direction**, not as equality. Only one pair below earns")
+    add("\"equivalent\", and only one way.")
+    add("")
+    add("| pair | relation | direction | note |")
+    add("|---|---|---|---|")
+    for pair, rel, direction, note in RELATIONS:
+        add(f"| {pair} | {rel} | {direction} | {note} |")
+    add("")
+    add("## Declared in a type, instantiated nowhere")
+    add("")
+    add(f"**{UNINSTANTIATED['type']}** — `{UNINSTANTIATED['fields']}`")
+    add("")
+    add(UNINSTANTIATED["note"])
+    add("")
+    add("## Rules this map follows")
+    add("")
+    add("- **Not stated is a finding, not a gap.** A schema with no curated subject is emitted as")
+    add("  such rather than omitted.")
+    add("- **A mapping is itself a claim.** Saying two fields are the same fact needs a stated")
+    add("  relation and a direction.")
+    add("- **No new vocabulary.** This map references what exists and mints nothing.")
+    # Exactly one trailing newline: the repository's end-of-file hook enforces it, and a generator
+    # whose output the hook rewrites would drift against the generated-docs-match check every run.
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo-root", default=".", type=Path)
+    ap.add_argument("--out", default="docs/architecture/CONFIGURATION-VOCABULARY-CROSSWALK.md")
+    ap.add_argument("--check", action="store_true",
+                    help="fail if the committed doc differs from freshly generated output")
+    args = ap.parse_args()
+
+    root = args.repo_root.resolve()
+    text = render(root, discover(root))
+    out = root / args.out
+    if args.check:
+        current = out.read_text() if out.exists() else ""
+        if current != text:
+            print(f"{args.out} is stale; re-run this generator")
+            return 1
+        print(f"{args.out} is current")
+        return 0
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(text)
+    print(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Two commits. The first is a prerequisite discovered while making the second: the workflow edit in
commit 2 trips a pre-commit hook that turns out to be broken in a way unrelated to this change, so
commit 1 fixes the hook and commit 2 is the actual work. They are independently reviewable.

## 1. `fix(ci)` — the assay-action consumer check scans the working directory, not the repository

`walk_unlisted()` in `scripts/ci/check-assay-action-pin.sh` walks the filesystem from the tree root,
pruning only `.git` and `target`. Two kinds of file reach it that are not repository content:

**Nested checkouts.** A git worktree created inside the tree carries a full copy of the sources, so
`crates/assay-cli/src/templates.rs` also exists at `.claude/worktrees/<name>/crates/…`. That copy is
not on the owner snippet list, because the list names the canonical path, so the walk reports it as
an unlisted consumer. Claude Code places worktrees under `.claude/worktrees/` by default, so this is
reachable without anyone opting in.

**Untracked files.** Pre-commit stashes unstaged modifications but leaves untracked files in place. A
local draft that is not in the repository, and not on the branch, was scanned as though it were.

Both surface as a *broken control* rather than as a finding, which is the part worth fixing beyond
the two cases. The self-test runs the checker over a synthetic tree it expects to be green, that run
inherits the same walk, and the message a contributor gets is:

```
== no-op control ==
FAIL: control-is-green exited non-zero:
  <some path outside your change>: assay-action uses is not on the owner snippet list
```

The check reads as broken rather than unmet, and it blocks every commit touching a workflow file
until someone goes and reads the walk.

**The fix.** Nested checkouts are pruned outright: a directory carrying its own `.git` is a separate
checkout whose files sit at paths this tree does not own. Untracked files are skipped *only when the
tree is a git worktree at all*. That condition is load-bearing, not defensive — the self-test
assembles its tree in a scratch directory that is deliberately not a repository, so enumerating from
git unconditionally would make every violation it plants invisible and turn its negative cases green
while looking like a pass.

**Verified in three parts**, because the second and third are what separate a fix from a blindfold:

| check | result |
|---|---|
| full self-test, end to end | passes — planted violations still bite where there is no git |
| real tree, untracked violating file present | ignored, which is the fix |
| real tree, violating file staged into the index | still caught |

The third is the one that matters: pre-commit runs against the index, so writing the exclusion as
"untracked or not" without the worktree condition would have silently stopped the check from ever
catching what it exists to catch.

## 2. `docs(architecture)` — a generated map of the four names for what was in force

Several record schemas carry a digest or version pinning what was in force when a tool decision was
made, under different field names, and nothing said how they relate. A reader who meets one can
reasonably assume the others mean the same thing. They do not:

- `assay.tool_decision_surface.v0` → `server.declared_manifest_digest` pins **what the server
  advertised it could do**.
- `assay.tool_decision_truth.v0` → `declared_policy_digest` pins **the constraint set the decision
  was measured against** (tool name, args schema, identity, classes, approval, scope, redaction).

Both answer "what was in force", about different things.

**Why generated rather than written.** A hand-kept map goes stale silently, and that is precisely the
failure it exists to prevent. The output states its own split: *which* schemas exist and how often
their keys are populated is discovered from the committed corpus on every run, while *what each field
is a statement about* is curated — read from the producing code by a human, never inferred from the
field name. A schema that appears without a curated entry is emitted as **"Semantics not stated."**
rather than omitted, so a fifth vocabulary announces itself instead of hiding. That path is verified
by removing a curated entry and watching the row appear with its discovered key path.

**Relations carry a direction** rather than being stated as equality. Only one pair earns
equivalence and only one way: the OTel span attributes are a projection of the truth carrier, and
reconstructing the carrier from the projection is *not* claimed, a projection being free to drop
fields.

**One surface relates to nothing, and the map says so.** `PayloadToolDecision`'s configuration fields
are optional, carry no doc comments, and are populated by no committed fixture, so their semantics
are stated nowhere and no relation can be asserted. `policy_digest` reads like a shorter
`declared_policy_digest`; that resemblance is a name, not evidence.

### Scope

No claim in this codebase depends on configuration — the claim gate knows `PositiveExistence`,
`ExhaustiveSet` and `BoundedNegative`, all about observation coverage. **This is a legibility map,
not a correctness mechanism, and it justifies no code change.** It is here because its absence caused
a concrete error: a measurement imposed one schema's field names, found none of them, and reported
everything absent over a corpus where the facts were present under three other names.

### Wiring

Added beside the other generators in `docs-auto-update.yml`, with a `--check` mode so staleness fails
rather than drifts. Two things the repo's own checks caught while writing it, both recorded in the
generator as comments so they are not reintroduced:

- The first version emitted two trailing newlines, which `end-of-file-fixer` rewrites — and a
  generator whose output a hook rewrites drifts against the generated-docs-match check on every run.
- The second stamped the HEAD commit into the file, which makes the file name the commit *before* its
  own and therefore report itself stale against its own `--check` forever. Freshness here is enforced
  by re-running, not by a stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
