### PR TITLE
fix(plugin): unset inherited Claude credential-storage override

### DIFF
--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -16,6 +16,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, NoReturn
+from unittest.mock import patch
 
 MAX_BYTES = 1_048_576
 DEFAULT_TIMEOUT_SECONDS = 30.0
@@ -27,6 +28,7 @@ EXPECTED_TOOLS = [
     "assay_policy_decide",
 ]
 AUTH_ENV_PREFIXES = ("ANTHROPIC_", "CLAUDE_CODE_OAUTH_", "ASSAY_AUTH_")
+STORAGE_OVERRIDE_ENV = "CLAUDE_SECURESTORAGE_CONFIG_DIR"
 DRIVER = Path(__file__).resolve()
 SOURCE_ROOT = DRIVER.parents[2]
 WORKFLOW_SCRIPT = DRIVER.with_name("test-claude-plugin-install.sh")
@@ -81,6 +83,9 @@ def clean_env(extra: dict[str, str] | None = None) -> dict[str, str]:
     env.pop("CLAUDE_PROJECT_DIR", None)
     if extra:
         env.update(extra)
+    # Unset, not empty: Claude Code 2.1.247 treats a present empty override as the
+    # default service name, ignoring the disposable CLAUDE_CONFIG_DIR (#2194).
+    env.pop(STORAGE_OVERRIDE_ENV, None)
     return env
 
 
@@ -992,6 +997,7 @@ for line in sys.stdin:
 def self_test() -> None:
     # First, because every later failure caused by a re-coupled probe would
     # surface as an unexplained fixture mismatch instead of the design error.
+    assert_clean_env_strips_storage_override()
     assert_transcript_probe_is_not_denied()
     assert_transcript_prompt_contract()
     assert_changelog_history_self_test()
@@ -1582,6 +1588,56 @@ def assert_transcript_prompt_contract() -> None:
             "the transcript probe is allowed, so its result has no matches list",
         )
     print("transcript_prompt_contract=pass")
+
+
+def assert_clean_env_strips_storage_override() -> None:
+    """Disposable child env must not inherit CLAUDE_SECURESTORAGE_CONFIG_DIR.
+
+    Claude Code 2.1.247 prefers this override over CLAUDE_CONFIG_DIR. Empty
+    selects the default service name; nonempty selects that directory's
+    namespace. Unset is not empty. See #2194.
+    """
+    disposable = "/tmp/assay-disposable-claude-config"
+    extra = {
+        "CLAUDE_CONFIG_DIR": disposable,
+        "PATH": "/tmp/assay-isolated-bin",
+    }
+    cases = (
+        ("absent", None),
+        ("empty", ""),
+        ("nonempty", "/tmp/assay-inherited-securestorage"),
+    )
+    leaked: list[str] = []
+    for label, inherited in cases:
+        overlay = {"ANTHROPIC_API_KEY": "synthetic-canary-2194-anthropic"}
+        if inherited is not None:
+            overlay[STORAGE_OVERRIDE_ENV] = inherited
+        with patch.dict(os.environ, overlay, clear=True):
+            cleaned = clean_env(extra)
+        if STORAGE_OVERRIDE_ENV in cleaned:
+            leaked.append(label)
+            continue
+        if cleaned.get("CLAUDE_CONFIG_DIR") != disposable:
+            fail(
+                "clean_env",
+                f"{label}: disposable CLAUDE_CONFIG_DIR was not preserved",
+                "keep the supplied CLAUDE_CONFIG_DIR extra after sanitizing inheritance",
+            )
+        if any(key.upper().startswith(AUTH_ENV_PREFIXES) for key in cleaned):
+            fail(
+                "clean_env",
+                f"{label}: auth overrides leaked into the disposable environment",
+                "keep stripping ANTHROPIC_, CLAUDE_CODE_OAUTH_, and ASSAY_AUTH_ prefixes",
+            )
+    if leaked:
+        fail(
+            "clean_env",
+            "inherited "
+            f"{STORAGE_OVERRIDE_ENV} must be unset, not present "
+            f"(leaked for: {', '.join(leaked)})",
+            "pop the inherited storage override; leave it unset rather than empty",
+        )
+    print("clean_env_storage_override=pass")
 
 
 def assert_transcript_probe_is_not_denied() -> None:

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -1611,10 +1611,12 @@ def assert_clean_env_strips_storage_override() -> None:
     for label, inherited in cases:
         overlay = {"ANTHROPIC_API_KEY": "synthetic-canary-2194-anthropic"}
         if inherited is not None:
-            overlay[STORAGE_OVERRIDE_ENV] = inherited
+            # Literal host name, not STORAGE_OVERRIDE_ENV: a renamed constant
+            # must not keep this assertion green.
+            overlay["CLAUDE_SECURESTORAGE_CONFIG_DIR"] = inherited
         with patch.dict(os.environ, overlay, clear=True):
             cleaned = clean_env(extra)
-        if STORAGE_OVERRIDE_ENV in cleaned:
+        if "CLAUDE_SECURESTORAGE_CONFIG_DIR" in cleaned:
             leaked.append(label)
             continue
         if cleaned.get("CLAUDE_CONFIG_DIR") != disposable:
@@ -1633,7 +1635,7 @@ def assert_clean_env_strips_storage_override() -> None:
         fail(
             "clean_env",
             "inherited "
-            f"{STORAGE_OVERRIDE_ENV} must be unset, not present "
+            "CLAUDE_SECURESTORAGE_CONFIG_DIR must be unset, not present "
             f"(leaked for: {', '.join(leaked)})",
             "pop the inherited storage override; leave it unset rather than empty",
         )


### PR DESCRIPTION
## Summary

Follow-up to #2194, not closure of its authenticated host proof.

`clean_env()` removes `CLAUDE_SECURESTORAGE_CONFIG_DIR` after applying extras. Unset is distinct from empty: inspected Claude Code 2.1.247 selects its default credential service name for a present empty override even when `CLAUDE_CONFIG_DIR` names a disposable profile. No live credential access or exposure was demonstrated.

Scope: `scripts/ci/claude_plugin_install_workflow.py` only. No authentication, host configuration, release artifact, or tool-contract change.

## Final Candidate

Head: `986897f9f4df13d53d75a0892202715f352dbba1`.
Base: `902882abdbd4ad4988fd12b4c548dbb294f4f647`.
Cursor-owned worktree: `/Users/roelschuurkes/wt-cursor-2194-storage-namespace`.

The first commit fixed the production environment. The second pins the external environment name literally in the test, independently of the production constant. This deliberate independent oracle catches a misspelled production key; sharing that constant made the regression test falsely green.

## Verification

On the committed final head, Codex's normal push completed with exit 0 on 2026-08-31. No hooks bypassed. Claude plugin workflow self-test, three import-safety tests through their hook, evidence vocabulary guard, runner gating map, cargo fmt, workspace clippy with warnings denied, and Linux cross-target compile gate passed. Other unrelated path-filtered hooks were skipped, not claimed as coverage. Worktree was clean before push.

Cursor separately reports: literal-key tests reject a misspelled production constant, removed pop, and assignment to empty; a comment-only control stays green. These writer checks do not count as independent review.

Earlier history is retained: the first push attempt on this same candidate reportedly failed the fake Claude-version probe's 2-second deadline; a standalone repeat passed. The current normal push also passed. A pass/fail repeat is not evidence that host load caused the earlier failure, and no timeout contract was changed here.

## Review Disposition

Ruley independently reproduced the test-oracle coupling and returned BLOCKED on the previous head `f2d273045fbc57694babf0140a4287ef7e1d899e`. That finding is addressed by the new literal-key test. Ruley completed a fresh independent full-diff review on `986897f9f4df13d53d75a0892202715f352dbba1`: READY, no actionable findings. His own typo, missing-pop and empty-assignment probes were red; original and comment-only controls were green. [Exact-head record, relayed by Codex](https://github.com/Rul1an/assay/pull/2727#issuecomment-5482743410). This is not a carry of the old review. Required CI remains pending; no merge until all required gates pass.

## Non-claims

This is a named environment-preparation fix, not complete identity isolation, authenticated Claude discovery, model invocation, Keychain behavior measured live, or released-host proof. #2194 remains open. No API-billed fallback, credential copy, login/logout, or normal-profile change. No merge authorization from this PR body.
