### PR TITLE
fix(deps): replace yanked chacha20 with SSE2 backend fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,9 +1003,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
## Summary

Fixes #2728. Updates only the workspace lockfile from yanked `chacha20 0.10.0` to `0.10.2`, with the published registry checksum. No other dependency, feature, version or policy changes.

Upstream [#579](https://github.com/RustCrypto/stream-ciphers/issues/579) reported an unavailable SSE4.1 instruction in the SSE2 RNG/legacy backend. [#580](https://github.com/RustCrypto/stream-ciphers/pull/580) fixes the backend; [#583](https://github.com/RustCrypto/stream-ciphers/pull/583) records that 0.10.0 and 0.10.1 were yanked. This is a supported-target dependency repair, not a locally reproduced Assay crash or exploitation claim.

The normal/build dependency path reaches the MCP package through `rand -> object_store -> assay-evidence`, not only dev dependencies. The locally generated MCP package lock also contains 0.10.2. Existing published v5.5.1 packages are immutable and remain unchanged by this PR.

## Verification

Measured at `bd8b7697db87bf1fb187a841bd489cc688666dfc`, base `f1e2fb644688a7768f12479b227ddde5c9328860`, worktree `/Users/roelschuurkes/wt-codex-2728-chacha20`; Rust/Cargo 1.96.0, macOS arm64, one build job and worktree-local target directory.

- `cargo fmt --all -- --check` and `git diff --check`: pass.
- `cargo test --locked -p assay-evidence -p assay-adapter-api -p assay-core -p assay-mcp-server --lib`: 1,405 passed, 0 failed. These are library tests, not a full repository suite.
- `cargo test --locked -p assay-mcp-server --tests`: 492 passed, 0 failed, 2 ignored across 41 test targets. The two ignored entries are `descendant_spawner_helper_process`, which is re-executed as a child by its owning tests. This invocation includes the MCP library tests already counted above; the two totals must not be added as unique tests.
- `cargo clippy --locked --workspace --all-targets --exclude assay-it --exclude assay-ebpf -- -D warnings`: pass.
- `cargo tree --locked -p assay-mcp-server --target x86_64-unknown-linux-gnu -e normal,build -i chacha20`: fixed version appears on the production dependency path. This is dependency resolution, not an x86 execution test.
- `cargo package -p assay-mcp-server --locked --no-verify`: archive created and its embedded Cargo.lock inspected. This command is packaging inspection, not a package compilation test or publication.
- Downloaded dependency archive SHA-256 matches the registry and lockfile: `65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06`.
- Normal commit and push hooks completed successfully, including cargo-deny, RustSec audit, workspace clippy and the local Linux cross-target gate. No hooks were disabled. Local hook success is not a substitute for hosted Linux integration or SSE2 execution proof.

## Pending Landing Evidence

Independent exact-head review and required GitHub CI/delegated proof are still required. Cargo.lock requires delegated `gates=all`; no proof on another SHA is accepted. macOS arm64 tests do not execute the SSE2 backend. No local Miri reproduction or full x86 behavioral claim is made.

A follow-up patch release is needed to deliver this fix through published locked installation artifacts. Do not silently relabel v5.5.1 host evidence as a new-release pass.
