### PR TITLE
fix(ci): supervise Python run_bounded stdin under the absolute deadline (#2193)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -221,6 +221,13 @@ repos:
         pass_filenames: false
         files: ^(scripts/ci/(claude_plugin_install_workflow|test_claude_plugin_install_import)\.py|\.pre-commit-config\.yaml)$
 
+      - id: claude-plugin-run-bounded-stdin
+        name: Claude plugin bounded stdin is deadline-supervised
+        entry: python3 scripts/ci/test_run_bounded_stdin.py
+        language: system
+        pass_filenames: false
+        files: ^(scripts/ci/(claude_plugin_install_workflow|test_run_bounded_stdin)\.py|\.pre-commit-config\.yaml)$
+
       - id: docs-auto-update-reconcile-self-test
         name: Docs auto-update reconciliation self-test
         entry: bash scripts/ci/test-reconcile-docs-auto-pr.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -226,6 +226,7 @@ repos:
         entry: python3 scripts/ci/test_run_bounded_stdin.py
         language: system
         pass_filenames: false
+        stages: [pre-commit, pre-push]
         files: ^(scripts/ci/(claude_plugin_install_workflow|test_run_bounded_stdin)\.py|\.pre-commit-config\.yaml)$
 
       - id: docs-auto-update-reconcile-self-test

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -1466,17 +1466,26 @@ REQUIRED_CLAUDE_PLUGIN_HOOKS: tuple[tuple[str, str], ...] = (
 )
 
 
+_REAL_HOOK_ID_LINE = re.compile(r"^([ \t]*)- id: (\S+)[ \t]*$", re.M)
+
+
 def _hook_block_by_id(config: str, hook_id: str) -> str:
-    marker = f"id: {hook_id}"
-    start = config.find(marker)
-    if start < 0:
+    matches = [m for m in _REAL_HOOK_ID_LINE.finditer(config) if m.group(2) == hook_id]
+    if not matches:
         fail(
             "hook_files",
             f"pre-commit config lost {hook_id}",
             "restore the Claude plugin required hook",
         )
-    nxt = config.find("\n      - id:", start + len(marker))
-    return config[start:] if nxt < 0 else config[start:nxt]
+    if len(matches) != 1:
+        fail(
+            "hook_files",
+            f"pre-commit config has {len(matches)} real list items for {hook_id}",
+            "keep exactly one uncommented YAML list item per required hook id",
+        )
+    start = matches[0].start()
+    nxt = _REAL_HOOK_ID_LINE.search(config, matches[0].end())
+    return config[start:] if nxt is None else config[start:nxt.start()]
 
 
 def _claude_plugin_hook_block(config: str) -> str:

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -102,6 +102,16 @@ def terminate_tree(process: subprocess.Popen[bytes]) -> None:
         process.wait()
 
 
+def _close_bounded_pipes(process: subprocess.Popen[bytes]) -> None:
+    for stream in (process.stdin, process.stdout, process.stderr):
+        if stream is None:
+            continue
+        try:
+            stream.close()
+        except (BrokenPipeError, OSError):
+            pass
+
+
 def _set_nonblocking(phase: str, fd: int) -> None:
     try:
         import fcntl
@@ -143,96 +153,107 @@ def run_bounded(
     assert process.stderr is not None
 
     deadline = time.monotonic() + timeout
-    selector = selectors.DefaultSelector()
-    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
-    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
-    buffers = {"stdout": bytearray(), "stderr": bytearray()}
-    stdin_view = memoryview(stdin) if stdin else None
-    stdin_offset = 0
-    if stdin_view is None:
-        process.stdin.close()
-    else:
-        _set_nonblocking(phase, process.stdin.fileno())
-        selector.register(process.stdin, selectors.EVENT_WRITE, "stdin")
-
+    selector = None
     try:
-        while selector.get_map():
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                terminate_tree(process)
-                fail(
-                    phase,
-                    f"process tree exceeded {timeout:g}s deadline",
-                    "retry after checking the client/server command for a prompt, hang, or inherited pipe",
-                )
-            events = selector.select(min(remaining, 0.1))
-            for key, _ in events:
-                if key.data == "stdin":
-                    assert stdin_view is not None
-                    try:
-                        written = os.write(key.fd, stdin_view[stdin_offset:])
-                    except BlockingIOError:
-                        continue
-                    except BrokenPipeError:
-                        written = -1
-                    except OSError as exc:
-                        if exc.errno in (errno.EPIPE, errno.ECONNRESET):
-                            written = -1
-                        elif exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
-                            continue
-                        else:
-                            raise
-                    if written < 0 or stdin_offset + written >= len(stdin_view):
-                        selector.unregister(key.fileobj)
-                        try:
-                            process.stdin.close()
-                        except BrokenPipeError:
-                            pass
-                    if written > 0:
-                        stdin_offset += written
-                    continue
+        selector = selectors.DefaultSelector()
+        selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+        selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+        buffers = {"stdout": bytearray(), "stderr": bytearray()}
+        stdin_view = memoryview(stdin) if stdin else None
+        stdin_offset = 0
+        if stdin_view is None:
+            process.stdin.close()
+        else:
+            _set_nonblocking(phase, process.stdin.fileno())
+            selector.register(process.stdin, selectors.EVENT_WRITE, "stdin")
 
-                chunk = os.read(key.fd, 65_536)
-                if not chunk:
-                    selector.unregister(key.fileobj)
-                    continue
-                target = buffers[key.data]
-                target.extend(chunk)
-                if len(target) > MAX_BYTES:
+        try:
+            while selector.get_map():
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
                     terminate_tree(process)
                     fail(
                         phase,
-                        f"{key.data} exceeded {MAX_BYTES}-byte ceiling",
-                        "inspect the command directly; the bounded workflow will not retain unbounded diagnostics",
+                        f"process tree exceeded {timeout:g}s deadline",
+                        "retry after checking the client/server command for a prompt, hang, or inherited pipe",
                     )
+                events = selector.select(min(remaining, 0.1))
+                for key, _ in events:
+                    if key.data == "stdin":
+                        assert stdin_view is not None
+                        try:
+                            written = os.write(key.fd, stdin_view[stdin_offset:])
+                        except BlockingIOError:
+                            continue
+                        except BrokenPipeError:
+                            written = -1
+                        except OSError as exc:
+                            if exc.errno in (errno.EPIPE, errno.ECONNRESET):
+                                written = -1
+                            elif exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+                                continue
+                            else:
+                                raise
+                        if written < 0 or stdin_offset + written >= len(stdin_view):
+                            selector.unregister(key.fileobj)
+                            try:
+                                process.stdin.close()
+                            except BrokenPipeError:
+                                pass
+                        if written > 0:
+                            stdin_offset += written
+                        continue
 
-            # Descendants can inherit a pipe after the direct child exits. The
-            # same absolute deadline continues to govern that drain.
+                    chunk = os.read(key.fd, 65_536)
+                    if not chunk:
+                        selector.unregister(key.fileobj)
+                        continue
+                    target = buffers[key.data]
+                    target.extend(chunk)
+                    if len(target) > MAX_BYTES:
+                        terminate_tree(process)
+                        fail(
+                            phase,
+                            f"{key.data} exceeded {MAX_BYTES}-byte ceiling",
+                            "inspect the command directly; the bounded workflow will not retain unbounded diagnostics",
+                        )
+
+                # Descendants can inherit a pipe after the direct child exits. The
+                # same absolute deadline continues to govern that drain.
+        finally:
+            selector.close()
+            selector = None
+
+        remaining = max(0.0, deadline - time.monotonic())
+        try:
+            returncode = process.wait(timeout=remaining)
+        except subprocess.TimeoutExpired:
+            terminate_tree(process)
+            process.wait()
+            fail(
+                phase,
+                f"process tree did not reap within {timeout:g}s deadline",
+                "inspect descendant processes spawned by the client command",
+            )
+
+        result = CommandResult(returncode, bytes(buffers["stdout"]), bytes(buffers["stderr"]))
+        if returncode not in set(allowed_codes):
+            diagnostic = (result.stderr or result.stdout).decode("utf-8", "replace").strip()
+            diagnostic = diagnostic[-600:] if diagnostic else "no diagnostic output"
+            fail(
+                phase,
+                f"command exited {returncode}: {diagnostic}",
+                "run the named phase directly with the same fresh config and consumer directory",
+            )
+        return result
+    except BaseException:
+        if process.poll() is None:
+            terminate_tree(process)
+        raise
     finally:
-        selector.close()
-
-    remaining = max(0.0, deadline - time.monotonic())
-    try:
-        returncode = process.wait(timeout=remaining)
-    except subprocess.TimeoutExpired:
-        terminate_tree(process)
-        process.wait()
-        fail(
-            phase,
-            f"process tree did not reap within {timeout:g}s deadline",
-            "inspect descendant processes spawned by the client command",
-        )
-
-    result = CommandResult(returncode, bytes(buffers["stdout"]), bytes(buffers["stderr"]))
-    if returncode not in set(allowed_codes):
-        diagnostic = (result.stderr or result.stdout).decode("utf-8", "replace").strip()
-        diagnostic = diagnostic[-600:] if diagnostic else "no diagnostic output"
-        fail(
-            phase,
-            f"command exited {returncode}: {diagnostic}",
-            "run the named phase directly with the same fresh config and consumer directory",
-        )
-    return result
+        if selector is not None:
+            selector.close()
+        _close_bounded_pipes(process)
 
 
 def read_bounded(path: Path, phase: str) -> bytes:

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import errno
-import fcntl
 import json
 import math
 import os
@@ -103,7 +102,15 @@ def terminate_tree(process: subprocess.Popen[bytes]) -> None:
         process.wait()
 
 
-def _set_nonblocking(fd: int) -> None:
+def _set_nonblocking(phase: str, fd: int) -> None:
+    try:
+        import fcntl
+    except ImportError:
+        fail(
+            phase,
+            "run_bounded needs POSIX nonblocking stdin; fcntl is unavailable on this host",
+            "run the Claude plugin workflow on a POSIX host; Windows process-tree semantics are a non-claim",
+        )
     flags = fcntl.fcntl(fd, fcntl.F_GETFL)
     fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
@@ -145,7 +152,7 @@ def run_bounded(
     if stdin_view is None:
         process.stdin.close()
     else:
-        _set_nonblocking(process.stdin.fileno())
+        _set_nonblocking(phase, process.stdin.fileno())
         selector.register(process.stdin, selectors.EVENT_WRITE, "stdin")
 
     try:

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import errno
+import fcntl
 import json
 import math
 import os
@@ -101,6 +103,15 @@ def terminate_tree(process: subprocess.Popen[bytes]) -> None:
         process.wait()
 
 
+def _set_nonblocking(fd: int) -> None:
+    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+
+# Same bounded-process invariants as tests/support/bounded_process.rs
+# (#2189/#2190): one absolute deadline, separate stdout/stderr caps,
+# process-tree termination, descendant-held pipe/orphan drain, and stdin
+# supervision. POSIX-only. Not a cross-language abstraction.
 def run_bounded(
     phase: str,
     argv: list[str],
@@ -124,19 +135,18 @@ def run_bounded(
     assert process.stdout is not None
     assert process.stderr is not None
 
-    if stdin:
-        try:
-            process.stdin.write(stdin)
-            process.stdin.flush()
-        except BrokenPipeError:
-            pass
-    process.stdin.close()
-
+    deadline = time.monotonic() + timeout
     selector = selectors.DefaultSelector()
     selector.register(process.stdout, selectors.EVENT_READ, "stdout")
     selector.register(process.stderr, selectors.EVENT_READ, "stderr")
     buffers = {"stdout": bytearray(), "stderr": bytearray()}
-    deadline = time.monotonic() + timeout
+    stdin_view = memoryview(stdin) if stdin else None
+    stdin_offset = 0
+    if stdin_view is None:
+        process.stdin.close()
+    else:
+        _set_nonblocking(process.stdin.fileno())
+        selector.register(process.stdin, selectors.EVENT_WRITE, "stdin")
 
     try:
         while selector.get_map():
@@ -150,6 +160,31 @@ def run_bounded(
                 )
             events = selector.select(min(remaining, 0.1))
             for key, _ in events:
+                if key.data == "stdin":
+                    assert stdin_view is not None
+                    try:
+                        written = os.write(key.fd, stdin_view[stdin_offset:])
+                    except BlockingIOError:
+                        continue
+                    except BrokenPipeError:
+                        written = -1
+                    except OSError as exc:
+                        if exc.errno in (errno.EPIPE, errno.ECONNRESET):
+                            written = -1
+                        elif exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+                            continue
+                        else:
+                            raise
+                    if written < 0 or stdin_offset + written >= len(stdin_view):
+                        selector.unregister(key.fileobj)
+                        try:
+                            process.stdin.close()
+                        except BrokenPipeError:
+                            pass
+                    if written > 0:
+                        stdin_offset += written
+                    continue
+
                 chunk = os.read(key.fd, 65_536)
                 if not chunk:
                     selector.unregister(key.fileobj)

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -1504,15 +1504,119 @@ def _hook_entry(block: str) -> str:
     )
 
 
+# Same parser route as scripts/ci/check-assay-action-pin.sh: Ruby
+# YAML.safe_load, then JSON. Comments and scalar values are not hooks.
+RUBY_SAFE_LOAD = r"""
+require "json"
+require "yaml"
+begin
+  val = YAML.safe_load(STDIN.read, aliases: false)
+  STDOUT.write(JSON.generate(val))
+rescue Psych::SyntaxError, Psych::BadAlias, Psych::DisallowedClass => e
+  STDERR.write(e.message)
+  exit 2
+end
+"""
+
+
+def load_pre_commit_yaml(config: str) -> object:
+    try:
+        proc = subprocess.run(
+            ["ruby", "-EUTF-8:UTF-8", "-e", RUBY_SAFE_LOAD],
+            input=config,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        fail(
+            "hook_files",
+            "ruby is required to parse .pre-commit-config.yaml",
+            "install ruby with Psych YAML.safe_load",
+        )
+    except subprocess.TimeoutExpired:
+        fail(
+            "hook_files",
+            "YAML parse timed out",
+            "retry after checking .pre-commit-config.yaml",
+        )
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "yaml parse failed").strip()
+        fail(
+            "hook_files",
+            f"YAML parse failed: {err}",
+            "fix .pre-commit-config.yaml so YAML.safe_load accepts it",
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        fail(
+            "hook_files",
+            f"YAML JSON decode failed: {exc}",
+            "fix .pre-commit-config.yaml so YAML.safe_load emits JSON",
+        )
+
+
+def _required_hook_entries_from_repos(parsed: object) -> dict[str, list[str]]:
+    required = {hook_id: [] for hook_id, _entry in REQUIRED_CLAUDE_PLUGIN_HOOKS}
+    if not isinstance(parsed, dict):
+        fail(
+            "hook_files",
+            "pre-commit config root is not a mapping",
+            "keep a standard pre-commit YAML mapping with repos",
+        )
+    repos = parsed.get("repos")
+    if not isinstance(repos, list):
+        fail(
+            "hook_files",
+            "pre-commit config repos is not a list",
+            "keep repos as a YAML list of hook repositories",
+        )
+    for repo in repos:
+        if not isinstance(repo, dict):
+            continue
+        hooks = repo.get("hooks")
+        if not isinstance(hooks, list):
+            continue
+        for hook in hooks:
+            if not isinstance(hook, dict):
+                continue
+            hook_id = hook.get("id")
+            if hook_id not in required:
+                continue
+            entry = hook.get("entry")
+            if not isinstance(hook_id, str) or not isinstance(entry, str):
+                fail(
+                    "hook_files",
+                    f"hook {hook_id!r} is not a mapping with string id and entry",
+                    "restore the required Claude plugin hook as a real YAML mapping",
+                )
+            required[hook_id].append(entry)
+    return required
+
+
 def assert_required_claude_plugin_hooks(config: str | None = None) -> None:
     if config is None:
         config = (SOURCE_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    found = _required_hook_entries_from_repos(load_pre_commit_yaml(config))
     for hook_id, entry in REQUIRED_CLAUDE_PLUGIN_HOOKS:
-        got = _hook_entry(_hook_block_by_id(config, hook_id))
-        if got != entry:
+        entries = found[hook_id]
+        if not entries:
             fail(
                 "hook_files",
-                f"{hook_id} entry {got!r} is not {entry!r}",
+                f"pre-commit config lost {hook_id}",
+                "restore the Claude plugin required hook",
+            )
+        if len(entries) != 1:
+            fail(
+                "hook_files",
+                f"pre-commit config has {len(entries)} real list items for {hook_id}",
+                "keep exactly one uncommented YAML list item per required hook id",
+            )
+        if entries[0] != entry:
+            fail(
+                "hook_files",
+                f"{hook_id} entry {entries[0]!r} is not {entry!r}",
                 "restore the required Claude plugin hook entry",
             )
     print("required_claude_plugin_hooks=pass")

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -125,6 +125,27 @@ def _set_nonblocking(phase: str, fd: int) -> None:
     fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
 
+def require_bounded_supervisor(phase: str) -> None:
+    """Refuse before spawn when killpg or fcntl cannot supervise the tree."""
+    missing: list[str] = []
+    if not callable(getattr(os, "killpg", None)):
+        missing.append("killpg")
+    try:
+        import fcntl as fcntl_mod
+    except ImportError:
+        missing.append("fcntl")
+    else:
+        if not callable(getattr(fcntl_mod, "fcntl", None)):
+            missing.append("fcntl")
+    if missing:
+        names = ", ".join(missing)
+        fail(
+            phase,
+            f"run_bounded needs POSIX supervisor; {names} unavailable on this host",
+            "run the Claude plugin workflow on a POSIX host; Windows process-tree semantics are a non-claim",
+        )
+
+
 # Same bounded-process invariants as tests/support/bounded_process.rs
 # (#2189/#2190): one absolute deadline, separate stdout/stderr caps,
 # process-tree termination, descendant-held pipe/orphan drain, and stdin
@@ -139,6 +160,7 @@ def run_bounded(
     allowed_codes: Iterable[int] = (0,),
 ) -> CommandResult:
     timeout = workflow_timeout_seconds()
+    require_bounded_supervisor(phase)
     process = subprocess.Popen(
         argv,
         cwd=cwd,
@@ -1066,6 +1088,7 @@ def self_test() -> None:
     assert_changelog_history_self_test()
     assert_changelog_contract()
     assert_hook_files_include_changelog()
+    assert_required_claude_plugin_hooks()
     assert_stream_fixture_table()
     assert_wrong_assay_tool_keeps_invoked_name()
     assert_companion_non_decide_does_not_invalidate()
@@ -1431,19 +1454,59 @@ def assert_changelog_history_self_test() -> None:
 
 
 CLAUDE_PLUGIN_HOOK_ID = "claude-plugin-install-workflow-self-test"
+REQUIRED_CLAUDE_PLUGIN_HOOKS: tuple[tuple[str, str], ...] = (
+    (
+        "claude-plugin-install-workflow-self-test",
+        "bash scripts/ci/test-claude-plugin-install.sh --self-test",
+    ),
+    (
+        "claude-plugin-run-bounded-stdin",
+        "python3 scripts/ci/test_run_bounded_stdin.py",
+    ),
+)
 
 
-def _claude_plugin_hook_block(config: str) -> str:
-    marker = f"id: {CLAUDE_PLUGIN_HOOK_ID}"
+def _hook_block_by_id(config: str, hook_id: str) -> str:
+    marker = f"id: {hook_id}"
     start = config.find(marker)
     if start < 0:
         fail(
             "hook_files",
-            "pre-commit config lost claude-plugin-install-workflow-self-test",
-            "restore the Claude plugin install self-test hook",
+            f"pre-commit config lost {hook_id}",
+            "restore the Claude plugin required hook",
         )
     nxt = config.find("\n      - id:", start + len(marker))
     return config[start:] if nxt < 0 else config[start:nxt]
+
+
+def _claude_plugin_hook_block(config: str) -> str:
+    return _hook_block_by_id(config, CLAUDE_PLUGIN_HOOK_ID)
+
+
+def _hook_entry(block: str) -> str:
+    for line in block.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("entry:"):
+            return stripped[len("entry:") :].strip()
+    fail(
+        "hook_files",
+        "required Claude plugin hook has no entry:",
+        "restore the hook entry",
+    )
+
+
+def assert_required_claude_plugin_hooks(config: str | None = None) -> None:
+    if config is None:
+        config = (SOURCE_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    for hook_id, entry in REQUIRED_CLAUDE_PLUGIN_HOOKS:
+        got = _hook_entry(_hook_block_by_id(config, hook_id))
+        if got != entry:
+            fail(
+                "hook_files",
+                f"{hook_id} entry {got!r} is not {entry!r}",
+                "restore the required Claude plugin hook entry",
+            )
+    print("required_claude_plugin_hooks=pass")
 
 
 def _hook_files_selector(block: str) -> str:

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -1557,8 +1557,22 @@ def load_pre_commit_yaml(config: str) -> object:
         )
 
 
-def _required_hook_entries_from_repos(parsed: object) -> dict[str, list[str]]:
-    required = {hook_id: [] for hook_id, _entry in REQUIRED_CLAUDE_PLUGIN_HOOKS}
+REQUIRED_CLAUDE_PLUGIN_HOOK_STAGES: dict[str, list[str]] = {
+    "claude-plugin-install-workflow-self-test": ["pre-push"],
+    "claude-plugin-run-bounded-stdin": ["pre-commit", "pre-push"],
+}
+STDIN_HOOK_ID = "claude-plugin-run-bounded-stdin"
+STDIN_HOOK_FILE_PATHS: tuple[str, ...] = (
+    "scripts/ci/claude_plugin_install_workflow.py",
+    "scripts/ci/test_run_bounded_stdin.py",
+    ".pre-commit-config.yaml",
+)
+
+
+def _required_local_hooks(parsed: object) -> dict[str, list[dict[str, object]]]:
+    required: dict[str, list[dict[str, object]]] = {
+        hook_id: [] for hook_id, _entry in REQUIRED_CLAUDE_PLUGIN_HOOKS
+    }
     if not isinstance(parsed, dict):
         fail(
             "hook_files",
@@ -1573,7 +1587,7 @@ def _required_hook_entries_from_repos(parsed: object) -> dict[str, list[str]]:
             "keep repos as a YAML list of hook repositories",
         )
     for repo in repos:
-        if not isinstance(repo, dict):
+        if not isinstance(repo, dict) or repo.get("repo") != "local":
             continue
         hooks = repo.get("hooks")
         if not isinstance(hooks, list):
@@ -1591,34 +1605,75 @@ def _required_hook_entries_from_repos(parsed: object) -> dict[str, list[str]]:
                     f"hook {hook_id!r} is not a mapping with string id and entry",
                     "restore the required Claude plugin hook as a real YAML mapping",
                 )
-            required[hook_id].append(entry)
+            required[hook_id].append(hook)
     return required
+
+
+def _assert_hook_stages(hook_id: str, hook: dict[str, object]) -> None:
+    expected = REQUIRED_CLAUDE_PLUGIN_HOOK_STAGES[hook_id]
+    stages = hook.get("stages")
+    if stages != expected:
+        fail(
+            "hook_files",
+            f"{hook_id} stages {stages!r} is not {expected!r}",
+            "restore the required Claude plugin hook stages",
+        )
+
+
+def _assert_stdin_files_selector(hook: dict[str, object]) -> None:
+    pattern = hook.get("files")
+    if not isinstance(pattern, str) or not pattern:
+        fail(
+            "hook_files",
+            f"{STDIN_HOOK_ID} files selector is missing",
+            "restore the bounded-stdin files regex",
+        )
+    try:
+        compiled = re.compile(pattern)
+    except re.error as error:
+        fail(
+            "hook_files",
+            f"{STDIN_HOOK_ID} files selector is not a regex: {error}",
+            "keep a valid files regex for the bounded-stdin hook",
+        )
+    missing = [path for path in STDIN_HOOK_FILE_PATHS if compiled.search(path) is None]
+    if missing:
+        fail(
+            "hook_files",
+            f"{STDIN_HOOK_ID} files regex does not match {missing[0]}",
+            "keep workflow.py, the stdin test, and .pre-commit-config.yaml in the files regex",
+        )
 
 
 def assert_required_claude_plugin_hooks(config: str | None = None) -> None:
     if config is None:
         config = (SOURCE_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
-    found = _required_hook_entries_from_repos(load_pre_commit_yaml(config))
+    found = _required_local_hooks(load_pre_commit_yaml(config))
     for hook_id, entry in REQUIRED_CLAUDE_PLUGIN_HOOKS:
-        entries = found[hook_id]
-        if not entries:
+        hooks = found[hook_id]
+        if not hooks:
             fail(
                 "hook_files",
-                f"pre-commit config lost {hook_id}",
-                "restore the Claude plugin required hook",
+                f"pre-commit config lost {hook_id} under repo: local",
+                "restore the Claude plugin required hook under repo: local",
             )
-        if len(entries) != 1:
+        if len(hooks) != 1:
             fail(
                 "hook_files",
-                f"pre-commit config has {len(entries)} real list items for {hook_id}",
+                f"pre-commit config has {len(hooks)} real list items for {hook_id}",
                 "keep exactly one uncommented YAML list item per required hook id",
             )
-        if entries[0] != entry:
+        hook = hooks[0]
+        got = hook.get("entry")
+        if got != entry:
             fail(
                 "hook_files",
-                f"{hook_id} entry {entries[0]!r} is not {entry!r}",
+                f"{hook_id} entry {got!r} is not {entry!r}",
                 "restore the required Claude plugin hook entry",
             )
+        _assert_hook_stages(hook_id, hook)
+        if hook_id == STDIN_HOOK_ID:
+            _assert_stdin_files_selector(hook)
     print("required_claude_plugin_hooks=pass")
 
 

--- a/scripts/ci/test_run_bounded_stdin.py
+++ b/scripts/ci/test_run_bounded_stdin.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import importlib.util
 import os
-import selectors
 import signal
 import subprocess
 import sys
@@ -155,91 +154,23 @@ def _invoke(
     return Outcome("exc", elapsed, reason="runner returned no outcome")
 
 
-def run_bounded_blocking_stdin_before_deadline(
-    phase: str,
-    argv: list[str],
-    *,
-    cwd: Path,
-    env: dict[str, str],
-    stdin: bytes = b"",
-    allowed_codes: Any = (0,),
-) -> Any:
-    """Mutation: blocking write/flush/close before the absolute deadline."""
-    timeout = WORKFLOW_MOD.workflow_timeout_seconds()
-    process = subprocess.Popen(
-        argv,
-        cwd=cwd,
-        env=env,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        start_new_session=True,
-    )
-    assert process.stdin is not None
-    assert process.stdout is not None
-    assert process.stderr is not None
-    if stdin:
-        try:
-            process.stdin.write(stdin)
-            process.stdin.flush()
-        except BrokenPipeError:
-            pass
-    process.stdin.close()
-    selector = selectors.DefaultSelector()
-    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
-    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
-    buffers = {"stdout": bytearray(), "stderr": bytearray()}
-    deadline = time.monotonic() + timeout
-    try:
-        while selector.get_map():
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                WORKFLOW_MOD.terminate_tree(process)
-                WORKFLOW_MOD.fail(
-                    phase,
-                    f"process tree exceeded {timeout:g}s deadline",
-                    "retry after checking the client/server command for a prompt, hang, or inherited pipe",
-                )
-            events = selector.select(min(remaining, 0.1))
-            for key, _ in events:
-                chunk = os.read(key.fd, 65_536)
-                if not chunk:
-                    selector.unregister(key.fileobj)
-                    continue
-                target = buffers[key.data]
-                target.extend(chunk)
-                if len(target) > WORKFLOW_MOD.MAX_BYTES:
-                    WORKFLOW_MOD.terminate_tree(process)
-                    WORKFLOW_MOD.fail(
-                        phase,
-                        f"{key.data} exceeded {WORKFLOW_MOD.MAX_BYTES}-byte ceiling",
-                        "inspect the command directly; the bounded workflow will not retain unbounded diagnostics",
-                    )
-    finally:
-        selector.close()
-    remaining = max(0.0, deadline - time.monotonic())
-    try:
-        returncode = process.wait(timeout=remaining)
-    except subprocess.TimeoutExpired:
-        WORKFLOW_MOD.terminate_tree(process)
-        process.wait()
-        WORKFLOW_MOD.fail(
-            phase,
-            f"process tree did not reap within {timeout:g}s deadline",
-            "inspect descendant processes spawned by the client command",
-        )
-    result = WORKFLOW_MOD.CommandResult(
-        returncode, bytes(buffers["stdout"]), bytes(buffers["stderr"])
-    )
-    if returncode not in set(allowed_codes):
-        diagnostic = (result.stderr or result.stdout).decode("utf-8", "replace").strip()
-        diagnostic = diagnostic[-600:] if diagnostic else "no diagnostic output"
-        WORKFLOW_MOD.fail(
-            phase,
-            f"command exited {returncode}: {diagnostic}",
-            "run the named phase directly with the same fresh config and consumer directory",
-        )
-    return result
+FCNTL_BLOCKER = r"""
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+
+class BlockFcntl:
+    def find_spec(self, name, path=None, target=None):
+        if name == "fcntl":
+            raise ImportError("simulated-unavailable fcntl")
+        return None
+
+sys.meta_path.insert(0, BlockFcntl())
+sys.modules.pop("fcntl", None)
+spec = spec_from_file_location("wf_no_fcntl", sys.argv[1])
+mod = module_from_spec(spec)
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+"""
 
 
 class BoundedStdinTests(unittest.TestCase):
@@ -255,15 +186,6 @@ class BoundedStdinTests(unittest.TestCase):
     def _run(self, action: str, stdin: bytes) -> Outcome:
         return _invoke(
             WORKFLOW_MOD.run_bounded,
-            _python(_probe_body(action)),
-            stdin,
-            self.cwd,
-            self.pidfile,
-        )
-
-    def _mut(self, action: str, stdin: bytes) -> Outcome:
-        return _invoke(
-            run_bounded_blocking_stdin_before_deadline,
             _python(_probe_body(action)),
             stdin,
             self.cwd,
@@ -295,6 +217,12 @@ class BoundedStdinTests(unittest.TestCase):
         self.assertIn("deadline", outcome.reason)
         self.assertLess(outcome.elapsed, SLEEP_S)
 
+    def test_empty_stdin_immediate_exit_succeeds(self) -> None:
+        outcome = self._run("true", b"")
+        self.assertEqual(outcome.kind, "ok", outcome.reason)
+        self.assertEqual(outcome.result.returncode, 0)
+        self.assertLess(outcome.elapsed, SLEEP_S)
+
     def test_early_stdin_close_preserves_success(self) -> None:
         outcome = self._run("early_close", STDIN_256K)
         self.assertEqual(outcome.kind, "ok", outcome.reason)
@@ -306,31 +234,78 @@ class BoundedStdinTests(unittest.TestCase):
         self.assertIn("ceiling", outcome.reason)
         self.assertIn("stdout", outcome.reason)
 
-    def test_mutation_non_reader_false_green_or_hang(self) -> None:
-        outcome = self._mut("non_reader", STDIN_256K)
-        beyond_budget = outcome.kind == "hang" or (
-            outcome.kind == "ok" and outcome.elapsed > float(DEADLINE_S)
-        )
-        self.assertTrue(
-            beyond_budget,
-            f"mutation stayed bounded: kind={outcome.kind} elapsed={outcome.elapsed:.3f} reason={outcome.reason!r}",
-        )
 
-    def test_mutation_write_first_false_green_or_hang(self) -> None:
-        outcome = self._mut("write_first", STDIN_256K)
-        beyond_budget = outcome.kind == "hang" or (
-            outcome.kind == "ok" and outcome.elapsed > float(DEADLINE_S)
-        )
-        self.assertTrue(
-            beyond_budget,
-            f"mutation stayed bounded: kind={outcome.kind} elapsed={outcome.elapsed:.3f} reason={outcome.reason!r}",
-        )
+class FcntlUnavailableTests(unittest.TestCase):
+    """Import stays safe when fcntl is missing; run_bounded fails only if stdin needs it."""
 
-    def test_mutation_empty_control_stays_green(self) -> None:
-        outcome = self._mut("true", b"")
-        self.assertEqual(outcome.kind, "ok", outcome.reason)
-        self.assertEqual(outcome.result.returncode, 0)
-        self.assertLess(outcome.elapsed, SLEEP_S)
+    def test_import_succeeds_when_fcntl_unavailable(self) -> None:
+        script = FCNTL_BLOCKER + "print('imported', mod.MAX_BYTES)\n"
+        result = subprocess.run(
+            [sys.executable, "-c", script, str(WORKFLOW)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("imported", result.stdout)
+
+    def test_run_bounded_fails_explicitly_when_stdin_needs_fcntl(self) -> None:
+        script = (
+            FCNTL_BLOCKER
+            + """
+import tempfile
+from pathlib import Path
+cwd = Path(tempfile.mkdtemp())
+try:
+    mod.run_bounded(
+        "bounded_stdin",
+        [sys.executable, "-c", "raise SystemExit(0)"],
+        cwd=cwd,
+        env=mod.clean_env(),
+        stdin=b"x",
+    )
+except mod.WorkflowError as error:
+    print("reason", error.reason)
+    raise SystemExit(0)
+print("unexpected success")
+raise SystemExit(2)
+"""
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script, str(WORKFLOW)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("fcntl", result.stdout)
+        self.assertIn("POSIX", result.stdout)
+
+    def test_empty_stdin_does_not_require_fcntl(self) -> None:
+        script = (
+            FCNTL_BLOCKER
+            + """
+import tempfile
+from pathlib import Path
+cwd = Path(tempfile.mkdtemp())
+result = mod.run_bounded(
+    "bounded_stdin",
+    [sys.executable, "-c", "raise SystemExit(0)"],
+    cwd=cwd,
+    env=mod.clean_env(),
+    stdin=b"",
+)
+print("rc", result.returncode)
+"""
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script, str(WORKFLOW)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("rc 0", result.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_run_bounded_stdin.py
+++ b/scripts/ci/test_run_bounded_stdin.py
@@ -281,6 +281,84 @@ raise SystemExit(2)
         self.assertIn("fcntl", result.stdout)
         self.assertIn("POSIX", result.stdout)
 
+    def test_fcntl_unavailable_child_is_reaped(self) -> None:
+        token = "bounded-fcntl-reap-probe"
+        inner = """
+import os, time, tempfile
+from pathlib import Path
+cwd = Path(tempfile.mkdtemp())
+pidfile = cwd / "child.pid"
+token = %r
+nl = chr(10)
+child = nl.join([
+    "import os, time",
+    "from pathlib import Path",
+    "Path(os.environ['BOUNDED_STDIN_PIDFILE']).write_text(str(os.getpid()))",
+    "time.sleep(30)",
+    "# " + token,
+])
+try:
+    mod.run_bounded(
+        "bounded_stdin",
+        [sys.executable, "-c", child],
+        cwd=cwd,
+        env=mod.clean_env({"BOUNDED_STDIN_PIDFILE": str(pidfile), "PYTHONUNBUFFERED": "1"}),
+        stdin=b"x",
+    )
+    print("unexpected success")
+    raise SystemExit(2)
+except mod.WorkflowError as error:
+    print("reason", error.reason)
+
+def alive(pid):
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+
+pid = None
+deadline = time.monotonic() + 1.0
+while time.monotonic() < deadline:
+    if pidfile.exists():
+        raw = pidfile.read_text().strip()
+        if raw.isdigit():
+            pid = int(raw)
+            break
+    time.sleep(0.01)
+
+self_pid = os.getpid()
+leftover = []
+for entry in Path("/proc").iterdir():
+    if not entry.name.isdigit():
+        continue
+    pid_n = int(entry.name)
+    if pid_n == self_pid:
+        continue
+    try:
+        cmdline = (entry / "cmdline").read_bytes().replace(bytes([0]), b" ").decode("utf-8", "replace")
+    except OSError:
+        continue
+    if token in cmdline:
+        leftover.append(pid_n)
+
+if pid is not None and alive(pid):
+    print("still-live", pid)
+    raise SystemExit(3)
+print("leftover", leftover)
+if leftover:
+    raise SystemExit(4)
+print("reaped")
+""" % token
+        result = subprocess.run(
+            [sys.executable, "-c", FCNTL_BLOCKER + inner, str(WORKFLOW)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("reaped", result.stdout)
+
     def test_empty_stdin_does_not_require_fcntl(self) -> None:
         script = (
             FCNTL_BLOCKER

--- a/scripts/ci/test_run_bounded_stdin.py
+++ b/scripts/ci/test_run_bounded_stdin.py
@@ -577,6 +577,42 @@ class RequiredHookTableTests(unittest.TestCase):
             WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
         self.assertIn("claude-plugin-install-workflow-self-test", str(raised.exception.reason))
 
+    def _comment_out_real_id_line(self, hook_id: str) -> str:
+        target = f"- id: {hook_id}"
+        found = 0
+        lines: list[str] = []
+        for line in self._config().splitlines(keepends=True):
+            stripped = line.lstrip(" \t")
+            indent = line[: len(line) - len(stripped)]
+            body = stripped.splitlines()[0]
+            if body == target:
+                newline = line[len(indent) + len(body) :]
+                lines.append(f"{indent}# {target}{newline}")
+                found += 1
+            else:
+                lines.append(line)
+        if found != 1:
+            self.fail(f"expected one real {target!r} line, got {found}")
+        return "".join(lines)
+
+    def test_mutation_comment_out_stdin_hook_id_goes_red(self) -> None:
+        config = self._comment_out_real_id_line("claude-plugin-run-bounded-stdin")
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+            WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
+        self.assertIn("claude-plugin-run-bounded-stdin", raised.exception.reason)
+
+    def test_mutation_comment_out_self_test_hook_id_goes_red(self) -> None:
+        config = self._comment_out_real_id_line("claude-plugin-install-workflow-self-test")
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+            WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
+        self.assertIn("claude-plugin-install-workflow-self-test", raised.exception.reason)
+
+    def test_commented_duplicate_id_does_not_replace_real_item(self) -> None:
+        hook_id = "claude-plugin-run-bounded-stdin"
+        real = f"      - id: {hook_id}"
+        config = self._config().replace(real, f"      # - id: {hook_id}\n{real}", 1)
+        WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/test_run_bounded_stdin.py
+++ b/scripts/ci/test_run_bounded_stdin.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Deadline must supervise stdin delivery for run_bounded."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import selectors
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / "scripts/ci/claude_plugin_install_workflow.py"
+STDIN_256K = b"x" * 262_144
+DEADLINE_S = "0.05"
+SLEEP_S = 0.35
+WALL_S = 1.0
+
+
+def load_workflow() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "claude_plugin_install_workflow_2193",
+        WORKFLOW,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {WORKFLOW}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+WORKFLOW_MOD = load_workflow()
+
+
+def _python(body: str) -> list[str]:
+    return [sys.executable, "-c", body]
+
+
+def _probe_body(action: str) -> str:
+    preamble = (
+        "import os, sys, time\n"
+        "from pathlib import Path\n"
+        "Path(os.environ['BOUNDED_STDIN_PIDFILE']).write_text(str(os.getpid()))\n"
+    )
+    actions = {
+        "non_reader": "time.sleep(0.35)\n",
+        "write_first": (
+            "sys.stdout.buffer.write(b'z' * 262144)\n"
+            "sys.stdout.buffer.flush()\n"
+            "time.sleep(0.35)\n"
+        ),
+        "reader": (
+            "data = sys.stdin.buffer.read()\n"
+            "sys.stdout.buffer.write(b'got:%d\\n' % len(data))\n"
+        ),
+        "early_close": (
+            "os.close(0)\n"
+            "raise SystemExit(0)\n"
+        ),
+        "flood": (
+            "sys.stdout.buffer.write(b'w' * (1048576 + 1))\n"
+            "sys.stdout.buffer.flush()\n"
+        ),
+        "true": "raise SystemExit(0)\n",
+    }
+    return preamble + actions[action]
+
+
+class Outcome:
+    def __init__(
+        self,
+        kind: str,
+        elapsed: float,
+        result: Any = None,
+        reason: str = "",
+    ) -> None:
+        self.kind = kind
+        self.elapsed = elapsed
+        self.result = result
+        self.reason = reason
+
+
+def _reap_probe(pidfile: Path) -> None:
+    try:
+        raw = pidfile.read_text().strip()
+        pid = int(raw)
+    except (FileNotFoundError, ValueError):
+        return
+    for kill in (
+        lambda: os.killpg(pid, signal.SIGKILL),
+        lambda: os.kill(pid, signal.SIGKILL),
+    ):
+        try:
+            kill()
+        except ProcessLookupError:
+            pass
+
+
+def _invoke(
+    runner: Callable[..., Any],
+    argv: list[str],
+    stdin: bytes,
+    cwd: Path,
+    pidfile: Path,
+    wall: float = WALL_S,
+) -> Outcome:
+    env = WORKFLOW_MOD.clean_env(
+        {"BOUNDED_STDIN_PIDFILE": str(pidfile), "PYTHONUNBUFFERED": "1"}
+    )
+    box: dict[str, Any] = {}
+
+    def target() -> None:
+        with patch.dict(
+            os.environ,
+            {"ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS": DEADLINE_S},
+            clear=False,
+        ):
+            try:
+                box["result"] = runner(
+                    "bounded_stdin",
+                    argv,
+                    cwd=cwd,
+                    env=env,
+                    stdin=stdin,
+                )
+                box["kind"] = "ok"
+            except WORKFLOW_MOD.WorkflowError as error:
+                box["kind"] = "err"
+                box["reason"] = error.reason
+                box["result"] = error
+
+    started = time.monotonic()
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(wall)
+    elapsed = time.monotonic() - started
+    if thread.is_alive():
+        _reap_probe(pidfile)
+        return Outcome("hang", elapsed, reason="blocked beyond wall budget")
+    if box.get("kind") == "err":
+        return Outcome("err", elapsed, result=box["result"], reason=box.get("reason", ""))
+    if box.get("kind") == "ok":
+        return Outcome("ok", elapsed, result=box["result"])
+    return Outcome("exc", elapsed, reason="runner returned no outcome")
+
+
+def run_bounded_blocking_stdin_before_deadline(
+    phase: str,
+    argv: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    stdin: bytes = b"",
+    allowed_codes: Any = (0,),
+) -> Any:
+    """Mutation: blocking write/flush/close before the absolute deadline."""
+    timeout = WORKFLOW_MOD.workflow_timeout_seconds()
+    process = subprocess.Popen(
+        argv,
+        cwd=cwd,
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    assert process.stdin is not None
+    assert process.stdout is not None
+    assert process.stderr is not None
+    if stdin:
+        try:
+            process.stdin.write(stdin)
+            process.stdin.flush()
+        except BrokenPipeError:
+            pass
+    process.stdin.close()
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+    buffers = {"stdout": bytearray(), "stderr": bytearray()}
+    deadline = time.monotonic() + timeout
+    try:
+        while selector.get_map():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                WORKFLOW_MOD.terminate_tree(process)
+                WORKFLOW_MOD.fail(
+                    phase,
+                    f"process tree exceeded {timeout:g}s deadline",
+                    "retry after checking the client/server command for a prompt, hang, or inherited pipe",
+                )
+            events = selector.select(min(remaining, 0.1))
+            for key, _ in events:
+                chunk = os.read(key.fd, 65_536)
+                if not chunk:
+                    selector.unregister(key.fileobj)
+                    continue
+                target = buffers[key.data]
+                target.extend(chunk)
+                if len(target) > WORKFLOW_MOD.MAX_BYTES:
+                    WORKFLOW_MOD.terminate_tree(process)
+                    WORKFLOW_MOD.fail(
+                        phase,
+                        f"{key.data} exceeded {WORKFLOW_MOD.MAX_BYTES}-byte ceiling",
+                        "inspect the command directly; the bounded workflow will not retain unbounded diagnostics",
+                    )
+    finally:
+        selector.close()
+    remaining = max(0.0, deadline - time.monotonic())
+    try:
+        returncode = process.wait(timeout=remaining)
+    except subprocess.TimeoutExpired:
+        WORKFLOW_MOD.terminate_tree(process)
+        process.wait()
+        WORKFLOW_MOD.fail(
+            phase,
+            f"process tree did not reap within {timeout:g}s deadline",
+            "inspect descendant processes spawned by the client command",
+        )
+    result = WORKFLOW_MOD.CommandResult(
+        returncode, bytes(buffers["stdout"]), bytes(buffers["stderr"])
+    )
+    if returncode not in set(allowed_codes):
+        diagnostic = (result.stderr or result.stdout).decode("utf-8", "replace").strip()
+        diagnostic = diagnostic[-600:] if diagnostic else "no diagnostic output"
+        WORKFLOW_MOD.fail(
+            phase,
+            f"command exited {returncode}: {diagnostic}",
+            "run the named phase directly with the same fresh config and consumer directory",
+        )
+    return result
+
+
+class BoundedStdinTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.cwd = Path(self._tmp.name)
+        self.pidfile = self.cwd / "child.pid"
+
+    def tearDown(self) -> None:
+        _reap_probe(self.pidfile)
+        self._tmp.cleanup()
+
+    def _run(self, action: str, stdin: bytes) -> Outcome:
+        return _invoke(
+            WORKFLOW_MOD.run_bounded,
+            _python(_probe_body(action)),
+            stdin,
+            self.cwd,
+            self.pidfile,
+        )
+
+    def _mut(self, action: str, stdin: bytes) -> Outcome:
+        return _invoke(
+            run_bounded_blocking_stdin_before_deadline,
+            _python(_probe_body(action)),
+            stdin,
+            self.cwd,
+            self.pidfile,
+        )
+
+    def test_non_reader_fails_by_deadline(self) -> None:
+        outcome = self._run("non_reader", STDIN_256K)
+        self.assertEqual(outcome.kind, "err", outcome.reason)
+        self.assertIn("deadline", outcome.reason)
+        self.assertLess(outcome.elapsed, SLEEP_S)
+
+    def test_write_first_fails_by_deadline(self) -> None:
+        outcome = self._run("write_first", STDIN_256K)
+        self.assertEqual(outcome.kind, "err", outcome.reason)
+        self.assertIn("deadline", outcome.reason)
+        self.assertLess(outcome.elapsed, SLEEP_S)
+
+    def test_reader_succeeds(self) -> None:
+        outcome = self._run("reader", STDIN_256K)
+        self.assertEqual(outcome.kind, "ok", outcome.reason)
+        self.assertEqual(outcome.result.returncode, 0)
+        self.assertEqual(outcome.result.stdout, b"got:262144\n")
+        self.assertLess(outcome.elapsed, SLEEP_S)
+
+    def test_empty_stdin_still_times_out(self) -> None:
+        outcome = self._run("non_reader", b"")
+        self.assertEqual(outcome.kind, "err", outcome.reason)
+        self.assertIn("deadline", outcome.reason)
+        self.assertLess(outcome.elapsed, SLEEP_S)
+
+    def test_early_stdin_close_preserves_success(self) -> None:
+        outcome = self._run("early_close", STDIN_256K)
+        self.assertEqual(outcome.kind, "ok", outcome.reason)
+        self.assertEqual(outcome.result.returncode, 0)
+
+    def test_stdout_over_ceiling_terminates_tree(self) -> None:
+        outcome = self._run("flood", b"")
+        self.assertEqual(outcome.kind, "err", outcome.reason)
+        self.assertIn("ceiling", outcome.reason)
+        self.assertIn("stdout", outcome.reason)
+
+    def test_mutation_non_reader_false_green_or_hang(self) -> None:
+        outcome = self._mut("non_reader", STDIN_256K)
+        beyond_budget = outcome.kind == "hang" or (
+            outcome.kind == "ok" and outcome.elapsed > float(DEADLINE_S)
+        )
+        self.assertTrue(
+            beyond_budget,
+            f"mutation stayed bounded: kind={outcome.kind} elapsed={outcome.elapsed:.3f} reason={outcome.reason!r}",
+        )
+
+    def test_mutation_write_first_false_green_or_hang(self) -> None:
+        outcome = self._mut("write_first", STDIN_256K)
+        beyond_budget = outcome.kind == "hang" or (
+            outcome.kind == "ok" and outcome.elapsed > float(DEADLINE_S)
+        )
+        self.assertTrue(
+            beyond_budget,
+            f"mutation stayed bounded: kind={outcome.kind} elapsed={outcome.elapsed:.3f} reason={outcome.reason!r}",
+        )
+
+    def test_mutation_empty_control_stays_green(self) -> None:
+        outcome = self._mut("true", b"")
+        self.assertEqual(outcome.kind, "ok", outcome.reason)
+        self.assertEqual(outcome.result.returncode, 0)
+        self.assertLess(outcome.elapsed, SLEEP_S)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_run_bounded_stdin.py
+++ b/scripts/ci/test_run_bounded_stdin.py
@@ -613,6 +613,61 @@ class RequiredHookTableTests(unittest.TestCase):
         config = self._config().replace(real, f"      # - id: {hook_id}\n{real}", 1)
         WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
 
+    def _scalar_decoy(self) -> str:
+        config = self._config()
+        blocks: list[str] = []
+        for hook_id, _entry in WORKFLOW_MOD.REQUIRED_CLAUDE_PLUGIN_HOOKS:
+            block = WORKFLOW_MOD._hook_block_by_id(config, hook_id)
+            blocks.append(block)
+            config = config.replace(block, "", 1)
+        body = "\n".join(blocks)
+        indented = "\n".join("    " + line for line in body.splitlines())
+        return config.rstrip() + "\n\ndecoy: |\n" + indented + "\n"
+
+    def _ruby_safe_load_ok(self, config: str) -> None:
+        script = (
+            "require \"yaml\"; YAML.safe_load(STDIN.read, aliases: false); "
+            "STDOUT.write(\"ok\")"
+        )
+        result = subprocess.run(
+            ["ruby", "-EUTF-8:UTF-8", "-e", script],
+            input=config,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "ok")
+
+    def test_mutation_scalar_decoy_goes_red(self) -> None:
+        config = self._scalar_decoy()
+        self._ruby_safe_load_ok(config)
+        self.assertIn("- id: claude-plugin-install-workflow-self-test", config)
+        self.assertIn("- id: claude-plugin-run-bounded-stdin", config)
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+            WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
+        self.assertIn("claude-plugin-install-workflow-self-test", raised.exception.reason)
+
+    def test_mutation_duplicate_real_hook_goes_red(self) -> None:
+        hook_id = "claude-plugin-run-bounded-stdin"
+        block = WORKFLOW_MOD._hook_block_by_id(self._config(), hook_id)
+        config = self._config().replace(block, block + block, 1)
+        self._ruby_safe_load_ok(config)
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+            WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
+        self.assertIn(hook_id, raised.exception.reason)
+
+    def test_missing_yaml_parser_fails_closed(self) -> None:
+        with patch.object(WORKFLOW_MOD.subprocess, "run", side_effect=FileNotFoundError):
+            with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+                WORKFLOW_MOD.assert_required_claude_plugin_hooks()
+        self.assertIn("ruby", raised.exception.reason)
+
+    def test_invalid_yaml_fails_closed(self) -> None:
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+            WORKFLOW_MOD.assert_required_claude_plugin_hooks("repos: [\n")
+        self.assertIn("YAML", raised.exception.reason)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/test_run_bounded_stdin.py
+++ b/scripts/ci/test_run_bounded_stdin.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import signal
 import subprocess
@@ -667,6 +668,114 @@ class RequiredHookTableTests(unittest.TestCase):
         with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
             WORKFLOW_MOD.assert_required_claude_plugin_hooks("repos: [\n")
         self.assertIn("YAML", raised.exception.reason)
+
+    def _dump_yaml(self, parsed: object) -> str:
+        script = (
+            "require \"json\"; require \"yaml\"; "
+            "STDOUT.write(YAML.dump(JSON.parse(STDIN.read)))"
+        )
+        result = subprocess.run(
+            ["ruby", "-EUTF-8:UTF-8", "-e", script],
+            input=json.dumps(parsed),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result.stdout
+
+    def _mutate_required_hooks(self, mutator: Callable[[str, dict[str, Any], dict[str, Any]], None]) -> str:
+        parsed = WORKFLOW_MOD.load_pre_commit_yaml(self._config())
+        required = {hook_id for hook_id, _entry in WORKFLOW_MOD.REQUIRED_CLAUDE_PLUGIN_HOOKS}
+        if not isinstance(parsed, dict) or not isinstance(parsed.get("repos"), list):
+            self.fail("pre-commit config root is not a mapping with repos")
+        for repo in parsed["repos"]:
+            if not isinstance(repo, dict) or not isinstance(repo.get("hooks"), list):
+                continue
+            for hook in repo["hooks"]:
+                if isinstance(hook, dict) and hook.get("id") in required:
+                    mutator(str(hook["id"]), repo, hook)
+        return self._dump_yaml(parsed)
+
+    def test_mutation_required_hooks_on_remote_repo_goes_red(self) -> None:
+        parsed = WORKFLOW_MOD.load_pre_commit_yaml(self._config())
+        required = {hook_id for hook_id, _entry in WORKFLOW_MOD.REQUIRED_CLAUDE_PLUGIN_HOOKS}
+        moved: list[dict[str, Any]] = []
+        assert isinstance(parsed, dict)
+        for repo in parsed["repos"]:
+            if not isinstance(repo, dict) or repo.get("repo") != "local":
+                continue
+            keep: list[Any] = []
+            for hook in repo.get("hooks") or []:
+                if isinstance(hook, dict) and hook.get("id") in required:
+                    moved.append(hook)
+                else:
+                    keep.append(hook)
+            repo["hooks"] = keep
+        parsed["repos"].append(
+            {
+                "repo": "https://github.com/pre-commit/pre-commit-hooks",
+                "rev": "v6.0.0",
+                "hooks": moved,
+            }
+        )
+        config = self._dump_yaml(parsed)
+        self._ruby_safe_load_ok(config)
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+            WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
+        self.assertIn("local", raised.exception.reason)
+
+    def test_mutation_self_test_manual_stage_goes_red(self) -> None:
+        def mutator(hook_id: str, _repo: dict[str, Any], hook: dict[str, Any]) -> None:
+            if hook_id == "claude-plugin-install-workflow-self-test":
+                hook["stages"] = ["manual"]
+        config = self._mutate_required_hooks(mutator)
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+            WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
+        self.assertIn("claude-plugin-install-workflow-self-test", raised.exception.reason)
+        self.assertIn("pre-push", raised.exception.reason)
+
+    def test_mutation_stdin_manual_stage_goes_red(self) -> None:
+        def mutator(hook_id: str, _repo: dict[str, Any], hook: dict[str, Any]) -> None:
+            if hook_id == "claude-plugin-run-bounded-stdin":
+                hook["stages"] = ["manual"]
+        config = self._mutate_required_hooks(mutator)
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+            WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
+        self.assertIn("claude-plugin-run-bounded-stdin", raised.exception.reason)
+        self.assertIn("pre-commit", raised.exception.reason)
+
+    def test_mutation_stdin_empty_files_selector_goes_red(self) -> None:
+        def mutator(hook_id: str, _repo: dict[str, Any], hook: dict[str, Any]) -> None:
+            if hook_id == "claude-plugin-run-bounded-stdin":
+                hook["files"] = "^$"
+        config = self._mutate_required_hooks(mutator)
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+            WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
+        self.assertIn("claude-plugin-run-bounded-stdin", raised.exception.reason)
+
+    def test_unrelated_local_hook_moved_remote_stays_green(self) -> None:
+        parsed = WORKFLOW_MOD.load_pre_commit_yaml(self._config())
+        assert isinstance(parsed, dict)
+        moved: list[dict[str, Any]] = []
+        for repo in parsed["repos"]:
+            if not isinstance(repo, dict) or repo.get("repo") != "local":
+                continue
+            keep: list[Any] = []
+            for hook in repo.get("hooks") or []:
+                if isinstance(hook, dict) and hook.get("id") == "claude-plugin-install-import-safe":
+                    moved.append(hook)
+                else:
+                    keep.append(hook)
+            repo["hooks"] = keep
+        parsed["repos"].append(
+            {
+                "repo": "https://github.com/pre-commit/pre-commit-hooks",
+                "rev": "v6.0.0",
+                "hooks": moved,
+            }
+        )
+        WORKFLOW_MOD.assert_required_claude_plugin_hooks(self._dump_yaml(parsed))
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_run_bounded_stdin.py
+++ b/scripts/ci/test_run_bounded_stdin.py
@@ -24,6 +24,7 @@ STDIN_256K = b"x" * 262_144
 DEADLINE_S = "0.05"
 SLEEP_S = 0.35
 WALL_S = 1.0
+SUBPROCESS_ENV = {**os.environ, "ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS": DEADLINE_S}
 
 
 def load_workflow() -> ModuleType:
@@ -173,6 +174,46 @@ spec.loader.exec_module(mod)
 """
 
 
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _wait_pidfile(pidfile: Path, timeout: float = 1.0) -> int | None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            raw = pidfile.read_text().strip()
+        except FileNotFoundError:
+            time.sleep(0.01)
+            continue
+        if raw.isdigit():
+            return int(raw)
+        time.sleep(0.01)
+    return None
+
+
+def _scan_live_by_proc(proc_root: Path, token: str) -> list[int]:
+    leftover: list[int] = []
+    for entry in proc_root.iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            cmdline = (entry / "cmdline").read_bytes().replace(bytes([0]), b" ").decode(
+                "utf-8", "replace"
+            )
+        except OSError:
+            continue
+        if token in cmdline:
+            leftover.append(int(entry.name))
+    return leftover
+
+
 class BoundedStdinTests(unittest.TestCase):
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
@@ -183,13 +224,14 @@ class BoundedStdinTests(unittest.TestCase):
         _reap_probe(self.pidfile)
         self._tmp.cleanup()
 
-    def _run(self, action: str, stdin: bytes) -> Outcome:
+    def _run(self, action: str, stdin: bytes, **kwargs: Any) -> Outcome:
         return _invoke(
             WORKFLOW_MOD.run_bounded,
             _python(_probe_body(action)),
             stdin,
             self.cwd,
             self.pidfile,
+            **kwargs,
         )
 
     def test_non_reader_fails_by_deadline(self) -> None:
@@ -234,10 +276,108 @@ class BoundedStdinTests(unittest.TestCase):
         self.assertIn("ceiling", outcome.reason)
         self.assertIn("stdout", outcome.reason)
 
+    def test_deadline_reaps_child_via_pidfile(self) -> None:
+        outcome = self._run("non_reader", b"")
+        self.assertEqual(outcome.kind, "err", outcome.reason)
+        pid = _wait_pidfile(self.pidfile, timeout=0.2)
+        if pid is not None:
+            self.assertFalse(_pid_alive(pid), f"child {pid} survived deadline")
 
-class FcntlUnavailableTests(unittest.TestCase):
-    """Import stays safe when fcntl is missing; run_bounded fails only if stdin needs it."""
+    def test_exit_7_rejected_preserves_sentinel(self) -> None:
+        argv = _python(
+            "import sys\nsys.stderr.write('err-sentinel\\n')\nraise SystemExit(7)\n"
+        )
+        outcome = _invoke(WORKFLOW_MOD.run_bounded, argv, b"", self.cwd, self.pidfile)
+        self.assertEqual(outcome.kind, "err", outcome.reason)
+        self.assertIn("exited 7", outcome.reason)
+        self.assertIn("err-sentinel", outcome.reason)
 
+    def test_exit_7_allowed_preserves_rc_and_stderr(self) -> None:
+        argv = _python(
+            "import sys\nsys.stderr.write('err-sentinel\\n')\nraise SystemExit(7)\n"
+        )
+        env = WORKFLOW_MOD.clean_env(
+            {"BOUNDED_STDIN_PIDFILE": str(self.pidfile), "PYTHONUNBUFFERED": "1"}
+        )
+        with patch.dict(
+            os.environ,
+            {"ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS": DEADLINE_S},
+            clear=False,
+        ):
+            result = WORKFLOW_MOD.run_bounded(
+                "bounded_stdin",
+                argv,
+                cwd=self.cwd,
+                env=env,
+                stdin=b"",
+                allowed_codes=(7,),
+            )
+        self.assertEqual(result.returncode, 7)
+        self.assertIn(b"err-sentinel", result.stderr)
+
+    def test_mutation_swallow_exit_7_goes_red(self) -> None:
+        argv = _python(
+            "import sys\nsys.stderr.write('err-sentinel\\n')\nraise SystemExit(7)\n"
+        )
+        real_fail = WORKFLOW_MOD.fail
+
+        def swallow(phase: str, reason: str, next_step: str) -> None:
+            real_fail(phase, "command exited 0: no diagnostic output", next_step)
+
+        with patch.object(WORKFLOW_MOD, "fail", swallow):
+            with self.assertRaises(WORKFLOW_MOD.WorkflowError) as mutant:
+                WORKFLOW_MOD.run_bounded(
+                    "bounded_stdin",
+                    argv,
+                    cwd=self.cwd,
+                    env=WORKFLOW_MOD.clean_env(),
+                    stdin=b"",
+                )
+        self.assertNotIn("exited 7", mutant.exception.reason)
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as production:
+            WORKFLOW_MOD.run_bounded(
+                "bounded_stdin",
+                argv,
+                cwd=self.cwd,
+                env=WORKFLOW_MOD.clean_env(),
+                stdin=b"",
+            )
+        self.assertIn("exited 7", production.exception.reason)
+        self.assertIn("err-sentinel", production.exception.reason)
+
+    def test_mutation_replace_stderr_goes_red(self) -> None:
+        argv = _python(
+            "import sys\nsys.stderr.write('err-sentinel\\n')\nraise SystemExit(7)\n"
+        )
+        real_fail = WORKFLOW_MOD.fail
+
+        def replace(phase: str, reason: str, next_step: str) -> None:
+            real_fail(phase, "command exited 7: replaced-diagnostic", next_step)
+
+        with patch.object(WORKFLOW_MOD, "fail", replace):
+            with self.assertRaises(WORKFLOW_MOD.WorkflowError) as mutant:
+                WORKFLOW_MOD.run_bounded(
+                    "bounded_stdin",
+                    argv,
+                    cwd=self.cwd,
+                    env=WORKFLOW_MOD.clean_env(),
+                    stdin=b"",
+                )
+        self.assertIn("replaced-diagnostic", mutant.exception.reason)
+        self.assertNotIn("err-sentinel", mutant.exception.reason)
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as production:
+            WORKFLOW_MOD.run_bounded(
+                "bounded_stdin",
+                argv,
+                cwd=self.cwd,
+                env=WORKFLOW_MOD.clean_env(),
+                stdin=b"",
+            )
+        self.assertIn("err-sentinel", production.exception.reason)
+        self.assertNotIn("replaced-diagnostic", production.exception.reason)
+
+
+class SupervisorPreflightTests(unittest.TestCase):
     def test_import_succeeds_when_fcntl_unavailable(self) -> None:
         script = FCNTL_BLOCKER + "print('imported', mod.MAX_BYTES)\n"
         result = subprocess.run(
@@ -245,145 +385,197 @@ class FcntlUnavailableTests(unittest.TestCase):
             capture_output=True,
             text=True,
             check=False,
+            env=SUBPROCESS_ENV,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("imported", result.stdout)
 
-    def test_run_bounded_fails_explicitly_when_stdin_needs_fcntl(self) -> None:
-        script = (
-            FCNTL_BLOCKER
-            + """
-import tempfile
-from pathlib import Path
-cwd = Path(tempfile.mkdtemp())
-try:
-    mod.run_bounded(
-        "bounded_stdin",
-        [sys.executable, "-c", "raise SystemExit(0)"],
-        cwd=cwd,
-        env=mod.clean_env(),
-        stdin=b"x",
-    )
-except mod.WorkflowError as error:
-    print("reason", error.reason)
-    raise SystemExit(0)
-print("unexpected success")
-raise SystemExit(2)
-"""
-        )
-        result = subprocess.run(
-            [sys.executable, "-c", script, str(WORKFLOW)],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("fcntl", result.stdout)
-        self.assertIn("POSIX", result.stdout)
-
-    def test_fcntl_unavailable_child_is_reaped(self) -> None:
-        token = "bounded-fcntl-reap-probe"
+    def test_fcntl_unavailable_refuses_before_spawn(self) -> None:
         inner = """
-import os, time, tempfile
+import os, tempfile
 from pathlib import Path
 cwd = Path(tempfile.mkdtemp())
-pidfile = cwd / "child.pid"
-token = %r
-nl = chr(10)
-child = nl.join([
-    "import os, time",
-    "from pathlib import Path",
-    "Path(os.environ['BOUNDED_STDIN_PIDFILE']).write_text(str(os.getpid()))",
-    "time.sleep(30)",
-    "# " + token,
-])
+marker = cwd / "started"
+child = "from pathlib import Path; Path(%r).write_text('started'); import time; time.sleep(30)" % str(marker)
 try:
     mod.run_bounded(
         "bounded_stdin",
         [sys.executable, "-c", child],
         cwd=cwd,
-        env=mod.clean_env({"BOUNDED_STDIN_PIDFILE": str(pidfile), "PYTHONUNBUFFERED": "1"}),
+        env=mod.clean_env(),
         stdin=b"x",
     )
     print("unexpected success")
     raise SystemExit(2)
 except mod.WorkflowError as error:
     print("reason", error.reason)
-
-def alive(pid):
-    try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-
-pid = None
-deadline = time.monotonic() + 1.0
-while time.monotonic() < deadline:
-    if pidfile.exists():
-        raw = pidfile.read_text().strip()
-        if raw.isdigit():
-            pid = int(raw)
-            break
+import time
+deadline = time.monotonic() + 0.25
+while time.monotonic() < deadline and not marker.exists():
     time.sleep(0.01)
-
-self_pid = os.getpid()
-leftover = []
-for entry in Path("/proc").iterdir():
-    if not entry.name.isdigit():
-        continue
-    pid_n = int(entry.name)
-    if pid_n == self_pid:
-        continue
-    try:
-        cmdline = (entry / "cmdline").read_bytes().replace(bytes([0]), b" ").decode("utf-8", "replace")
-    except OSError:
-        continue
-    if token in cmdline:
-        leftover.append(pid_n)
-
-if pid is not None and alive(pid):
-    print("still-live", pid)
-    raise SystemExit(3)
-print("leftover", leftover)
-if leftover:
-    raise SystemExit(4)
-print("reaped")
-""" % token
+print("marker", marker.exists())
+"""
         result = subprocess.run(
             [sys.executable, "-c", FCNTL_BLOCKER + inner, str(WORKFLOW)],
             capture_output=True,
             text=True,
             check=False,
+            env=SUBPROCESS_ENV,
         )
         self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
-        self.assertIn("reaped", result.stdout)
+        self.assertIn("supervisor", result.stdout)
+        self.assertIn("fcntl", result.stdout)
+        self.assertNotIn("nonblocking stdin", result.stdout)
+        self.assertIn("marker False", result.stdout)
 
-    def test_empty_stdin_does_not_require_fcntl(self) -> None:
-        script = (
-            FCNTL_BLOCKER
-            + """
-import tempfile
+    def test_killpg_unavailable_refuses_before_spawn(self) -> None:
+        inner = r"""
+import os, tempfile, sys
 from pathlib import Path
+from importlib.util import module_from_spec, spec_from_file_location
+spec = spec_from_file_location("wf_no_killpg", sys.argv[1])
+mod = module_from_spec(spec)
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+if hasattr(os, "killpg"):
+    del os.killpg
 cwd = Path(tempfile.mkdtemp())
-result = mod.run_bounded(
-    "bounded_stdin",
-    [sys.executable, "-c", "raise SystemExit(0)"],
-    cwd=cwd,
-    env=mod.clean_env(),
-    stdin=b"",
-)
-print("rc", result.returncode)
+marker = cwd / "started"
+child = "from pathlib import Path; Path(%r).write_text('started'); import time; time.sleep(30)" % str(marker)
+try:
+    mod.run_bounded(
+        "bounded_stdin",
+        [sys.executable, "-c", child],
+        cwd=cwd,
+        env=mod.clean_env(),
+        stdin=b"",
+    )
+    print("unexpected success")
+    raise SystemExit(2)
+except Exception as error:
+    print("reason", getattr(error, "reason", type(error).__name__ + ": " + str(error)))
+import time
+deadline = time.monotonic() + 0.25
+while time.monotonic() < deadline and not marker.exists():
+    time.sleep(0.01)
+print("marker", marker.exists())
 """
-        )
         result = subprocess.run(
-            [sys.executable, "-c", script, str(WORKFLOW)],
+            [sys.executable, "-c", inner, str(WORKFLOW)],
             capture_output=True,
             text=True,
             check=False,
+            env=SUBPROCESS_ENV,
         )
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("rc 0", result.stdout)
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("supervisor", result.stdout)
+        self.assertIn("killpg", result.stdout)
+        self.assertIn("marker False", result.stdout)
+
+    def test_mutation_disable_preflight_starts_marker_child(self) -> None:
+        inner = """
+import os, signal, subprocess, tempfile, time
+from pathlib import Path
+cwd = Path(tempfile.mkdtemp())
+marker = cwd / "started"
+orig = getattr(mod, "require_bounded_supervisor", None)
+if orig is None:
+    print("missing-preflight")
+    raise SystemExit(3)
+mod.require_bounded_supervisor = lambda phase: None
+real_popen = subprocess.Popen
+spawned = []
+def wrapping_popen(*args, **kwargs):
+    process = real_popen(*args, **kwargs)
+    spawned.append(process)
+    return process
+subprocess.Popen = wrapping_popen
+try:
+    try:
+        mod.run_bounded(
+            "bounded_stdin",
+            ["/bin/sleep", "30"],
+            cwd=cwd,
+            env=mod.clean_env(),
+            stdin=b"x",
+        )
+    except mod.WorkflowError as error:
+        print("reason", error.reason)
+finally:
+    subprocess.Popen = real_popen
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline and not marker.exists():
+        time.sleep(0.01)
+    print("spawned", len(spawned))
+    print("marker", marker.exists())
+    for process in spawned:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+        try:
+            process.wait(timeout=1.0)
+        except Exception:
+            pass
+    mod.require_bounded_supervisor = orig
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", FCNTL_BLOCKER + inner, str(WORKFLOW)],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=SUBPROCESS_ENV,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("spawned 1", result.stdout)
+        self.assertIn("nonblocking stdin", result.stdout)
+        self.assertNotIn("supervisor", result.stdout)
+
+    def test_mutation_proc_scan_fails_without_proc(self) -> None:
+        missing = Path(tempfile.mkdtemp()) / "no-proc"
+        with self.assertRaises(FileNotFoundError):
+            _scan_live_by_proc(missing, "bounded-fcntl-reap-probe")
+
+
+class RequiredHookTableTests(unittest.TestCase):
+    def test_required_hooks_are_pinned(self) -> None:
+        WORKFLOW_MOD.assert_required_claude_plugin_hooks()
+
+    def _config(self) -> str:
+        return (ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+
+    def test_mutation_delete_stdin_hook_goes_red(self) -> None:
+        config = self._config().replace("claude-plugin-run-bounded-stdin", "claude-plugin-run-bounded-gone")
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+            WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
+        self.assertIn("claude-plugin-run-bounded-stdin", str(raised.exception.reason))
+
+    def test_mutation_retarget_stdin_hook_goes_red(self) -> None:
+        config = self._config().replace(
+            "python3 scripts/ci/test_run_bounded_stdin.py",
+            "python3 scripts/ci/test_claude_plugin_install_import.py",
+        )
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+            WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
+        self.assertIn("claude-plugin-run-bounded-stdin", str(raised.exception.reason))
+
+    def test_mutation_delete_self_test_hook_goes_red(self) -> None:
+        config = self._config().replace(
+            "claude-plugin-install-workflow-self-test",
+            "claude-plugin-install-workflow-gone",
+        )
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+            WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
+        self.assertIn("claude-plugin-install-workflow-self-test", str(raised.exception.reason))
+
+    def test_mutation_retarget_self_test_hook_goes_red(self) -> None:
+        config = self._config().replace(
+            "bash scripts/ci/test-claude-plugin-install.sh --self-test",
+            "bash scripts/ci/test-claude-plugin-install.sh --verify",
+        )
+        with self.assertRaises(WORKFLOW_MOD.WorkflowError) as raised:
+            WORKFLOW_MOD.assert_required_claude_plugin_hooks(config)
+        self.assertIn("claude-plugin-install-workflow-self-test", str(raised.exception.reason))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #2193.

Wait-gate: `origin/main` `2b1339e309c7027d63970dd5913b28b3bab36409`. Head `cb4771fba2f895af3a55efae2c4558dfa7fe5cb9` (merge-not-rebase of that main; tree `0807c5f774a22eb73c6329b979052dc9a14f272f`). Draft only; do not ready or merge. New head needs a fresh independent review. #2193 stays open until final review.

## Change
`run_bounded` in `scripts/ci/claude_plugin_install_workflow.py` armed the absolute deadline after a blocking stdin `write`/`flush`/`close`. A non-reader with 256KiB stdin could fill the pipe and stall before the clock started. The deadline is now armed immediately after `Popen`, and stdin is delivered nonblocking on the existing POSIX selector (one event loop). `killpg`, output ceilings, orphan drain, and BrokenPipe behavior are unchanged.

`fcntl` is imported lazily inside the nonblocking helper. Importing the module stays safe on non-POSIX hosts. `require_bounded_supervisor` now runs before `Popen` and names unavailable `killpg` / `fcntl` as `WorkflowError`, so unsupported hosts refuse before spawn. Windows process-tree semantics are not implemented.

If `_set_nonblocking` or selector registration fails after `Popen`, the process tree is terminated and stdin/stdout/stderr are closed before re-raising. All three pipe file objects are closed after selector ownership ends on every normal and error path.

Child-not-leaked is proven with a pidfile plus `os.kill(pid, 0)`, not `/proc`, so the focused suite runs on Darwin.

A required-hook table pins both `claude-plugin-install-workflow-self-test` and `claude-plugin-run-bounded-stdin`. Deleting or retargeting either goes red. Exit 7 plus `err-sentinel` is preserved under default rejection and `allowed_codes=(7,)`.

## TDD
RED on current `run_bounded` (256KiB stdin, 0.05s deadline): finite non-reader returned success (false-green); write-first stdout producer hung past the 1s wall. Reader, empty-stdin timeout, early stdin close, and stdout >1MiB ceiling were already green.

GREEN after the selector path: both backpressure cases fail by the bounded deadline (elapsed < 0.35s sleep); reader still succeeds; empty stdin still times out; empty immediate-exit still succeeds; early close still succeeds; stdout ceiling still terminates the tree.

Manual reversal (not in-tree): restore blocking `write`/`flush`/`close` before the deadline. The production non-reader and write-first tests go RED again (false-green or hang beyond budget). Empty production control stays green. No second `run_bounded` copy is shipped.

This follow-on: RED without `require_bounded_supervisor` (hiding `killpg` still spawned; hook table missing). GREEN after the shared preflight, pidfile reap, hook table, and exit-7 pins. Mutations that bite: reintroduce `/proc` scan without `/proc`; delete/retarget either required hook; disable preflight so `Popen` runs; hide `killpg`/`fcntl`; swallow/replace exit 7 or stderr. Deadline and empty-stdin controls stay green.

## Follow-on: upstream advance only
Merge commit `cb4771fba2f895af3a55efae2c4558dfa7fe5cb9` parents `9938f51daa7688103804f362c4b40a6661a4dfb1` and `2b1339e309c7027d63970dd5913b28b3bab36409`. `HEAD^{tree}` is `0807c5f774a22eb73c6329b979052dc9a14f272f`. Main advance vs PR base `3dd32b8f` is only `scripts/ci/codex_host_proof_validator.mjs` and `scripts/ci/test_codex_host_proof.mjs`. Intersection with the three #2736 paths is empty; those blobs are unchanged vs `9938f51d`. No product edit.

## Follow-on: effective wiring
A remote `repo` still kept the required ids green. Each required hook must now appear exactly once under `repo: local`. Self-test stages must be exactly `[pre-push]`. Bounded-stdin stages are explicit `[pre-commit, pre-push]`, and its compiled `files` regex must match `scripts/ci/claude_plugin_install_workflow.py`, `scripts/ci/test_run_bounded_stdin.py`, and `.pre-commit-config.yaml`. Same `repos[*].hooks[*]` parse; no broader YAML policy.

## Follow-on: scalar decoy is not a hook
Removing both required hook mappings and pasting their text into a top-level YAML block scalar kept the raw-text guard green. `assert_required_claude_plugin_hooks` now loads `.pre-commit-config.yaml` with the same Ruby `YAML.safe_load` route as `scripts/ci/check-assay-action-pin.sh` and walks `repos[*].hooks[*]`. Exactly one mapping per required id, with the exact `entry`. Comments and scalar values do not count. Missing ruby or invalid YAML fails closed. No new Python dependency.

## Follow-on: commented `- id:` is not a hook
Unanchored `config.find("id: ...")` stayed green when either real `- id:` line was commented out. Discovery now requires exactly one uncommented YAML list item `^[ \t]*- id: <hook>[ \t]*$` for both required ids. Comment-out of each line goes red; a commented duplicate next to the real item stays green.

## Evidence
- Linux: `PYTHONWARNINGS=error::ResourceWarning python3 scripts/ci/test_run_bounded_stdin.py` 34/34 (kept the previous 29, plus remote-repo, `[manual]` stages, `files: ^$`, and an unrelated-local no-op); `test_claude_plugin_install_import.py`; both hook entries; `git diff --check` clean. `pre-commit` not installed on this host, so no `validate-config` / live hook run here.
- Darwin 3.14.3, no `/proc`: same 22 stdin tests plus import-safe, 2.549s.

## Files
- `scripts/ci/claude_plugin_install_workflow.py`
- `scripts/ci/test_run_bounded_stdin.py`
- `.pre-commit-config.yaml` (discovery hook already present; entries pinned by the required-hook table, file itself unchanged in this follow-on)

## Shared invariants with `tests/support/bounded_process.rs` (#2189/#2190)

POSIX-only. Same invariants, not a cross-language abstraction. No docs file and no table-driven cross-language harness.

| invariant | Python `run_bounded` | Rust `bounded_process.rs` |
| --- | --- | --- |
| absolute deadline | armed before any stdin I/O; selector `select` is capped by remaining time | `Instant::now() + limits.timeout` governs the wait |
| separate stdout/stderr caps | `MAX_BYTES` per stream; oversize terminates the tree | `max_stdout_bytes` / `max_stderr_bytes` |
| process-tree termination | `killpg` via `start_new_session` | Unix process group / Windows Job Object |
| descendant-held pipe / orphan drain | same absolute deadline continues after the direct child exits | descendants remaining in the group/job are terminated before return |
| stdin supervision | nonblocking writes on the same selector under that deadline | stdin writer is included in outstanding-deadline state |

## Non-claims
- Not a reproduced Claude-host hang (real initialize payload was 622 bytes, not 256KiB).
- POSIX-only; Windows / non-POSIX is a non-claim for this Python helper. Import is safe there; `run_bounded` refuses before spawn and does not grow Windows process-tree support.
- Not a shared abstraction with the Rust helper; comment-only cross-reference.
- No Cargo, auth, Claude host/model call, or unrelated cleanup.
- #2474 remains parked; Cursor owns that side.
- #2193 is not closed until final review/merge.




