### PR TITLE
fix(ci): accept current Codex host lifecycle safely

### DIFF
--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -44,6 +44,7 @@ import {
   projectRetainedEvent,
   projectHostIdentity,
   proofAllowlist,
+  requirePrivateDirectory,
   requirePrivateProofRoot,
   requiredCellsForJourney,
   resolvePendingResponse,
@@ -142,6 +143,14 @@ function requireFreshProofRoot(proofRoot) {
     fs.mkdirSync(proofRoot, { recursive: true, mode: 0o700 });
   }
   return requirePrivateProofRoot(proofRoot);
+}
+
+function requireOrCreatePrivateCodexHome(projectRoot) {
+  const codexHome = path.join(projectRoot, ".codex-home");
+  if (!fs.existsSync(codexHome)) {
+    fs.mkdirSync(codexHome, { mode: 0o700 });
+  }
+  return requirePrivateDirectory(codexHome, "CODEX_HOME");
 }
 
 function encode(message) {
@@ -529,11 +538,11 @@ export async function runProof(options) {
   if (credential) {
     return writeProofFiles(options, {
       events: [
-        {
+        projectRetainedEvent({
           direction: "driver",
           method: "error",
           params: { message: credential },
-        },
+        }),
       ],
       childExit: 1,
       truncated: false,
@@ -543,6 +552,7 @@ export async function runProof(options) {
     });
   }
 
+  const codexHome = requireOrCreatePrivateCodexHome(options.projectRoot);
   const events = [];
   const stdout = new BoundBuffer(options.maxBytes);
   const stderr = new BoundBuffer(options.maxBytes);
@@ -580,7 +590,7 @@ export async function runProof(options) {
     env: {
       PATH: process.env.PATH,
       HOME: options.projectRoot,
-      CODEX_HOME: path.join(options.projectRoot, ".codex-home"),
+      CODEX_HOME: codexHome,
     },
   };
   const child = options.testOnlyChild
@@ -646,11 +656,13 @@ export async function runProof(options) {
     }
     if (resolved.kind === "reject") {
       streamUnavailable = true;
-      retainEvent({
-        direction: "driver",
-        method: "error",
-        params: { message: resolved.reason },
-      });
+      retainEvent(
+        projectRetainedEvent({
+          direction: "driver",
+          method: "error",
+          params: { message: resolved.reason },
+        }),
+      );
       stopChild();
       return;
     }
@@ -730,11 +742,13 @@ export async function runProof(options) {
       } else {
         streamUnavailable = true;
       }
-      retainEvent({
-        direction: "driver",
-        method: "error",
-        params: { message: "stdio parse failed" },
-      });
+      retainEvent(
+        projectRetainedEvent({
+          direction: "driver",
+          method: "error",
+          params: { message: "stdio parse failed" },
+        }),
+      );
       stopChild();
     }
   });
@@ -870,7 +884,13 @@ export async function runProof(options) {
     }
   } catch (error) {
     streamUnavailable = streamUnavailable || /timeout|unavailable/i.test(String(error));
-    retainEvent({ direction: "driver", method: "error", params: { message: String(error) } });
+    retainEvent(
+      projectRetainedEvent({
+        direction: "driver",
+        method: "error",
+        params: { message: String(error) },
+      }),
+    );
     stopChild();
   }
 

--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -556,6 +556,9 @@ export async function runProof(options) {
     return writePreSpawnFailure(options, credential);
   }
 
+  if (!options.testOnlyChild && !options.hostIdentity) {
+    options.hostIdentity = resolveHostIdentity({ proofRoot: options.proofRoot });
+  }
   let codexHome;
   try {
     codexHome = requireOrCreatePrivateCodexHome(options.projectRoot);
@@ -590,9 +593,6 @@ export async function runProof(options) {
     return true;
   };
 
-  if (!options.testOnlyChild && !options.hostIdentity) {
-    options.hostIdentity = resolveHostIdentity({ proofRoot: options.proofRoot });
-  }
   const bound = options.hostIdentity?.[BOUND_EXEC];
   const spawnOpts = {
     stdio: ["pipe", "pipe", "pipe"],

--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -509,7 +509,7 @@ function writePreSpawnFailure(options, message) {
     events: [
       projectRetainedEvent({
         direction: "driver",
-        method: "error",
+        method: "pre-spawn-error",
         params: { message },
       }),
     ],

--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -504,6 +504,23 @@ function writeProofFiles(options, pack) {
   };
 }
 
+function writePreSpawnFailure(options, message) {
+  return writeProofFiles(options, {
+    events: [
+      projectRetainedEvent({
+        direction: "driver",
+        method: "error",
+        params: { message },
+      }),
+    ],
+    childExit: 1,
+    truncated: false,
+    streamUnavailable: true,
+    stdoutBytes: 0,
+    stderrBytes: 0,
+  });
+}
+
 export async function runProof(options) {
   requiredCellsForJourney(options.journey);
   const forbidden = forbiddenProofRoot(
@@ -536,23 +553,15 @@ export async function runProof(options) {
     ? credentialArgvReason(options.childArgv)
     : null;
   if (credential) {
-    return writeProofFiles(options, {
-      events: [
-        projectRetainedEvent({
-          direction: "driver",
-          method: "error",
-          params: { message: credential },
-        }),
-      ],
-      childExit: 1,
-      truncated: false,
-      streamUnavailable: true,
-      stdoutBytes: 0,
-      stderrBytes: 0,
-    });
+    return writePreSpawnFailure(options, credential);
   }
 
-  const codexHome = requireOrCreatePrivateCodexHome(options.projectRoot);
+  let codexHome;
+  try {
+    codexHome = requireOrCreatePrivateCodexHome(options.projectRoot);
+  } catch (error) {
+    return writePreSpawnFailure(options, String(error));
+  }
   const events = [];
   const stdout = new BoundBuffer(options.maxBytes);
   const stderr = new BoundBuffer(options.maxBytes);

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -486,9 +486,6 @@ export function driverOutcomeExit(pack, cells, journey) {
 }
 
 export function closedDriverOutcomeStatus(meta) {
-  if (meta.streamUnavailable || meta.truncated) {
-    return "unavailable";
-  }
   const child = meta.childExitCode;
   const outcome = meta.driverOutcome;
   if (outcome == null) {
@@ -496,6 +493,11 @@ export function closedDriverOutcomeStatus(meta) {
   }
   if (typeof outcome !== "object" || Array.isArray(outcome) || typeof outcome.exitCode !== "number") {
     return "invalid";
+  }
+  if (meta.streamUnavailable || meta.truncated) {
+    return outcome.exitCode !== 0 && outcome.status === "unavailable"
+      ? "unavailable"
+      : "invalid";
   }
   if (child === 0 && outcome.exitCode === 0 && outcome.status === "pass") {
     return "pass";

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -41,24 +41,28 @@ export const HOST_ALLOWLIST = Object.freeze([...ALLOWLIST, ...HOST_SUBJECTS]);
 export const EXTERNAL_ATTESTATION = "not_provided";
 export const HOST_ENV_NAMES = Object.freeze(["PATH", "HOME", "CODEX_HOME"]);
 
-export function requirePrivateProofRoot(proofRoot) {
-  if (typeof proofRoot !== "string" || proofRoot.length === 0) {
-    throw new Error("proof root must be a non-empty path");
+export function requirePrivateDirectory(directory, label) {
+  if (typeof directory !== "string" || directory.length === 0) {
+    throw new Error(`${label} must be a non-empty path`);
   }
-  const resolved = path.resolve(proofRoot);
+  const resolved = path.resolve(directory);
   const st = fs.lstatSync(resolved);
   if (st.isSymbolicLink() || !st.isDirectory()) {
-    throw new Error("proof root must be a real directory");
+    throw new Error(`${label} must be a real directory`);
   }
   if (process.platform !== "win32") {
     if (typeof process.getuid === "function" && st.uid !== process.getuid()) {
-      throw new Error("proof root must be owned by the current user");
+      throw new Error(`${label} must be owned by the current user`);
     }
     if ((st.mode & 0o7777) !== 0o700) {
-      throw new Error("proof root must be private to its owner (mode 0700)");
+      throw new Error(`${label} must be private to its owner (mode 0700)`);
     }
   }
   return fs.realpathSync(resolved);
+}
+
+export function requirePrivateProofRoot(proofRoot) {
+  return requirePrivateDirectory(proofRoot, "proof root");
 }
 
 export function proofAllowlist(hasHostIdentity) {
@@ -449,7 +453,7 @@ export function driverOutcomeExit(pack, cells, journey) {
   if (pack.truncated || pack.streamUnavailable) {
     return fail;
   }
-  if (cells?.driverCompleted?.status === "unavailable") {
+  if (cells?.driverCompleted?.status !== "pass") {
     return fail;
   }
   const required = requiredCellsForJourney(journey);
@@ -576,7 +580,21 @@ export function journeyPairCounts(journey) {
 }
 
 export const ALLOWED_SERVER_REQUESTS = Object.freeze(["mcpServer/elicitation/request"]);
-export const ALLOWED_SERVER_NOTIFICATIONS = Object.freeze(["item/completed", "turn/completed"]);
+export const LIFECYCLE_SERVER_NOTIFICATIONS = Object.freeze([
+  "remoteControl/status/changed",
+  "thread/started",
+  "mcpServer/startupStatus/updated",
+  "thread/status/changed",
+  "turn/started",
+  "item/started",
+]);
+export const SERVER_DIAGNOSTIC_NOTIFICATIONS = Object.freeze(["warning", "error"]);
+export const ALLOWED_SERVER_NOTIFICATIONS = Object.freeze([
+  ...LIFECYCLE_SERVER_NOTIFICATIONS,
+  ...SERVER_DIAGNOSTIC_NOTIFICATIONS,
+  "item/completed",
+  "turn/completed",
+]);
 export const ALLOWED_CLIENT_NOTIFICATIONS = Object.freeze(["initialized"]);
 export const ALLOWED_CLIENT_RESPONSES = Object.freeze(["mcpServer/elicitation/request"]);
 export const ALLOWED_DRIVER_METHODS = Object.freeze(["error"]);
@@ -628,6 +646,14 @@ function retainedItemReason(item) {
 }
 
 function retainedMethodParamsReason(method, params) {
+  if (
+    LIFECYCLE_SERVER_NOTIFICATIONS.includes(method) ||
+    SERVER_DIAGNOSTIC_NOTIFICATIONS.includes(method)
+  ) {
+    return isPlainObject(params) && Object.keys(params).length === 0
+      ? null
+      : `${method} params must be the recorder's empty object`;
+  }
   switch (method) {
     case "initialized":
       if (!isPlainObject(params) || Object.keys(params).length !== 0) {
@@ -770,6 +796,9 @@ export function classifyStoredEvent(event) {
         if (payloadReason) {
           return { type: "unclassified", reason: payloadReason };
         }
+        if (SERVER_DIAGNOSTIC_NOTIFICATIONS.includes(method)) {
+          return { type: "server-diagnostic", method };
+        }
         return { type: "server-notification", method };
       }
       return { type: "unclassified", reason: "unclassified server event" };
@@ -871,6 +900,9 @@ function consumeClassifiedEvent(classified, event, ctx) {
     case "server-notification":
       ctx.notifications.push(event);
       return;
+    case "server-diagnostic":
+      ctx.serverDiagnostics.push(event);
+      return;
     case "client-notification":
       ctx.clientNotifications.push(event);
       return;
@@ -914,6 +946,7 @@ export function consumeJourneyTopology(events, journey) {
   const clientResponses = [];
   const clientNotifications = [];
   const driverErrors = [];
+  const serverDiagnostics = [];
   if (!Array.isArray(events)) {
     return { ok: false, reasons: ["events must be an array"], pairs, counts };
   }
@@ -929,6 +962,7 @@ export function consumeJourneyTopology(events, journey) {
     clientResponses,
     clientNotifications,
     driverErrors,
+    serverDiagnostics,
   };
   for (const event of events) {
     consumeClassifiedEvent(classifyStoredEvent(event), event, ctx);
@@ -1071,6 +1105,7 @@ export function consumeJourneyTopology(events, journey) {
     clientResponses,
     clientNotifications,
     driverErrors,
+    serverDiagnostics,
   };
 }
 
@@ -1467,6 +1502,9 @@ function classifyNegative(statuses, index, label) {
 function classifyDriver(meta, topology) {
   if (Array.isArray(topology?.driverErrors) && topology.driverErrors.length > 0) {
     return cell("fail", "retained driver/error contradicts a completed journey");
+  }
+  if (Array.isArray(topology?.serverDiagnostics) && topology.serverDiagnostics.length > 0) {
+    return cell("fail", "retained server diagnostic contradicts a completed journey");
   }
   const kind = closedDriverOutcomeStatus(meta);
   if (kind === "unavailable") {

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -349,12 +349,13 @@ function verifyObservedBinary(bin) {
   }
 }
 
-export function verifyLiveIdentity(
+function verifyLiveIdentityBound(
   identity,
   invocation,
   topology,
   proofRoot,
   journey = "tool",
+  allowMissingCommand = false,
 ) {
   if (!liveIdentityBound(identity)) {
     return false;
@@ -376,7 +377,7 @@ export function verifyLiveIdentity(
   if (!verifyObservedBinary(identity.codex) || !verifyObservedBinary(identity.assayMcp)) {
     return false;
   }
-  if (journey !== "discovery") {
+  if (journey !== "discovery" && !allowMissingCommand) {
     const command =
       topology?.primaryThread?.request?.params?.config?.mcp_servers?.assay?.command;
     if (command !== identity.assayMcp.path) {
@@ -384,6 +385,16 @@ export function verifyLiveIdentity(
     }
   }
   return liveInvocationBound(identity, invocation);
+}
+
+export function verifyLiveIdentity(
+  identity,
+  invocation,
+  topology,
+  proofRoot,
+  journey = "tool",
+) {
+  return verifyLiveIdentityBound(identity, invocation, topology, proofRoot, journey, false);
 }
 
 export function liveInvocationBound(identity, invocation) {
@@ -398,7 +409,13 @@ export function liveInvocationBound(identity, invocation) {
   );
 }
 
-export function observedIdentityBound(identity, invocation, topology, proofRoot, journey = "tool") {
+export function observedIdentityBound(
+  identity,
+  invocation,
+  topology,
+  proofRoot,
+  journey = "tool",
+) {
   return verifyLiveIdentity(identity, invocation, topology, proofRoot, journey);
 }
 
@@ -597,7 +614,49 @@ export const ALLOWED_SERVER_NOTIFICATIONS = Object.freeze([
 ]);
 export const ALLOWED_CLIENT_NOTIFICATIONS = Object.freeze(["initialized"]);
 export const ALLOWED_CLIENT_RESPONSES = Object.freeze(["mcpServer/elicitation/request"]);
-export const ALLOWED_DRIVER_METHODS = Object.freeze(["error"]);
+export const ALLOWED_DRIVER_METHODS = Object.freeze(["error", "pre-spawn-error"]);
+
+export function preSpawnFailureState(events, manifest) {
+  const rows = Array.isArray(events)
+    ? events.filter(
+        (event) =>
+          isPlainObject(event) &&
+          event.direction === "driver" &&
+          event.method === "pre-spawn-error",
+      )
+    : [];
+  if (rows.length === 0) {
+    return { present: false, valid: false, reason: null };
+  }
+  const expectedEvent = {
+    direction: "driver",
+    method: "pre-spawn-error",
+    params: { message: "retained driver error" },
+  };
+  if (rows.length !== 1 || events.length !== 1 || !sameJson(rows[0], expectedEvent)) {
+    return {
+      present: true,
+      valid: false,
+      reason: "pre-spawn failure must be the one closed retained event",
+    };
+  }
+  if (
+    manifest?.childExitCode !== 1 ||
+    !sameJson(manifest?.driverOutcome, { exitCode: 1, status: "unavailable" }) ||
+    manifest?.truncated !== false ||
+    manifest?.streamUnavailable !== true ||
+    manifest?.bounds?.stdoutBytes !== 0 ||
+    manifest?.bounds?.stderrBytes !== 0 ||
+    !sameJson(manifest?.initialize, emptyInitialize())
+  ) {
+    return {
+      present: true,
+      valid: false,
+      reason: "pre-spawn failure metadata is not the closed unavailable state",
+    };
+  }
+  return { present: true, valid: true, reason: null };
+}
 
 function hasOwn(value, key) {
   return value != null && Object.prototype.hasOwnProperty.call(value, key);
@@ -2365,6 +2424,10 @@ export function validateProofRoot(proofRoot, maxBytes = DEFAULT_MAX_BYTES) {
   if (shapeReason) {
     reasons.push(shapeReason);
   }
+  const preSpawn = preSpawnFailureState(events, manifest);
+  if (preSpawn.present && !preSpawn.valid) {
+    reasons.push(preSpawn.reason);
+  }
   if (manifest.schema !== SCHEMA) {
     reasons.push(`unexpected schema ${manifest.schema}`);
   }
@@ -2482,12 +2545,13 @@ export function validateProofRoot(proofRoot, maxBytes = DEFAULT_MAX_BYTES) {
       topology = null;
     }
     if (
-      !verifyLiveIdentity(
+      !verifyLiveIdentityBound(
         manifest.hostIdentity,
         manifest.invocation,
         topology,
         proofRoot,
         manifest.journey,
+        preSpawn.valid,
       )
     ) {
       reasons.push("retained host subjects do not match their fixed paths, hashes, or commands");

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -649,6 +649,24 @@ child.on("close", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
       );
       const checked = validateProofRoot(hostCli.proofRoot);
       preSpawnResults.push({ journey: row.journey, ok: checked.ok, reasons: checked.reasons });
+      if (row.journey !== "discovery") {
+        const manifest = JSON.parse(
+          fs.readFileSync(path.join(hostCli.proofRoot, "manifest.json"), "utf8"),
+        );
+        const genericEvents = JSON.parse(
+          fs.readFileSync(path.join(hostCli.proofRoot, "events.json"), "utf8"),
+        );
+        genericEvents[0].method = "error";
+        const genericClassified = classifyRecord({ ...manifest, events: genericEvents });
+        rewriteProof(hostCli.proofRoot, manifest, genericEvents, genericClassified);
+        const genericChecked = validateProofRoot(hostCli.proofRoot);
+        assert.equal(
+          genericChecked.ok,
+          false,
+          `generic driver/error must not unlock ${row.journey} missing-command validation`,
+        );
+        assert.match(genericChecked.reasons.join("; "), /host subjects.*commands/);
+      }
       assert.equal(
         fs.existsSync(path.join(hostProjectRoot, ".codex-app-server-started")),
         false,

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -590,6 +590,26 @@ child.on("close", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
     codexBin,
   });
   assert.notEqual(fileCli.status, 0);
+  assert.deepEqual(
+    proofFiles(fileCli.proofRoot),
+    ["classification.json", "events.json", "manifest.json"],
+    "a rejected CODEX_HOME must still leave a complete retained failure record",
+  );
+  const fileEvents = JSON.parse(
+    fs.readFileSync(path.join(fileCli.proofRoot, "events.json"), "utf8"),
+  );
+  assert.deepEqual(fileEvents, [
+    {
+      direction: "driver",
+      method: "error",
+      params: { message: "retained driver error" },
+    },
+  ]);
+  const fileManifest = JSON.parse(
+    fs.readFileSync(path.join(fileCli.proofRoot, "manifest.json"), "utf8"),
+  );
+  assert.notEqual(fileManifest.driverOutcome.exitCode, 0);
+  assert.equal(validateProofRoot(fileCli.proofRoot).ok, true);
   assert.equal(
     fs.existsSync(path.join(fileProjectRoot, ".codex-app-server-started")),
     false,
@@ -2792,6 +2812,7 @@ test("current Codex lifecycle chatter is inert while diagnostics remain non-clea
   const terminalIndex = withLifecycle.findIndex(
     (event) => event.direction === "server" && event.method === "turn/completed",
   );
+  assert.notEqual(terminalIndex, -1, "control must contain the terminal turn insertion anchor");
   withLifecycle.splice(
     terminalIndex,
     0,

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -549,6 +549,13 @@ test("malformed JSON line writes unavailable evidence; CLI proof root is not emp
 test("production driver creates and verifies its disposable CODEX_HOME before spawn", () => {
   const projectRoot = seedProject();
   const codexHome = path.join(projectRoot, ".codex-home");
+  const retainedFilesWithIdentity = [
+    "assay-mcp-server.snapshot",
+    "classification.json",
+    "codex.snapshot",
+    "events.json",
+    "manifest.json",
+  ];
   assert.equal(fs.existsSync(codexHome), false, "control starts without CODEX_HOME");
 
   const binDir = scratch();
@@ -592,7 +599,7 @@ child.on("close", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
   assert.notEqual(fileCli.status, 0);
   assert.deepEqual(
     proofFiles(fileCli.proofRoot),
-    ["classification.json", "events.json", "manifest.json"],
+    retainedFilesWithIdentity,
     "a rejected CODEX_HOME must still leave a complete retained failure record",
   );
   const fileEvents = JSON.parse(
@@ -615,6 +622,32 @@ child.on("close", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
     false,
     "a non-directory CODEX_HOME must be rejected before app-server spawn",
   );
+
+  const hostProjectRoot = seedProject();
+  fs.writeFileSync(path.join(hostProjectRoot, ".codex-home"), "not a directory\n");
+  const hostProofRoot = portableLiveProofRoot();
+  try {
+    const hostCli = driveCli("valid", "discovery", {
+      captureMode: "host-observation",
+      projectRoot: hostProjectRoot,
+      proofRoot: hostProofRoot,
+      codexBin,
+    });
+    assert.notEqual(hostCli.status, 0);
+    assert.deepEqual(
+      proofFiles(hostCli.proofRoot),
+      retainedFilesWithIdentity,
+      `host-observation failure must retain its proof-owned subjects: ${hostCli.stderr || hostCli.stdout}`,
+    );
+    assert.equal(validateProofRoot(hostCli.proofRoot).ok, true);
+    assert.equal(
+      fs.existsSync(path.join(hostProjectRoot, ".codex-app-server-started")),
+      false,
+      "host-observation must reject unsafe CODEX_HOME before app-server spawn",
+    );
+  } finally {
+    fs.rmSync(hostProofRoot, { recursive: true, force: true });
+  }
 
   if (process.platform !== "win32") {
     const publicProjectRoot = seedProject();

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -1166,6 +1166,29 @@ test("driver exits nonzero for truncated or unavailable streams even when the ch
   assert.notEqual(cli.status, 0, "CLI must exit nonzero when the proof journey failed");
 });
 
+test("unavailable stream cannot retain a clean driver outcome", async () => {
+  const { events, manifest, proofRoot } = await drive("valid");
+  assert.equal(validateProofRoot(proofRoot).ok, true, "unaltered control must validate");
+
+  const unavailable = {
+    ...structuredClone(manifest),
+    streamUnavailable: true,
+  };
+  const classified = classifyRecord({ ...unavailable, events });
+  rewriteProof(proofRoot, unavailable, events, classified);
+
+  const checked = validateProofRoot(proofRoot);
+  assert.equal(
+    checked.ok,
+    false,
+    "stream-unavailable evidence must reject a retained child/driver pass outcome",
+  );
+  assert.match(
+    checked.reasons.join(" "),
+    /childExitCode and driverOutcome violate the closed driver-outcome rule/,
+  );
+});
+
 test("live mode declines elicitation that is not from the assay server", async () => {
   const { events } = await drive("foreign-elicit");
   const replies = events.filter(

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -26,6 +26,7 @@ import {
   classifyRecord,
   consumeJourneyTopology,
   decidePrompt,
+  driverOutcomeFrom,
   elicitationAcceptable,
   forbiddenProofRoot,
   projectClientRequestParams,
@@ -149,7 +150,7 @@ process.stdout.write("assay-mcp-server-shadow/0.0.0\\n");
 }
 
 function driveCli(scenario, journey = "tool", extra = {}) {
-  const projectRoot = seedProject();
+  const projectRoot = extra.projectRoot ?? seedProject();
   const proofRoot = extra.proofRoot ?? scratch();
   const mcpBin = extra.assayMcpBin ?? writeShadowMcp();
   const codexBin =
@@ -533,6 +534,84 @@ test("malformed JSON line writes unavailable evidence; CLI proof root is not emp
   assert.equal(stored.cells.oneToolInvoked.status, "unavailable");
   assert.notEqual(stored.cells.oneToolInvoked.status, "pass");
   assert.notEqual(stored.externalAttestation, "pass");
+  const events = JSON.parse(fs.readFileSync(path.join(cli.proofRoot, "events.json"), "utf8"));
+  const driverErrors = events.filter(
+    (event) => event.direction === "driver" && event.method === "error",
+  );
+  assert.ok(driverErrors.length >= 1, "the failed run must retain a driver error witness");
+  assert.deepEqual(
+    [...new Set(driverErrors.map((event) => event.params?.message))],
+    ["retained driver error"],
+    "driver failures must be the same closed projection the validator recomputes",
+  );
+});
+
+test("production driver creates and verifies its disposable CODEX_HOME before spawn", () => {
+  const projectRoot = seedProject();
+  const codexHome = path.join(projectRoot, ".codex-home");
+  assert.equal(fs.existsSync(codexHome), false, "control starts without CODEX_HOME");
+
+  const binDir = scratch();
+  const codexBin = path.join(binDir, "codex");
+  writePortableNodeExecutable(
+    codexBin,
+    `import fs from "node:fs";
+import { spawn } from "node:child_process";
+if (process.argv.includes("--version")) {
+  process.stdout.write("codex-home-check/1.0.0\\n");
+  process.exit(0);
+}
+fs.writeFileSync(process.env.HOME + "/.codex-app-server-started", "1");
+const stat = fs.statSync(process.env.CODEX_HOME);
+if (!stat.isDirectory() || (process.platform !== "win32" && (stat.mode & 0o7777) !== 0o700)) {
+  process.exit(73);
+}
+const child = spawn(${JSON.stringify(process.execPath)}, ${JSON.stringify([FAKE, "--scenario", "valid", "--project-root", projectRoot])}, { stdio: "inherit" });
+const stop = () => { try { child.kill("SIGTERM"); } catch { /* already exited */ } };
+process.on("SIGTERM", stop);
+process.on("SIGINT", stop);
+child.on("close", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
+`,
+  );
+
+  const cli = driveCli("valid", "discovery", { projectRoot, codexBin });
+  assert.equal(cli.status, 0, cli.stderr || cli.stdout);
+  const stat = fs.lstatSync(codexHome);
+  assert.equal(stat.isSymbolicLink(), false);
+  assert.equal(stat.isDirectory(), true);
+  if (process.platform !== "win32") {
+    assert.equal(stat.mode & 0o7777, 0o700);
+  }
+
+  const fileProjectRoot = seedProject();
+  fs.writeFileSync(path.join(fileProjectRoot, ".codex-home"), "not a directory\n");
+  const fileCli = driveCli("valid", "discovery", {
+    projectRoot: fileProjectRoot,
+    codexBin,
+  });
+  assert.notEqual(fileCli.status, 0);
+  assert.equal(
+    fs.existsSync(path.join(fileProjectRoot, ".codex-app-server-started")),
+    false,
+    "a non-directory CODEX_HOME must be rejected before app-server spawn",
+  );
+
+  if (process.platform !== "win32") {
+    const publicProjectRoot = seedProject();
+    const publicCodexHome = path.join(publicProjectRoot, ".codex-home");
+    fs.mkdirSync(publicCodexHome, { mode: 0o755 });
+    fs.chmodSync(publicCodexHome, 0o755);
+    const publicCli = driveCli("valid", "discovery", {
+      projectRoot: publicProjectRoot,
+      codexBin,
+    });
+    assert.notEqual(publicCli.status, 0);
+    assert.equal(
+      fs.existsSync(path.join(publicProjectRoot, ".codex-app-server-started")),
+      false,
+      "a non-private CODEX_HOME must be rejected before app-server spawn",
+    );
+  }
 });
 
 test("credential-bearing argv is rejected before spawn and not persisted", async () => {
@@ -1920,7 +1999,16 @@ test("F1 strict JSON-RPC envelopes reject method+result, result+error, duplicate
     "a notification carrying a pending id must not yield all-pass",
   );
   assert.notEqual(impersonated.classified.cells.driverCompleted.status, "pass");
-  assert.equal(validateProofRoot(impersonated.proofRoot).ok, false);
+  assert.notEqual(
+    impersonated.manifest.driverOutcome.exitCode,
+    0,
+    "a rejected envelope must be retained as a non-clean driver outcome",
+  );
+  assert.equal(
+    validateProofRoot(impersonated.proofRoot).ok,
+    true,
+    "honest evidence of a failed journey remains a valid proof record",
+  );
 
   const both = await drive("result-and-error-response");
   assert.equal(
@@ -2686,6 +2774,94 @@ test("closed-world server-row taxonomy refuses id-less response shapes; allowed 
   const control = await drive("valid");
   assert.equal(allIntendedCellsPass(control.classified), true);
   assert.equal(validateProofRoot(control.proofRoot).ok, true);
+});
+
+test("current Codex lifecycle chatter is inert while diagnostics remain non-clean", async () => {
+  const { events, manifest, classified } = await drive("valid");
+  assert.equal(allIntendedCellsPass(classified), true);
+
+  const lifecycleMethods = [
+    "remoteControl/status/changed",
+    "thread/started",
+    "mcpServer/startupStatus/updated",
+    "thread/status/changed",
+    "turn/started",
+    "item/started",
+  ];
+  const withLifecycle = structuredClone(events);
+  const terminalIndex = withLifecycle.findIndex(
+    (event) => event.direction === "server" && event.method === "turn/completed",
+  );
+  withLifecycle.splice(
+    terminalIndex,
+    0,
+    ...lifecycleMethods.map((method) => ({ direction: "server", method, params: {} })),
+  );
+  const lifecycle = classifyRecord({ ...manifest, events: withLifecycle });
+  assert.equal(
+    allIntendedCellsPass(lifecycle),
+    true,
+    "known lifecycle notifications must not erase independently observed host cells",
+  );
+  const lifecycleRoot = scratch();
+  fs.mkdirSync(lifecycleRoot, { recursive: true });
+  rewriteProof(lifecycleRoot, manifest, withLifecycle, lifecycle);
+  assert.equal(validateProofRoot(lifecycleRoot).ok, true);
+
+  for (const method of ["warning", "error"]) {
+    const withDiagnostic = structuredClone(events);
+    withDiagnostic.splice(terminalIndex, 0, { direction: "server", method, params: {} });
+    const diagnostic = classifyRecord({ ...manifest, events: withDiagnostic });
+    assert.equal(
+      diagnostic.cells.skillDiscovered.status,
+      "pass",
+      `${method} must not relabel completed discovery as absent`,
+    );
+    assert.equal(
+      diagnostic.cells.exactToolsListed.status,
+      "pass",
+      `${method} must not relabel the observed tool list as absent`,
+    );
+    assert.equal(
+      diagnostic.cells.driverCompleted.status,
+      "fail",
+      `${method} must keep the overall proof non-clean`,
+    );
+    assert.notEqual(
+      driverOutcomeFrom(
+        { childExit: 0, truncated: false, streamUnavailable: false },
+        diagnostic.cells,
+        "tool",
+      ).exitCode,
+      0,
+      `${method} must keep the generated driver outcome nonzero`,
+    );
+    assert.equal(allIntendedCellsPass(diagnostic), false);
+  }
+
+  const malformedLifecycle = structuredClone(events);
+  malformedLifecycle.splice(terminalIndex, 0, {
+    direction: "server",
+    method: lifecycleMethods[0],
+    params: { unexpected: true },
+  });
+  assert.equal(
+    allIntendedCellsPass(classifyRecord({ ...manifest, events: malformedLifecycle })),
+    false,
+    "lifecycle payloads outside the retained empty projection must fail closed",
+  );
+
+  const unknown = structuredClone(events);
+  unknown.splice(terminalIndex, 0, {
+    direction: "server",
+    method: "future/unknown",
+    params: {},
+  });
+  assert.equal(
+    allIntendedCellsPass(classifyRecord({ ...manifest, events: unknown })),
+    false,
+    "future notification methods remain fail-closed",
+  );
 });
 
 test("successful initialize result is required; initialize error cannot clean the record", async () => {

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -29,6 +29,7 @@ import {
   driverOutcomeFrom,
   elicitationAcceptable,
   forbiddenProofRoot,
+  preSpawnFailureState,
   projectClientRequestParams,
   sha256File,
   sha256Utf8,
@@ -608,7 +609,7 @@ child.on("close", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
   assert.deepEqual(fileEvents, [
     {
       direction: "driver",
-      method: "error",
+      method: "pre-spawn-error",
       params: { message: "retained driver error" },
     },
   ]);
@@ -623,31 +624,49 @@ child.on("close", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
     "a non-directory CODEX_HOME must be rejected before app-server spawn",
   );
 
-  const hostProjectRoot = seedProject();
-  fs.writeFileSync(path.join(hostProjectRoot, ".codex-home"), "not a directory\n");
-  const hostProofRoot = portableLiveProofRoot();
-  try {
-    const hostCli = driveCli("valid", "discovery", {
-      captureMode: "host-observation",
-      projectRoot: hostProjectRoot,
-      proofRoot: hostProofRoot,
-      codexBin,
-    });
-    assert.notEqual(hostCli.status, 0);
-    assert.deepEqual(
-      proofFiles(hostCli.proofRoot),
-      retainedFilesWithIdentity,
-      `host-observation failure must retain its proof-owned subjects: ${hostCli.stderr || hostCli.stdout}`,
-    );
-    assert.equal(validateProofRoot(hostCli.proofRoot).ok, true);
-    assert.equal(
-      fs.existsSync(path.join(hostProjectRoot, ".codex-app-server-started")),
-      false,
-      "host-observation must reject unsafe CODEX_HOME before app-server spawn",
-    );
-  } finally {
-    fs.rmSync(hostProofRoot, { recursive: true, force: true });
+  const preSpawnResults = [];
+  for (const row of [
+    { journey: "discovery", allowLiveTurn: false },
+    { journey: "failures", allowLiveTurn: false },
+    { journey: "tool", allowLiveTurn: true },
+  ]) {
+    const hostProjectRoot = seedProject();
+    fs.writeFileSync(path.join(hostProjectRoot, ".codex-home"), "not a directory\n");
+    const hostProofRoot = portableLiveProofRoot();
+    try {
+      const hostCli = driveCli("valid", row.journey, {
+        allowLiveTurn: row.allowLiveTurn,
+        captureMode: "host-observation",
+        projectRoot: hostProjectRoot,
+        proofRoot: hostProofRoot,
+        codexBin,
+      });
+      assert.notEqual(hostCli.status, 0);
+      assert.deepEqual(
+        proofFiles(hostCli.proofRoot),
+        retainedFilesWithIdentity,
+        `host-observation ${row.journey} failure must retain its proof-owned subjects: ${hostCli.stderr || hostCli.stdout}`,
+      );
+      const checked = validateProofRoot(hostCli.proofRoot);
+      preSpawnResults.push({ journey: row.journey, ok: checked.ok, reasons: checked.reasons });
+      assert.equal(
+        fs.existsSync(path.join(hostProjectRoot, ".codex-app-server-started")),
+        false,
+        `host-observation ${row.journey} must reject unsafe CODEX_HOME before app-server spawn`,
+      );
+    } finally {
+      fs.rmSync(hostProofRoot, { recursive: true, force: true });
+    }
   }
+  assert.deepEqual(
+    preSpawnResults,
+    [
+      { journey: "discovery", ok: true, reasons: [] },
+      { journey: "failures", ok: true, reasons: [] },
+      { journey: "tool", ok: true, reasons: [] },
+    ],
+    JSON.stringify(preSpawnResults),
+  );
 
   if (process.platform !== "win32") {
     const publicProjectRoot = seedProject();
@@ -664,6 +683,61 @@ child.on("close", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
       false,
       "a non-private CODEX_HOME must be rejected before app-server spawn",
     );
+  }
+});
+
+test("pre-spawn failure is one closed unavailable state, not a generic stream exception", () => {
+  const event = {
+    direction: "driver",
+    method: "pre-spawn-error",
+    params: { message: "retained driver error" },
+  };
+  const manifest = {
+    childExitCode: 1,
+    driverOutcome: { exitCode: 1, status: "unavailable" },
+    truncated: false,
+    streamUnavailable: true,
+    bounds: { stdoutBytes: 0, stderrBytes: 0 },
+    initialize: {
+      codexHome: null,
+      userAgent: null,
+      platformFamily: null,
+      platformOs: null,
+    },
+  };
+  assert.deepEqual(preSpawnFailureState([event], manifest), {
+    present: true,
+    valid: true,
+    reason: null,
+  });
+
+  const mutations = [
+    { events: [event, event], manifest },
+    { events: [event], manifest: { ...manifest, childExitCode: 2 } },
+    {
+      events: [event],
+      manifest: { ...manifest, driverOutcome: { exitCode: 1, status: "fail" } },
+    },
+    { events: [event], manifest: { ...manifest, truncated: true } },
+    { events: [event], manifest: { ...manifest, streamUnavailable: false } },
+    {
+      events: [event],
+      manifest: { ...manifest, bounds: { ...manifest.bounds, stdoutBytes: 1 } },
+    },
+    {
+      events: [event],
+      manifest: { ...manifest, bounds: { ...manifest.bounds, stderrBytes: 1 } },
+    },
+    {
+      events: [event],
+      manifest: { ...manifest, initialize: { ...manifest.initialize, userAgent: "spawned" } },
+    },
+  ];
+  for (const mutation of mutations) {
+    const state = preSpawnFailureState(mutation.events, mutation.manifest);
+    assert.equal(state.present, true);
+    assert.equal(state.valid, false);
+    assert.match(state.reason, /^pre-spawn failure /);
   }
 });
 
@@ -3477,6 +3551,20 @@ test("review closeout: host subjects are proof-owned and independently revalidat
       ),
       true,
       JSON.stringify({ hostIdentity: manifest.hostIdentity, invocation: manifest.invocation }),
+    );
+    const wrongCommand = structuredClone(topology);
+    wrongCommand.primaryThread.request.params.config.mcp_servers.assay.command =
+      "/wrong/canonical/assay-mcp-server";
+    assert.equal(
+      verifyLiveIdentity(
+        manifest.hostIdentity,
+        manifest.invocation,
+        wrongCommand,
+        proofRoot,
+        manifest.journey,
+      ),
+      false,
+      "a normal journey cannot bypass the canonical MCP command binding",
     );
     const checked = validateProofRoot(proofRoot);
     assert.equal(checked.ok, true, checked.reasons.join("; "));

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -547,6 +547,47 @@ test("malformed JSON line writes unavailable evidence; CLI proof root is not emp
   );
 });
 
+function preSpawnStateMutations(event, manifest) {
+  return [
+    { label: "extra event", events: [event, event], manifest },
+    {
+      label: "wrong child exit",
+      events: [event],
+      manifest: { ...manifest, childExitCode: 2 },
+    },
+    {
+      label: "wrong driver outcome",
+      events: [event],
+      manifest: { ...manifest, driverOutcome: { exitCode: 1, status: "fail" } },
+    },
+    {
+      label: "truncated stream",
+      events: [event],
+      manifest: { ...manifest, truncated: true },
+    },
+    {
+      label: "available stream",
+      events: [event],
+      manifest: { ...manifest, streamUnavailable: false },
+    },
+    {
+      label: "stdout bytes",
+      events: [event],
+      manifest: { ...manifest, bounds: { ...manifest.bounds, stdoutBytes: 1 } },
+    },
+    {
+      label: "stderr bytes",
+      events: [event],
+      manifest: { ...manifest, bounds: { ...manifest.bounds, stderrBytes: 1 } },
+    },
+    {
+      label: "initialize metadata",
+      events: [event],
+      manifest: { ...manifest, initialize: { ...manifest.initialize, userAgent: "spawned" } },
+    },
+  ];
+}
+
 test("production driver creates and verifies its disposable CODEX_HOME before spawn", () => {
   const projectRoot = seedProject();
   const codexHome = path.join(projectRoot, ".codex-home");
@@ -649,13 +690,36 @@ child.on("close", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
       );
       const checked = validateProofRoot(hostCli.proofRoot);
       preSpawnResults.push({ journey: row.journey, ok: checked.ok, reasons: checked.reasons });
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(hostCli.proofRoot, "manifest.json"), "utf8"),
+      );
+      const events = JSON.parse(
+        fs.readFileSync(path.join(hostCli.proofRoot, "events.json"), "utf8"),
+      );
+      if (row.journey === "discovery") {
+        const originalClassified = classifyRecord({ ...manifest, events });
+        for (const mutation of preSpawnStateMutations(events[0], manifest)) {
+          const mutatedClassified = classifyRecord({
+            ...mutation.manifest,
+            events: mutation.events,
+          });
+          rewriteProof(
+            hostCli.proofRoot,
+            mutation.manifest,
+            mutation.events,
+            mutatedClassified,
+          );
+          const mutatedChecked = validateProofRoot(hostCli.proofRoot);
+          assert.equal(
+            mutatedChecked.ok,
+            false,
+            `${mutation.label} must fail at the retained-proof validator funnel`,
+          );
+          rewriteProof(hostCli.proofRoot, manifest, events, originalClassified);
+        }
+      }
       if (row.journey !== "discovery") {
-        const manifest = JSON.parse(
-          fs.readFileSync(path.join(hostCli.proofRoot, "manifest.json"), "utf8"),
-        );
-        const genericEvents = JSON.parse(
-          fs.readFileSync(path.join(hostCli.proofRoot, "events.json"), "utf8"),
-        );
+        const genericEvents = structuredClone(events);
         genericEvents[0].method = "error";
         const genericClassified = classifyRecord({ ...manifest, events: genericEvents });
         rewriteProof(hostCli.proofRoot, manifest, genericEvents, genericClassified);
@@ -729,29 +793,7 @@ test("pre-spawn failure is one closed unavailable state, not a generic stream ex
     reason: null,
   });
 
-  const mutations = [
-    { events: [event, event], manifest },
-    { events: [event], manifest: { ...manifest, childExitCode: 2 } },
-    {
-      events: [event],
-      manifest: { ...manifest, driverOutcome: { exitCode: 1, status: "fail" } },
-    },
-    { events: [event], manifest: { ...manifest, truncated: true } },
-    { events: [event], manifest: { ...manifest, streamUnavailable: false } },
-    {
-      events: [event],
-      manifest: { ...manifest, bounds: { ...manifest.bounds, stdoutBytes: 1 } },
-    },
-    {
-      events: [event],
-      manifest: { ...manifest, bounds: { ...manifest.bounds, stderrBytes: 1 } },
-    },
-    {
-      events: [event],
-      manifest: { ...manifest, initialize: { ...manifest.initialize, userAgent: "spawned" } },
-    },
-  ];
-  for (const mutation of mutations) {
+  for (const mutation of preSpawnStateMutations(event, manifest)) {
     const state = preSpawnFailureState(mutation.events, mutation.manifest);
     assert.equal(state.present, true);
     assert.equal(state.valid, false);


### PR DESCRIPTION
## Summary

A retained v5.5.2 Codex host observation on Codex `0.151.0-alpha.7.2` exposed four driver-contract defects before the model turn could be classified honestly:

- current Codex lifecycle notifications erased already observed host cells as unknown topology;
- `warning` / `error` notifications had no distinct non-clean classification;
- a missing disposable `CODEX_HOME` failed before `app-server` spawn, while an unsafe existing directory was not verified;
- raw driver-error strings did not match the validator's closed retained projection, and `driverCompleted=fail` could still produce exit 0.

This PR repairs those driver/validator contracts without changing Assay product behavior.

## Changes

- create a missing disposable `CODEX_HOME` at mode `0700` and fail before spawn if it is not a private, current-user-owned real directory;
- retain a rejected pre-spawn `CODEX_HOME` as a complete, non-clean proof record instead of leaving an empty proof root;
- bind every retained host-observation pre-spawn failure to proof-owned Codex and Assay MCP snapshots before `app-server` can start;
- represent pre-spawn failure as one closed `pre-spawn-error` state: one retained event, child/driver exit 1 and unavailable, no truncation, unavailable stream, zero stdout/stderr bytes, and no initialize metadata;
- allow the absent primary-thread MCP command only inside validator-owned processing of that exact closed state; exported identity validation remains strict;
- admit only the six lifecycle notification methods observed from the current Codex host, each under the exact empty retained projection;
- classify `warning` and `error` separately so completed discovery remains visible while the overall driver result stays non-clean;
- route every driver error through the same closed projection the validator recomputes;
- require every non-`pass` `driverCompleted` cell to produce a nonzero driver outcome.

## Verification

Exact head: `76b7fbcbeebc9a958726e5f83c39a713f77c0b05`

- RED first: malformed driver errors, missing or unsafe `CODEX_HOME`, and current lifecycle/diagnostic rows failed the new behavioral tests before the repair. The review-found failures/tool false-clean reproduced before the closed-state fix while discovery remained valid.
- `node --test scripts/ci/test_codex_host_proof.mjs`: 91/91 pass, 0 skipped.
- `node --check` on driver, validator, and test: pass.
- commit and pre-push hook catalogues: pass, including `Codex host-proof Node contract`, evidence vocabulary, runner map, workspace clippy with `-D warnings`, `cargo fmt --check`, and the Linux cross-target gate.
- `git diff --check`: pass.
- fourteen mutations went red: lifecycle omission, inert diagnostics, exit-zero driver failure, missing home creation, raw driver error, bypassed private-directory verification, removal of pre-spawn failure retention, moving host identity acquisition below unsafe-home validation, replacing the explicit pre-spawn label with generic `error`, disabling the normal MCP-command binding, weakening the closed state's zero-byte metadata requirement, broadening the validator-only bypass to generic `driver/error`, and deleting final-funnel rejection of an explicitly present but invalid pre-spawn state, and restoring the early unavailable-stream return so a retained pass/0 contradiction validates.
- both Copilot findings on the earlier head were addressed: rejected `CODEX_HOME` retains a complete failure record, and the lifecycle test asserts its terminal insertion anchor before splicing.
- the prior independent-review blocker is closed across all three journeys: discovery, failures, and tool each exit nonzero, retain a validator-valid pack with proof-owned subjects, and prove `app-server` never started.
- the generic-error review blocker is closed behaviorally: after changing only `pre-spawn-error` to generic `driver/error` and recomputing hashes/classification, both failures and tool packs are rejected; broadening the validator-only bypass makes the test fail.
- the closed-state final-funnel blocker is closed with one shared eight-case mutation table consumed both by `preSpawnFailureState` and retained discovery-pack validation; deleting the final rejection now makes the pack test fail.
- the contradictory-outcome blocker is closed at the validator funnel: unavailable/truncated evidence now requires a nonzero unavailable driver outcome, and restoring the prior early return makes the new test fail.

## Non-claims

- This is not a live Codex tool-invocation proof and does not close #2684.
- It does not authenticate or copy credentials into a disposable Codex profile.
- It does not claim the lifecycle allowlist covers future Codex versions; unknown methods remain fail-closed.
- It does not change the Assay CLI, MCP server, skill, or plugin.

Supports #2684.



