### PR TITLE
fix(host-proof): retain Codex item drift as valid JSON without accepting it

### DIFF
--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -1197,7 +1197,11 @@ export function stableStringify(value) {
 
 function stringifySorted(value) {
   if (value === null || typeof value !== "object") {
-    return JSON.stringify(value);
+    const token = JSON.stringify(value);
+    if (token === undefined) {
+      throw new Error(`stable stringify cannot encode ${typeof value} as JSON`);
+    }
+    return token;
   }
   if (Array.isArray(value)) {
     return `[${value.map(stringifySorted).join(",")}]`;
@@ -1785,7 +1789,7 @@ function invalidProjection(value) {
 }
 
 function projectedScalar(value) {
-  return value == null || ["string", "number", "boolean"].includes(typeof value)
+  return value === null || ["string", "number", "boolean"].includes(typeof value)
     ? value
     : invalidProjection(value);
 }
@@ -2168,7 +2172,7 @@ export function projectRetainedEvent(event) {
   if (!isPlainObject(event)) {
     return invalidProjection(event);
   }
-  const out = { direction: event.direction, method: event.method };
+  const out = { direction: projectedScalar(event.direction), method: projectedScalar(event.method) };
   if (hasOwn(event, "id")) {
     out.id = event.id;
   }

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -680,9 +680,9 @@ export function isProofRpcId(id) {
   return Number.isSafeInteger(id);
 }
 
-function retainedItemReason(item) {
+function retainedItemReason(item, label = "item/completed") {
   if (!isPlainObject(item) || !isNonemptyString(item.type) || !isNonemptyString(item.id)) {
-    return "item/completed item is not a typed retained item";
+    return `${label} item is not a typed retained item`;
   }
   switch (item.type) {
     case "mcpToolCall":
@@ -695,12 +695,12 @@ function retainedItemReason(item) {
       ) {
         return null;
       }
-      return "item/completed mcpToolCall is missing required retained fields";
+      return `${label} mcpToolCall is missing required retained fields`;
     case "userMessage":
       if (Array.isArray(item.content)) {
         return null;
       }
-      return "item/completed userMessage is missing required retained fields";
+      return `${label} userMessage is missing required retained fields`;
     default:
       return `unknown retained item type ${item.type}`;
   }
@@ -748,6 +748,12 @@ function retainedMethodParamsReason(method, params) {
         !isNonemptyString(turn.status)
       ) {
         return "turn/completed turn must have typed id, items, and status";
+      }
+      for (const item of turn.items) {
+        const itemReason = retainedItemReason(item, "turn/completed");
+        if (itemReason) {
+          return itemReason;
+        }
       }
       return null;
     }
@@ -1195,13 +1201,25 @@ export function stableStringify(value) {
   return `${stringifySorted(value)}\n`;
 }
 
+// The one JSON scalar rule for both the projection and stringify boundaries:
+// null, string, boolean, and only finite numbers. NaN and the infinities are
+// not JSON and must never silently become a null token.
+function isJsonScalar(value) {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
 function stringifySorted(value) {
   if (value === null || typeof value !== "object") {
-    const token = JSON.stringify(value);
-    if (token === undefined) {
-      throw new Error(`stable stringify cannot encode ${typeof value} as JSON`);
+    if (!isJsonScalar(value)) {
+      const shown = typeof value === "number" ? String(value) : typeof value;
+      throw new Error(`stable stringify cannot encode ${shown} as JSON`);
     }
-    return token;
+    return JSON.stringify(value);
   }
   if (Array.isArray(value)) {
     return `[${value.map(stringifySorted).join(",")}]`;
@@ -1789,9 +1807,7 @@ function invalidProjection(value) {
 }
 
 function projectedScalar(value) {
-  return value === null || ["string", "number", "boolean"].includes(typeof value)
-    ? value
-    : invalidProjection(value);
+  return isJsonScalar(value) ? value : invalidProjection(value);
 }
 
 function projectDecisionObject(value) {

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -4163,3 +4163,74 @@ test("zero retained mcpToolCall rows keep oneToolInvoked non-pass", async () => 
   assert.match(classified.cells.oneToolInvoked.reason, /no mcpToolCall/);
   assert.notEqual(classified.cells.structuredResultValidated.status, "pass");
 });
+
+test("projection-idempotent unknown terminal items are drift, not accepted topology", async () => {
+  const control = await drive("valid");
+  for (const type of ["reasoning", "agentMessage"]) {
+    const events = structuredClone(control.events);
+    const terminal = events.find((event) => event.method === "turn/completed");
+    assert.ok(terminal, "control run must contain the terminal turn");
+    const crafted = {
+      type,
+      id: `item_${type}`,
+      server: "assay",
+      tool: "unmapped",
+      arguments: { tool: "x", policy: "y" },
+      status: "completed",
+    };
+    terminal.params.turn.items.push(crafted);
+    assert.deepEqual(
+      projectRetainedEvent(terminal),
+      terminal,
+      `${type} fixture must be a projection fixed point, or this test stops probing past the round-trip check`,
+    );
+    const classified = classifyRecord({ ...control.manifest, events });
+    assert.equal(
+      allIntendedCellsPass(classified),
+      false,
+      `a ${type} terminal item must not classify clean`,
+    );
+    assert.match(
+      Object.values(classified.cells)
+        .map((entry) => entry.reason)
+        .join("; "),
+      /unknown retained item type/,
+      `a ${type} terminal item must be explicit protocol drift`,
+    );
+    rewriteProof(control.proofRoot, control.manifest, events, classified);
+    const revalidated = validateProofRoot(control.proofRoot);
+    assert.equal(revalidated.ok, false, `a ${type} terminal item must not validate clean`);
+    assert.match(revalidated.reasons.join("; "), /unknown retained item type/);
+  }
+});
+
+test("non-finite numbers never silently become JSON null at either boundary", () => {
+  for (const bad of [NaN, Infinity, -Infinity]) {
+    assert.throws(
+      () => stableStringify({ completedAtMs: bad }),
+      /JSON/,
+      `${bad} must fail loud before persistence, never serialize as null`,
+    );
+    assert.throws(() => stableStringify([bad]), /JSON/);
+    const projected = projectRetainedEvent({
+      direction: "server",
+      method: "item/completed",
+      id: null,
+      params: {
+        completedAtMs: bad,
+        threadId: "t",
+        turnId: "u",
+        item: { type: "userMessage", id: "u1", content: [] },
+      },
+    });
+    assert.deepEqual(
+      projected.params.completedAtMs,
+      { __invalidType: "number" },
+      `${bad} must project to the explicit invalid marker, not travel as a number`,
+    );
+    const serialized = stableStringify(projected);
+    assert.deepEqual(JSON.parse(serialized), projected, "the marker form must round-trip");
+  }
+  assert.equal(stableStringify({ completedAtMs: 5 }), '{"completedAtMs":5}\n');
+  assert.equal(stableStringify([0, -1.5]), '[0,-1.5]\n');
+});

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -31,6 +31,7 @@ import {
   forbiddenProofRoot,
   preSpawnFailureState,
   projectClientRequestParams,
+  projectRetainedEvent,
   sha256File,
   sha256Utf8,
   stableStringify,
@@ -4002,4 +4003,163 @@ test("review repair: host manifest invocation is exact and credential-free", () 
     }
     fs.rmSync(proofRoot, { recursive: true, force: true });
   }
+});
+
+const OBSERVED_DRIFT_ITEMS = Object.freeze([
+  Object.freeze({ type: "reasoning", id: "item_0", text: "Considering the assay decide tool." }),
+  Object.freeze({ type: "agentMessage", id: "item_2", text: "The decision endpoint returned allow." }),
+]);
+
+test("stableStringify refuses non-JSON primitives; JSON null stays a valid token", () => {
+  assert.equal(stableStringify({ a: null }), '{"a":null}\n');
+  assert.equal(stableStringify([null, 1, "x", true]), '[null,1,"x",true]\n');
+  for (const bad of [
+    undefined,
+    { server: undefined },
+    [undefined],
+    { nested: { deep: undefined } },
+    { fn: () => {} },
+  ]) {
+    assert.throws(
+      () => stableStringify(bad),
+      /JSON/,
+      "a value JSON cannot encode must be rejected, never serialized as a bare token",
+    );
+  }
+});
+
+test("absent scalar fields project to explicit invalid markers, never undefined", () => {
+  const projected = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 5,
+      threadId: "t",
+      turnId: "u",
+      item: OBSERVED_DRIFT_ITEMS[0],
+    },
+  });
+  const item = projected.params.item;
+  for (const key of ["server", "tool", "arguments", "status"]) {
+    assert.notEqual(typeof item[key], "undefined", `${key} must not project to undefined`);
+  }
+  const serialized = stableStringify(projected);
+  assert.doesNotMatch(
+    serialized,
+    /[:,[]undefined/,
+    "a bare undefined token must never appear; the quoted marker string is the valid form",
+  );
+  assert.equal(
+    serialized.includes(OBSERVED_DRIFT_ITEMS[0].text),
+    false,
+    "reasoning text must not be retained",
+  );
+  assert.deepEqual(JSON.parse(serialized), projected, "retained bytes must round-trip");
+  const withNull = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 5,
+      threadId: "t",
+      turnId: "u",
+      item: { type: "userMessage", id: null, content: [] },
+    },
+  });
+  assert.equal(withNull.params.item.id, null, "JSON null must survive the scalar boundary");
+});
+
+test("observed Codex item drift retains valid JSON and classifies fail-closed", async () => {
+  const control = await drive("valid");
+  assert.equal(validateProofRoot(control.proofRoot).ok, true, "unchanged control must validate");
+  const events = structuredClone(control.events);
+  const toolIndex = events.findIndex(
+    (event) => event.method === "item/completed" && event.params?.item?.type === "mcpToolCall",
+  );
+  assert.notEqual(toolIndex, -1, "control run must contain the tool item to replace");
+  const toolRow = events[toolIndex];
+  const driftRows = OBSERVED_DRIFT_ITEMS.map((item) =>
+    projectRetainedEvent({
+      direction: "server",
+      method: "item/completed",
+      id: null,
+      params: {
+        completedAtMs: toolRow.params.completedAtMs,
+        threadId: toolRow.params.threadId,
+        turnId: toolRow.params.turnId,
+        item,
+      },
+    }),
+  );
+  events.splice(toolIndex, 1, ...driftRows);
+  const terminalIndex = events.findIndex((event) => event.method === "turn/completed");
+  assert.notEqual(terminalIndex, -1, "control run must contain the terminal turn");
+  const terminal = events[terminalIndex];
+  events[terminalIndex] = projectRetainedEvent({
+    direction: "server",
+    method: "turn/completed",
+    id: null,
+    params: {
+      threadId: terminal.params.threadId,
+      turn: {
+        id: terminal.params.turn.id,
+        status: terminal.params.turn.status,
+        items: [
+          ...terminal.params.turn.items.filter((item) => item?.type !== "mcpToolCall"),
+          ...OBSERVED_DRIFT_ITEMS,
+        ],
+      },
+    },
+  });
+  const serialized = stableStringify(events);
+  const parsed = JSON.parse(serialized);
+  assert.deepEqual(parsed, events, "retained drift events must round-trip through JSON");
+  for (const item of OBSERVED_DRIFT_ITEMS) {
+    assert.equal(serialized.includes(item.text), false, `${item.type} text must not be retained`);
+  }
+  const notificationItem = driftRows[0].params.item;
+  const terminalItems = events[terminalIndex].params.turn.items;
+  const terminalReasoning = terminalItems.find((item) => item.type === "reasoning");
+  assert.deepEqual(
+    terminalReasoning,
+    notificationItem,
+    "item/completed and terminal items must share one projection rule",
+  );
+  const classified = classifyRecord({ ...control.manifest, events });
+  assert.notEqual(classified.cells.oneToolInvoked.status, "pass");
+  assert.match(
+    Object.values(classified.cells)
+      .map((entry) => entry.reason)
+      .join("; "),
+    /unknown retained item type (reasoning|agentMessage)/,
+    "unknown item types must stay explicit protocol drift",
+  );
+  rewriteProof(control.proofRoot, control.manifest, events, classified);
+  const revalidated = validateProofRoot(control.proofRoot);
+  assert.equal(revalidated.ok, false, "a drift proof must not validate clean");
+  assert.ok(
+    revalidated.classified,
+    "a retained drift proof must still be classifiable, not unparsable",
+  );
+  assert.doesNotMatch(revalidated.reasons.join("; "), /unavailable allowlisted proof/);
+  assert.match(revalidated.reasons.join("; "), /unknown retained item type/);
+  assert.notEqual(revalidated.classified.cells.oneToolInvoked.status, "pass");
+});
+
+test("zero retained mcpToolCall rows keep oneToolInvoked non-pass", async () => {
+  const control = await drive("valid");
+  const events = structuredClone(control.events).filter(
+    (event) =>
+      !(event.method === "item/completed" && event.params?.item?.type === "mcpToolCall"),
+  );
+  const terminal = events.find((event) => event.method === "turn/completed");
+  assert.ok(terminal, "control run must contain the terminal turn");
+  terminal.params.turn.items = terminal.params.turn.items.filter(
+    (item) => item?.type !== "mcpToolCall",
+  );
+  const classified = classifyRecord({ ...control.manifest, events });
+  assert.notEqual(classified.cells.oneToolInvoked.status, "pass");
+  assert.match(classified.cells.oneToolInvoked.reason, /no mcpToolCall/);
+  assert.notEqual(classified.cells.structuredResultValidated.status, "pass");
 });


### PR DESCRIPTION
Closes #2740 (parent #2684).

## Measured defect

The first authorized live v5.5.2 tool journey on bundled Codex `0.151.0-alpha.7.2` emitted `item/completed` types `reasoning` and `agentMessage`. `projectRetainedItem` defaulted their absent `server`/`tool`/`status` through `projectedScalar`, whose loose `== null` admitted JavaScript `undefined`; `stringifySorted` then interpolated `JSON.stringify(undefined)` as a literal `undefined` token, so the retained `events.json` was not valid JSON and the independent validator could not classify the otherwise fail-closed run. The same run contained zero `mcpToolCall` rows.

## Repair (two layers, one rule per function)

Both files are the exact #2740 allowlist: `scripts/ci/codex_host_proof_validator.mjs`, `scripts/ci/test_codex_host_proof.mjs`. The driver writes through the validator's exported `projectRetainedEvent`/`stableStringify`, so it is covered without being touched.

1. **Scalar boundary** — `projectedScalar` admits only JSON scalars (`=== null`); an absent field now projects to the pre-existing explicit `__invalidType` marker: valid JSON, flagged as protocol drift, never accepted topology.
2. **Serialization guard** — `stringifySorted` throws on any primitive `JSON.stringify` cannot encode, so a future projection regression crashes the writer loudly instead of persisting an unparsable proof. JSON `null` remains a valid token.
3. The guard immediately exposed the same undefined leak in `projectRetainedEvent`'s raw `direction`/`method` copies (surfaced by two existing adversarial tests); those now route through the same scalar boundary.

`item/completed` and terminal `turn/completed.items` continue to share the single `projectRetainedItem` projection rule (now pinned by test). Unknown item types still classify as `unknown retained item type <type>` (fail-closed drift). Reasoning/agent text is not retained — only the key name lands in `__unexpectedKeys`, pinned by test.

## TDD evidence

RED first (base `3dd32b8f4`): 3 of 4 new tests failed on the exact live signature — `Unexpected token 'u', ..."server":undefined,"... is not valid JSON`. The fourth (zero `mcpToolCall` → `oneToolInvoked` non-pass) was already green and is retained as a pin of existing closure.

GREEN: full focused suite 95/95 (`node --test scripts/ci/test_codex_host_proof.mjs`), also re-run by the `codex-host-proof-node-contract` pre-commit hook at commit time.

Mutations (each applied to the committed head, then restored):
- restore `== null` in `projectedScalar` → 2/4 new tests fail;
- remove the `stringifySorted` guard → 1/4 fails (guard pin);
- restore raw `direction`/`method` copies → 2 existing P1/taxonomy tests fail.

Other checks: `git diff --check` clean; typos/fmt/vocabulary pre-commit hooks pass; public strings inspected — the two fixture texts are invented placeholders for the observed item *shapes*, not live model output.

## Non-claims

No tool invocation, structured-result validation, or authenticated-host success is claimed. No marketplace support, no protocol-support expansion, no new schema version, no permission for another model turn. The failed live proof remains retained as evidence of this defect. Zero retained `mcpToolCall` rows still classify `oneToolInvoked` as non-pass.

---

## Review repair (round 2, commit `ec67cdc3e`)

The independent exact-head review found one P1 and one adjacent P2 against the same closed projection rule; both are repaired here under the same allowlist.

**P1 — terminal items skipped the shared item rule.** `turn/completed.items` members were never run through `retainedItemReason`; `classifyInvocation` only filters for `mcpToolCall` and ignores the rest. A projection-idempotent unknown item (all expected fields present as scalars, no unexpected keys) beside the canonical tool entry therefore classified clean and validated `ok`. Terminal items now pass through the same shared `retainedItemReason` (carrier label parameterized to keep reasons honest); unknown terminal types are explicit `unknown retained item type <type>` drift and non-pass, with no item text retained. The new test first asserts the crafted item is a projection fixed point — proving the round-trip check alone could not catch it — then asserts drift.

**P2 — non-finite numbers silently became JSON null.** `typeof NaN === "number"`, so the scalar boundary admitted NaN/±Infinity, and `JSON.stringify` serialized them as a silent `null` token — value substitution rather than corruption. One shared `isJsonScalar` rule (null, string, boolean, finite number) now backs both `projectedScalar` and `stringifySorted`: invalid values project to the explicit `__invalidType` marker, and the stringify boundary fails loud before persistence.

**RED** (on `43c438e20`): both new tests failed on the reviewed claims — the idempotent unknown terminal item classified clean (`allPass true`), and `stableStringify({completedAtMs: NaN})` returned a `null` token without throwing. **GREEN**: full focused suite 97/97, re-run by the pre-commit node contract hook.

**Mutations** (each on the committed head, then restored; no-op control stays 97/97 green):
- remove the terminal item-loop → P1 test fails;
- drop the finite-number check from `isJsonScalar` → P2 test fails;
- restore loose `== null` undefined admission → 2 round-1 tests fail;
- remove the serialization guard → 2 tests fail (round-1 guard pin + P2);
- restore raw `direction`/`method` copies → 2 existing P1/taxonomy tests fail.

`node --check` and `git diff --check` clean on both files. Marker non-idempotence is kept deliberately; no schema or item-support expansion, no new number handling beyond refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Exact candidate head: `ec67cdc3e275937af53fe75ded83ca3804704c27`.
