### PR TITLE
ci: lockstep the two direct actions/attest producers (#2474)

### DIFF
--- a/.github/workflows/privileged-mcp-action-pack-release.yml
+++ b/.github/workflows/privileged-mcp-action-pack-release.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Attest release pack
         id: attest
-        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-checksums: release/SHA256SUMS
           show-summary: true

--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -298,7 +298,7 @@ jobs:
       - name: Attest delegated proof pack subjects
         id: attest-proof-pack
         if: always() && hashFiles('assay-runner-proof-upload/subject-checksums.txt') != ''
-        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-checksums: assay-runner-proof-upload/subject-checksums.txt
           show-summary: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -422,6 +422,13 @@ repos:
         pass_filenames: false
         files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(check-codeql-upload-sarif-lockstep\.py|test-codeql-upload-sarif-lockstep\.sh)|\.pre-commit-config\.yaml)$
 
+      - id: actions-attest-lockstep
+        name: Direct actions/attest producer lockstep
+        entry: bash scripts/ci/test-actions-attest-lockstep.sh
+        language: system
+        pass_filenames: false
+        files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$
+
       - id: crosswalk-generator-contract
         name: Configuration crosswalk generator contract
         entry: bash scripts/ci/test-crosswalk-generator.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -427,7 +427,7 @@ repos:
         entry: bash scripts/ci/test-actions-attest-lockstep.sh
         language: system
         pass_filenames: false
-        files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$
+        files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(assay_runner_delegated_proof_pack\.py|check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$
 
       - id: crosswalk-generator-contract
         name: Configuration crosswalk generator contract

--- a/scripts/ci/check-actions-attest-lockstep.py
+++ b/scripts/ci/check-actions-attest-lockstep.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Pin Assay's two direct actions/attest producers in lockstep."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+EXPECTED_SHA = "1e69f48acb82d1966a394da916b4c1698aa569d6"
+EXPECTED_TAG = "v4.2.2"
+WORKFLOW_DIR = Path(".github/workflows")
+ATTEST_ACTION = "actions/attest@"
+YAML_HEX_ESCAPE_RE = re.compile(
+    r"\\(?:x([0-9a-fA-F]{2})|u([0-9a-fA-F]{4})|U([0-9a-fA-F]{8}))"
+)
+USES_RE = re.compile(
+    r"^[ \t]*(?:-[ \t]+)?uses:[ \t]+"
+    r"(?P<quote>['\"]?)actions/attest@"
+    r"(?P<sha>[0-9a-f]{40})(?P=quote)[ \t]+"
+    r"#[ \t]+(?P<tag>v\d+\.\d+\.\d+)[ \t]*$"
+)
+DIRECT_USES_SHA_RE = re.compile(r"^actions/attest@([0-9a-f]{40})$")
+
+
+class Producer(NamedTuple):
+    path: Path
+    step_id: str
+    subject_checksums: str
+    bundle_output: str
+
+
+class WorkflowParseError(Exception):
+    """A producer workflow could not be loaded, so the contract cannot pass."""
+
+
+PRODUCERS = (
+    Producer(
+        path=Path(".github/workflows/runner-spike-delegated.yml"),
+        step_id="attest-proof-pack",
+        subject_checksums="assay-runner-proof-upload/subject-checksums.txt",
+        bundle_output="steps.attest-proof-pack.outputs.bundle-path",
+    ),
+    Producer(
+        path=Path(".github/workflows/privileged-mcp-action-pack-release.yml"),
+        step_id="attest",
+        subject_checksums="release/SHA256SUMS",
+        bundle_output="steps.attest.outputs.bundle-path",
+    ),
+)
+
+
+def decode_hex_escape(match: re.Match[str]) -> str:
+    codepoint = next(group for group in match.groups() if group is not None)
+    try:
+        return chr(int(codepoint, 16))
+    except ValueError:
+        return "\N{REPLACEMENT CHARACTER}"
+
+
+def active_attest_pins(text: str) -> list[tuple[str, str]]:
+    pins: list[tuple[str, str]] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = USES_RE.match(line)
+        if match:
+            pins.append((match.group("sha"), match.group("tag")))
+    return pins
+
+
+def active_attest_references(text: str) -> int:
+    active_text = "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+    # GitHub resolves repository names case-insensitively, and YAML double-quoted
+    # scalars decode hexadecimal escapes and escaped line breaks before dispatch.
+    # Needle is actions/attest@, which does not match attest-build-provenance@.
+    normalized = re.sub(r"\\\r?\n[ \t]*", "", active_text)
+    normalized = YAML_HEX_ESCAPE_RE.sub(decode_hex_escape, normalized)
+    normalized = normalized.casefold()
+    return normalized.count(ATTEST_ACTION)
+
+
+def has_active_attest_callsite(text: str) -> bool:
+    return active_attest_references(text) > 0
+
+
+def load_workflow_mapping(path: Path) -> object:
+    try:
+        completed = subprocess.run(
+            [
+                "ruby",
+                "-ryaml",
+                "-rjson",
+                "-e",
+                "puts JSON.generate(YAML.load_file(ARGV[0]))",
+                str(path),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise WorkflowParseError(f"{path}: yaml parser unavailable: {error}") from error
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or (
+            f"exit {completed.returncode}"
+        )
+        raise WorkflowParseError(f"{path}: malformed workflow YAML: {detail}")
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise WorkflowParseError(
+            f"{path}: yaml parser returned non-JSON: {error}"
+        ) from error
+
+
+def iter_steps(document: object) -> list[dict[str, object]]:
+    if not isinstance(document, dict):
+        raise WorkflowParseError("workflow root is not a mapping")
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict):
+        raise WorkflowParseError("workflow jobs is not a mapping")
+    steps: list[dict[str, object]] = []
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        raw_steps = job.get("steps") or []
+        if not isinstance(raw_steps, list):
+            continue
+        for step in raw_steps:
+            if isinstance(step, dict):
+                steps.append(step)
+    return steps
+
+
+def direct_attest_steps(document: object) -> list[dict[str, object]]:
+    found: list[dict[str, object]] = []
+    for step in iter_steps(document):
+        uses = step.get("uses")
+        if isinstance(uses, str) and DIRECT_USES_SHA_RE.fullmatch(uses.strip()):
+            found.append(step)
+    return found
+
+
+def producer_contract_errors(producer: Producer, text: str, document: object) -> list[str]:
+    errors: list[str] = []
+    steps = direct_attest_steps(document)
+    if len(steps) != 1:
+        errors.append(
+            f"{producer.path}: want exactly one direct actions/attest step, "
+            f"found {len(steps)}"
+        )
+        return errors
+    step = steps[0]
+    if step.get("id") != producer.step_id:
+        errors.append(
+            f"{producer.path}: attest step id {step.get('id')!r}, "
+            f"want {producer.step_id!r}"
+        )
+    with_block = step.get("with")
+    if not isinstance(with_block, dict):
+        errors.append(
+            f"{producer.path}: SHA pin is unwired; missing with.subject-checksums "
+            f"{producer.subject_checksums}"
+        )
+    elif with_block.get("subject-checksums") != producer.subject_checksums:
+        errors.append(
+            f"{producer.path}: subject-checksums {with_block.get('subject-checksums')!r}, "
+            f"want {producer.subject_checksums!r}"
+        )
+    if producer.bundle_output not in text:
+        errors.append(
+            f"{producer.path}: missing bundle consumer {producer.bundle_output}"
+        )
+    return errors
+
+
+def check() -> list[str]:
+    errors: list[str] = []
+    expected = (EXPECTED_SHA, EXPECTED_TAG)
+    expected_paths = {producer.path for producer in PRODUCERS}
+
+    discovered: set[Path] = set()
+    for pattern in ("*.yml", "*.yaml"):
+        for workflow in WORKFLOW_DIR.glob(pattern):
+            if has_active_attest_callsite(workflow.read_text(encoding="utf-8")):
+                discovered.add(workflow)
+    for workflow in sorted(discovered - expected_paths):
+        errors.append(f"unexpected actions/attest workflow callsite: {workflow}")
+
+    for producer in PRODUCERS:
+        workflow = producer.path
+        if not workflow.is_file():
+            errors.append(f"workflow missing: {workflow}")
+            continue
+        text = workflow.read_text(encoding="utf-8")
+        pins = active_attest_pins(text)
+        references = active_attest_references(text)
+        if references != len(pins):
+            errors.append(
+                f"{workflow}: found {references} actions/attest reference(s), "
+                f"but only {len(pins)} canonical pin(s)"
+            )
+        if len(pins) != 1:
+            errors.append(
+                f"{workflow}: want exactly one active actions/attest SHA pin, "
+                f"found {len(pins)}"
+            )
+        elif pins[0] != expected:
+            errors.append(
+                f"{workflow}: pin @{pins[0][0]} # {pins[0][1]}, "
+                f"want @{EXPECTED_SHA} # {EXPECTED_TAG}"
+            )
+        try:
+            document = load_workflow_mapping(workflow)
+        except WorkflowParseError as error:
+            errors.append(str(error))
+            continue
+        errors.extend(producer_contract_errors(producer, text, document))
+    return errors
+
+
+def main() -> int:
+    errors = check()
+    if errors:
+        print("FAIL: actions/attest workflow pins", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+    print(
+        f"ok    {len(PRODUCERS)} actions/attest callsites "
+        f"@{EXPECTED_SHA} # {EXPECTED_TAG}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check-actions-attest-lockstep.py
+++ b/scripts/ci/check-actions-attest-lockstep.py
@@ -13,24 +13,24 @@ from typing import NamedTuple
 EXPECTED_SHA = "1e69f48acb82d1966a394da916b4c1698aa569d6"
 EXPECTED_TAG = "v4.2.2"
 WORKFLOW_DIR = Path(".github/workflows")
-ATTEST_ACTION = "actions/attest@"
-YAML_HEX_ESCAPE_RE = re.compile(
-    r"\\(?:x([0-9a-fA-F]{2})|u([0-9a-fA-F]{4})|U([0-9a-fA-F]{8}))"
-)
 USES_RE = re.compile(
     r"^[ \t]*(?:-[ \t]+)?uses:[ \t]+"
     r"(?P<quote>['\"]?)actions/attest@"
     r"(?P<sha>[0-9a-f]{40})(?P=quote)[ \t]+"
     r"#[ \t]+(?P<tag>v\d+\.\d+\.\d+)[ \t]*$"
 )
-DIRECT_USES_SHA_RE = re.compile(r"^actions/attest@([0-9a-f]{40})$")
+DIRECT_USES_SHA_RE = re.compile(r"^actions/attest@([0-9a-f]{40})$", re.IGNORECASE)
 
 
 class Producer(NamedTuple):
     path: Path
+    job_id: str
     step_id: str
     subject_checksums: str
+    subject_producer: str
     bundle_output: str
+    consumer_if: str | None
+    consumer_env: tuple[str, str] | None
 
 
 class WorkflowParseError(Exception):
@@ -40,25 +40,30 @@ class WorkflowParseError(Exception):
 PRODUCERS = (
     Producer(
         path=Path(".github/workflows/runner-spike-delegated.yml"),
+        job_id="phase1-delegated-gates",
         step_id="attest-proof-pack",
         subject_checksums="assay-runner-proof-upload/subject-checksums.txt",
+        subject_producer="python3 scripts/ci/assay_runner_delegated_proof_pack.py",
         bundle_output="steps.attest-proof-pack.outputs.bundle-path",
+        consumer_if="always() && steps.attest-proof-pack.outputs.bundle-path != ''",
+        consumer_env=None,
     ),
     Producer(
         path=Path(".github/workflows/privileged-mcp-action-pack-release.yml"),
+        job_id="release-pack",
         step_id="attest",
         subject_checksums="release/SHA256SUMS",
+        subject_producer=(
+            "sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS"
+        ),
         bundle_output="steps.attest.outputs.bundle-path",
+        consumer_if=None,
+        consumer_env=(
+            "ATTESTATION_BUNDLE",
+            "${{ steps.attest.outputs.bundle-path }}",
+        ),
     ),
 )
-
-
-def decode_hex_escape(match: re.Match[str]) -> str:
-    codepoint = next(group for group in match.groups() if group is not None)
-    try:
-        return chr(int(codepoint, 16))
-    except ValueError:
-        return "\N{REPLACEMENT CHARACTER}"
 
 
 def active_attest_pins(text: str) -> list[tuple[str, str]]:
@@ -71,23 +76,6 @@ def active_attest_pins(text: str) -> list[tuple[str, str]]:
         if match:
             pins.append((match.group("sha"), match.group("tag")))
     return pins
-
-
-def active_attest_references(text: str) -> int:
-    active_text = "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
-    # GitHub resolves repository names case-insensitively, and YAML double-quoted
-    # scalars decode hexadecimal escapes and escaped line breaks before dispatch.
-    # Needle is actions/attest@, which does not match attest-build-provenance@.
-    normalized = re.sub(r"\\\r?\n[ \t]*", "", active_text)
-    normalized = YAML_HEX_ESCAPE_RE.sub(decode_hex_escape, normalized)
-    normalized = normalized.casefold()
-    return normalized.count(ATTEST_ACTION)
-
-
-def has_active_attest_callsite(text: str) -> bool:
-    return active_attest_references(text) > 0
 
 
 def load_workflow_mapping(path: Path) -> object:
@@ -120,44 +108,92 @@ def load_workflow_mapping(path: Path) -> object:
         ) from error
 
 
-def iter_steps(document: object) -> list[dict[str, object]]:
-    if not isinstance(document, dict):
-        raise WorkflowParseError("workflow root is not a mapping")
-    jobs = document.get("jobs")
-    if not isinstance(jobs, dict):
-        raise WorkflowParseError("workflow jobs is not a mapping")
-    steps: list[dict[str, object]] = []
-    for job in jobs.values():
-        if not isinstance(job, dict):
-            continue
-        raw_steps = job.get("steps") or []
-        if not isinstance(raw_steps, list):
-            continue
-        for step in raw_steps:
-            if isinstance(step, dict):
-                steps.append(step)
-    return steps
+def mapping(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise WorkflowParseError(f"{label} is not a mapping")
+    return value
 
 
-def direct_attest_steps(document: object) -> list[dict[str, object]]:
-    found: list[dict[str, object]] = []
-    for step in iter_steps(document):
-        uses = step.get("uses")
-        if isinstance(uses, str) and DIRECT_USES_SHA_RE.fullmatch(uses.strip()):
-            found.append(step)
+def job_steps(job: dict[str, object]) -> list[dict[str, object]]:
+    raw_steps = job.get("steps") or []
+    if not isinstance(raw_steps, list):
+        return []
+    return [step for step in raw_steps if isinstance(step, dict)]
+
+
+def iter_jobs(document: object) -> list[tuple[str, dict[str, object]]]:
+    root = mapping(document, "workflow root")
+    jobs = mapping(root.get("jobs"), "workflow jobs")
+    named: list[tuple[str, dict[str, object]]] = []
+    for name, job in jobs.items():
+        if isinstance(name, str) and isinstance(job, dict):
+            named.append((name, job))
+    return named
+
+
+def is_direct_attest_uses(uses: object) -> bool:
+    return isinstance(uses, str) and DIRECT_USES_SHA_RE.fullmatch(uses.strip()) is not None
+
+
+def structural_attest_steps(
+    document: object,
+) -> list[tuple[str, int, dict[str, object]]]:
+    found: list[tuple[str, int, dict[str, object]]] = []
+    for job_id, job in iter_jobs(document):
+        for index, step in enumerate(job_steps(job)):
+            if is_direct_attest_uses(step.get("uses")):
+                found.append((job_id, index, step))
     return found
 
 
-def producer_contract_errors(producer: Producer, text: str, document: object) -> list[str]:
+def condition_is_false(value: object) -> bool:
+    return value is False or (
+        isinstance(value, str) and value.strip().casefold() in {"false", "${{ false }}"}
+    )
+
+
+def is_reachable(node: dict[str, object]) -> bool:
+    return not condition_is_false(node.get("if"))
+
+
+def step_run_text(step: dict[str, object]) -> str:
+    run = step.get("run")
+    return run if isinstance(run, str) else ""
+
+
+def step_has_bundle_expression(step: dict[str, object], expression: str) -> bool:
+    if expression in step_run_text(step):
+        return True
+    env = step.get("env")
+    if not isinstance(env, dict):
+        return False
+    return any(isinstance(value, str) and expression in value for value in env.values())
+
+
+def producer_contract_errors(producer: Producer, document: object) -> list[str]:
     errors: list[str] = []
-    steps = direct_attest_steps(document)
-    if len(steps) != 1:
+    attest_steps = structural_attest_steps(document)
+    if len(attest_steps) != 1:
         errors.append(
             f"{producer.path}: want exactly one direct actions/attest step, "
-            f"found {len(steps)}"
+            f"found {len(attest_steps)}"
         )
         return errors
-    step = steps[0]
+    job_id, attest_index, step = attest_steps[0]
+    jobs = dict(iter_jobs(document))
+    job = jobs.get(producer.job_id)
+    if job_id != producer.job_id or job is None:
+        errors.append(
+            f"{producer.path}: attest step is in job {job_id!r}, "
+            f"want {producer.job_id!r}"
+        )
+        return errors
+    if not is_reachable(job):
+        errors.append(f"{producer.path}: job {producer.job_id!r} is not reachable")
+    if not is_reachable(step):
+        errors.append(
+            f"{producer.path}: attest step {producer.step_id!r} is not reachable"
+        )
     if step.get("id") != producer.step_id:
         errors.append(
             f"{producer.path}: attest step id {step.get('id')!r}, "
@@ -174,9 +210,36 @@ def producer_contract_errors(producer: Producer, text: str, document: object) ->
             f"{producer.path}: subject-checksums {with_block.get('subject-checksums')!r}, "
             f"want {producer.subject_checksums!r}"
         )
-    if producer.bundle_output not in text:
+    same_job_steps = job_steps(job)
+    earlier = same_job_steps[:attest_index]
+    if not any(producer.subject_producer in step_run_text(item) for item in earlier):
         errors.append(
-            f"{producer.path}: missing bundle consumer {producer.bundle_output}"
+            f"{producer.path}: subject {producer.subject_checksums} is not produced "
+            f"earlier in job {producer.job_id!r} by {producer.subject_producer!r}"
+        )
+    later = same_job_steps[attest_index + 1 :]
+    expression = "${{ " + producer.bundle_output + " }}"
+    found_consumer = False
+    for consumer in later:
+        if not is_reachable(consumer):
+            continue
+        if producer.consumer_if is not None and consumer.get("if") != producer.consumer_if:
+            continue
+        if producer.consumer_env is not None:
+            env = consumer.get("env")
+            key, value = producer.consumer_env
+            if not isinstance(env, dict) or env.get(key) != value:
+                continue
+        if not step_has_bundle_expression(consumer, expression):
+            continue
+        if not step_run_text(consumer):
+            continue
+        found_consumer = True
+        break
+    if not found_consumer:
+        errors.append(
+            f"{producer.path}: missing reachable same-job consumer "
+            f"{producer.bundle_output}"
         )
     return errors
 
@@ -186,13 +249,16 @@ def check() -> list[str]:
     expected = (EXPECTED_SHA, EXPECTED_TAG)
     expected_paths = {producer.path for producer in PRODUCERS}
 
-    discovered: set[Path] = set()
     for pattern in ("*.yml", "*.yaml"):
-        for workflow in WORKFLOW_DIR.glob(pattern):
-            if has_active_attest_callsite(workflow.read_text(encoding="utf-8")):
-                discovered.add(workflow)
-    for workflow in sorted(discovered - expected_paths):
-        errors.append(f"unexpected actions/attest workflow callsite: {workflow}")
+        for workflow in sorted(WORKFLOW_DIR.glob(pattern)):
+            if workflow in expected_paths:
+                continue
+            try:
+                document = load_workflow_mapping(workflow)
+            except WorkflowParseError:
+                continue
+            if structural_attest_steps(document):
+                errors.append(f"unexpected actions/attest workflow callsite: {workflow}")
 
     for producer in PRODUCERS:
         workflow = producer.path
@@ -201,12 +267,6 @@ def check() -> list[str]:
             continue
         text = workflow.read_text(encoding="utf-8")
         pins = active_attest_pins(text)
-        references = active_attest_references(text)
-        if references != len(pins):
-            errors.append(
-                f"{workflow}: found {references} actions/attest reference(s), "
-                f"but only {len(pins)} canonical pin(s)"
-            )
         if len(pins) != 1:
             errors.append(
                 f"{workflow}: want exactly one active actions/attest SHA pin, "
@@ -222,7 +282,7 @@ def check() -> list[str]:
         except WorkflowParseError as error:
             errors.append(str(error))
             continue
-        errors.extend(producer_contract_errors(producer, text, document))
+        errors.extend(producer_contract_errors(producer, document))
     return errors
 
 

--- a/scripts/ci/test-actions-attest-lockstep.sh
+++ b/scripts/ci/test-actions-attest-lockstep.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# Mutation battery for the closed two-workflow actions/attest pin set.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="scripts/ci/check-actions-attest-lockstep.py"
+PRECOMMIT=".pre-commit-config.yaml"
+WORKFLOWS=(
+  .github/workflows/runner-spike-delegated.yml
+  .github/workflows/privileged-mcp-action-pack-release.yml
+)
+OWNER_SHA="1e69f48acb82d1966a394da916b4c1698aa569d6"
+DRIFT_SHA="d1ba80a13dd99fba24a470575428917156a28b43"
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+seed() {
+  local dest="$1" path
+  mkdir -p "$dest/scripts/ci" "$dest/.github/workflows"
+  cp "$ROOT/$CHECKER" "$dest/$CHECKER"
+  cp "$ROOT/$PRECOMMIT" "$dest/$PRECOMMIT"
+  for path in "${WORKFLOWS[@]}"; do
+    cp "$ROOT/$path" "$dest/$path"
+  done
+}
+
+check_hook_scope() {
+  local root="$1"
+  python3 - "$root/$PRECOMMIT" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+if "- id: actions-attest-lockstep" not in text:
+    raise SystemExit("actions/attest lockstep hook is missing")
+block = text.split("- id: actions-attest-lockstep", 1)[1].split("\n      - id:", 1)[0]
+match = re.search(r"^[ \t]*files:[ \t]*(.+)$", block, re.MULTILINE)
+if match is None:
+    raise SystemExit("actions/attest lockstep hook has no files selector")
+pattern = match.group(1).strip()
+required = (
+    ".github/workflows/third-attest.yml",
+    ".github/workflows/third-attest.yaml",
+    "scripts/ci/check-actions-attest-lockstep.py",
+    "scripts/ci/test-actions-attest-lockstep.sh",
+    ".pre-commit-config.yaml",
+)
+missing = [path for path in required if re.search(pattern, path) is None]
+if missing:
+    raise SystemExit(f"actions/attest lockstep hook does not trigger for: {', '.join(missing)}")
+PY
+}
+
+run_hook_scope_case() {
+  local name="$1" root="$2" expected="$3" status=0
+  check_hook_scope "$root" >"$scratch/$name.log" 2>&1 || status=$?
+  if [[ "$status" -ne "$expected" ]]; then
+    cat "$scratch/$name.log" >&2
+    echo "FAIL: $name exited $status, wanted $expected" >&2
+    exit 1
+  fi
+  echo "ok    $name (exit $status)"
+}
+
+run_case() {
+  local name="$1" root="$2" expected="$3" status=0
+  (cd "$root" && python3 "$CHECKER") >"$scratch/$name.log" 2>&1 || status=$?
+  if [[ "$status" -ne "$expected" ]]; then
+    cat "$scratch/$name.log" >&2
+    echo "FAIL: $name exited $status, wanted $expected" >&2
+    exit 1
+  fi
+  echo "ok    $name (exit $status)"
+}
+
+mutate_once() {
+  local path="$1" old="$2" new="$3"
+  python3 - "$path" "$old" "$new" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+old, new = sys.argv[2], sys.argv[3]
+text = path.read_text(encoding="utf-8")
+if text.count(old) != 1:
+    raise SystemExit(f"mutation subject count is {text.count(old)}, want 1: {old}")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+}
+
+case_root="$scratch/control"
+seed "$case_root"
+run_case control-is-green "$case_root" 0
+run_hook_scope_case hook-scope-covers-all-workflows "$case_root" 0
+
+case_root="$scratch/narrow-hook-scope"
+seed "$case_root"
+mutate_once \
+  "$case_root/$PRECOMMIT" \
+  'files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$' \
+  'files: ^(\.github/workflows/(runner-spike-delegated|privileged-mcp-action-pack-release)\.yml|scripts/ci/(check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$'
+run_hook_scope_case narrow-hook-scope-is-refused "$case_root" 1
+
+case_root="$scratch/missing-hook"
+seed "$case_root"
+python3 - "$case_root/$PRECOMMIT" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+start = text.find("      - id: actions-attest-lockstep")
+if start < 0:
+    raise SystemExit("hook block missing")
+end = text.find("      - id:", start + 1)
+if end < 0:
+    raise SystemExit("next hook id missing")
+path.write_text(text[:start] + text[end:], encoding="utf-8")
+PY
+run_hook_scope_case missing-hook-is-refused "$case_root" 1
+
+case_root="$scratch/one-laggard"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "$OWNER_SHA" \
+  "$DRIFT_SHA"
+run_case one-laggard-is-refused "$case_root" 1
+
+case_root="$scratch/tag-drift"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "# v4.2.2" \
+  "# v4.2.1"
+run_case tag-drift-is-refused "$case_root" 1
+
+case_root="$scratch/retarget-delegated-subject"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "          subject-checksums: assay-runner-proof-upload/subject-checksums.txt" \
+  "          subject-checksums: assay-runner-proof-upload/retargeted-checksums.txt"
+run_case retarget-delegated-subject-is-refused "$case_root" 1
+
+case_root="$scratch/retarget-pack-subject"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "subject-checksums: release/SHA256SUMS" \
+  "subject-checksums: release/OTHERSUMS"
+run_case retarget-pack-subject-is-refused "$case_root" 1
+
+case_root="$scratch/delete-delegated-subject"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "          subject-checksums: assay-runner-proof-upload/subject-checksums.txt
+" \
+  ""
+run_case delete-delegated-subject-is-refused "$case_root" 1
+
+case_root="$scratch/delete-pack-subject"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "          subject-checksums: release/SHA256SUMS
+" \
+  ""
+run_case delete-pack-subject-is-refused "$case_root" 1
+
+case_root="$scratch/unwired-with"
+seed "$case_root"
+python3 - "$case_root/.github/workflows/runner-spike-delegated.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = """        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-checksums: assay-runner-proof-upload/subject-checksums.txt
+          show-summary: true
+"""
+new = """        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+"""
+if text.count(old) != 1:
+    raise SystemExit("unwired-with subject missing")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+run_case sha-only-unwired-with-is-refused "$case_root" 1
+
+case_root="$scratch/remove-delegated-uses"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "        uses: actions/attest@${OWNER_SHA} # v4.2.2" \
+  "        run: echo bypassed-attest"
+run_case remove-delegated-uses-is-refused "$case_root" 1
+
+case_root="$scratch/remove-pack-uses"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "        uses: actions/attest@${OWNER_SHA} # v4.2.2" \
+  "        run: echo bypassed-attest"
+run_case remove-pack-uses-is-refused "$case_root" 1
+
+case_root="$scratch/remove-delegated-workflow"
+seed "$case_root"
+rm "$case_root/.github/workflows/runner-spike-delegated.yml"
+run_case remove-delegated-workflow-is-refused "$case_root" 1
+
+case_root="$scratch/remove-pack-workflow"
+seed "$case_root"
+rm "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml"
+run_case remove-pack-workflow-is-refused "$case_root" 1
+
+case_root="$scratch/malformed-delegated"
+seed "$case_root"
+printf '\n{ [ }\n' >>"$case_root/.github/workflows/runner-spike-delegated.yml"
+run_case malformed-delegated-is-refused "$case_root" 1
+
+case_root="$scratch/malformed-pack"
+seed "$case_root"
+printf '\n{ [ }\n' >>"$case_root/.github/workflows/privileged-mcp-action-pack-release.yml"
+run_case malformed-pack-is-refused "$case_root" 1
+
+case_root="$scratch/provenance-is-not-attest"
+seed "$case_root"
+cat >"$case_root/.github/workflows/release-wrapper.yml" <<'YAML'
+name: Wrapper is a different action
+on: workflow_dispatch
+jobs:
+  provenance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+YAML
+run_case provenance-wrapper-is-not-a-callsite "$case_root" 0
+
+case_root="$scratch/extra-callsite"
+seed "$case_root"
+cat >>"$case_root/.github/workflows/runner-spike-delegated.yml" <<YAML
+
+# Mutation: a second active attest is outside the closed one-callsite contract.
+uses: actions/attest@${OWNER_SHA} # v4.2.2
+YAML
+run_case extra-callsite-is-refused "$case_root" 1
+
+case_root="$scratch/quoted-duplicate"
+seed "$case_root"
+cat >>"$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<YAML
+
+# Mutation: quoted uses values are valid workflow YAML and remain active.
+uses: "actions/attest@${OWNER_SHA}" # v4.2.2
+YAML
+run_case quoted-duplicate-is-refused "$case_root" 1
+
+case_root="$scratch/foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/third-attest.yml" <<YAML
+name: Mutated third actions/attest
+jobs:
+  attest:
+    steps:
+      - uses: actions/attest@${OWNER_SHA} # v4.2.2
+YAML
+run_case foreign-workflow-callsite-is-refused "$case_root" 1
+
+case_root="$scratch/quoted-foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/quoted-attest.yaml" <<YAML
+name: Mutated quoted actions/attest
+jobs:
+  attest:
+    steps:
+      - uses: 'actions/attest@${OWNER_SHA}' # v4.2.2
+YAML
+run_case quoted-foreign-workflow-callsite-is-refused "$case_root" 1
+
+case_root="$scratch/flow-mapping-foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/flow-attest.yml" <<YAML
+name: Mutated flow-mapping actions/attest
+on: workflow_dispatch
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - {uses: actions/attest@${OWNER_SHA}}
+YAML
+run_case flow-mapping-foreign-workflow-is-refused "$case_root" 1
+
+case_root="$scratch/quoted-key-foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/quoted-key-attest.yml" <<YAML
+name: Mutated quoted-key actions/attest
+on: workflow_dispatch
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - "uses": actions/attest@${OWNER_SHA}
+YAML
+run_case quoted-key-foreign-workflow-is-refused "$case_root" 1
+
+case_root="$scratch/hex-escaped-action"
+seed "$case_root"
+cat >"$case_root/.github/workflows/hex-escaped-attest.yml" <<YAML
+name: Mutated hex-escaped actions/attest
+on: workflow_dispatch
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/attest\\x40${OWNER_SHA}"
+YAML
+run_case hex-escaped-action-is-refused "$case_root" 1
+
+case_root="$scratch/unicode-escaped-action"
+seed "$case_root"
+cat >"$case_root/.github/workflows/unicode-escaped-attest.yml" <<YAML
+name: Mutated Unicode-escaped actions/attest
+on: workflow_dispatch
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/attest\\u0040${OWNER_SHA}"
+YAML
+run_case unicode-escaped-action-is-refused "$case_root" 1
+
+case_root="$scratch/case-variant-action"
+seed "$case_root"
+cat >"$case_root/.github/workflows/case-variant-attest.yml" <<YAML
+name: Mutated case-variant actions/attest
+on: workflow_dispatch
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions/attest@${OWNER_SHA}
+YAML
+run_case case-variant-action-is-refused "$case_root" 1
+
+case_root="$scratch/unicode-escaped-identity"
+seed "$case_root"
+cat >"$case_root/.github/workflows/unicode-identity-attest.yml" <<YAML
+name: Mutated Unicode-escaped actions/attest identity
+on: workflow_dispatch
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "\\u0061ctions/attest@${OWNER_SHA}"
+YAML
+run_case unicode-escaped-identity-is-refused "$case_root" 1
+
+case_root="$scratch/escaped-line-break-action"
+seed "$case_root"
+python3 - "$case_root/.github/workflows/escaped-break-attest.yml" "$OWNER_SHA" <<'PY'
+from pathlib import Path
+import sys
+
+sha = sys.argv[2]
+Path(sys.argv[1]).write_text(
+    "name: Mutated escaped-line-break actions/attest\n"
+    "on: workflow_dispatch\n"
+    "jobs:\n"
+    "  attest:\n"
+    "    runs-on: ubuntu-latest\n"
+    "    steps:\n"
+    f'      - uses: "actions/att\\\n          est@{sha}"\n',
+    encoding="utf-8",
+)
+PY
+run_case escaped-line-break-action-is-refused "$case_root" 1
+
+printf 'PASS: actions/attest lockstep battery\n'

--- a/scripts/ci/test-actions-attest-lockstep.sh
+++ b/scripts/ci/test-actions-attest-lockstep.sh
@@ -11,6 +11,8 @@ WORKFLOWS=(
 )
 OWNER_SHA="1e69f48acb82d1966a394da916b4c1698aa569d6"
 DRIFT_SHA="d1ba80a13dd99fba24a470575428917156a28b43"
+HOOK_ENTRY="bash scripts/ci/test-actions-attest-lockstep.sh"
+HOOK_FILES='^(\.github/workflows/.*\.ya?ml|scripts/ci/(assay_runner_delegated_proof_pack\.py|check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$'
 
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
@@ -27,22 +29,37 @@ seed() {
 
 check_hook_scope() {
   local root="$1"
-  python3 - "$root/$PRECOMMIT" <<'PY'
+  python3 - "$root/$PRECOMMIT" "$HOOK_ENTRY" "$HOOK_FILES" <<'PY'
 import re
 import sys
 from pathlib import Path
 
 text = Path(sys.argv[1]).read_text(encoding="utf-8")
+expected_entry = sys.argv[2]
+expected_files = sys.argv[3]
 if "- id: actions-attest-lockstep" not in text:
     raise SystemExit("actions/attest lockstep hook is missing")
 block = text.split("- id: actions-attest-lockstep", 1)[1].split("\n      - id:", 1)[0]
+entry_match = re.search(r"^[ \t]*entry:[ \t]*(.+)$", block, re.MULTILINE)
+if entry_match is None:
+    raise SystemExit("actions/attest lockstep hook has no entry")
+entry = entry_match.group(1).strip()
+if entry != expected_entry:
+    raise SystemExit(
+        f"actions/attest lockstep hook entry {entry!r}, want {expected_entry!r}"
+    )
 match = re.search(r"^[ \t]*files:[ \t]*(.+)$", block, re.MULTILINE)
 if match is None:
     raise SystemExit("actions/attest lockstep hook has no files selector")
 pattern = match.group(1).strip()
+if pattern != expected_files:
+    raise SystemExit(
+        f"actions/attest lockstep hook files {pattern!r}, want {expected_files!r}"
+    )
 required = (
     ".github/workflows/third-attest.yml",
     ".github/workflows/third-attest.yaml",
+    "scripts/ci/assay_runner_delegated_proof_pack.py",
     "scripts/ci/check-actions-attest-lockstep.py",
     "scripts/ci/test-actions-attest-lockstep.sh",
     ".pre-commit-config.yaml",
@@ -95,12 +112,20 @@ seed "$case_root"
 run_case control-is-green "$case_root" 0
 run_hook_scope_case hook-scope-covers-all-workflows "$case_root" 0
 
+case_root="$scratch/hook-entry-true"
+seed "$case_root"
+mutate_once \
+  "$case_root/$PRECOMMIT" \
+  "        entry: ${HOOK_ENTRY}" \
+  "        entry: true"
+run_hook_scope_case hook-entry-true-is-refused "$case_root" 1
+
 case_root="$scratch/narrow-hook-scope"
 seed "$case_root"
 mutate_once \
   "$case_root/$PRECOMMIT" \
-  'files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$' \
-  'files: ^(\.github/workflows/(runner-spike-delegated|privileged-mcp-action-pack-release)\.yml|scripts/ci/(check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$'
+  "files: ${HOOK_FILES}" \
+  'files: ^(\.github/workflows/(runner-spike-delegated|privileged-mcp-action-pack-release)\.yml|scripts/ci/(assay_runner_delegated_proof_pack\.py|check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$'
 run_hook_scope_case narrow-hook-scope-is-refused "$case_root" 1
 
 case_root="$scratch/missing-hook"
@@ -378,5 +403,177 @@ Path(sys.argv[1]).write_text(
 )
 PY
 run_case escaped-line-break-action-is-refused "$case_root" 1
+
+case_root="$scratch/retarget-pack-sha256sum"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS" \
+  "            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > OTHERSUMS"
+run_case retarget-pack-sha256sum-is-refused "$case_root" 1
+
+case_root="$scratch/delete-pack-sha256sum"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS
+" \
+  ""
+run_case delete-pack-sha256sum-is-refused "$case_root" 1
+
+case_root="$scratch/retarget-delegated-proof-pack"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "          python3 scripts/ci/assay_runner_delegated_proof_pack.py \\" \
+  "          python3 scripts/ci/other_delegated_proof_pack.py \\"
+run_case retarget-delegated-proof-pack-is-refused "$case_root" 1
+
+case_root="$scratch/delete-delegated-proof-pack"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "          python3 scripts/ci/assay_runner_delegated_proof_pack.py \\" \
+  "          true \\"
+run_case delete-delegated-proof-pack-is-refused "$case_root" 1
+
+case_root="$scratch/pack-consumer-comment"
+seed "$case_root"
+python3 - "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = """      - name: Retain attestation bundle
+        env:
+          ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+          test -n "$ATTESTATION_BUNDLE"
+          cp "$ATTESTATION_BUNDLE" release/attestation-bundle.json
+"""
+new = """      # Retain attestation bundle via steps.attest.outputs.bundle-path
+"""
+if text.count(old) != 1:
+    raise SystemExit("pack-consumer-comment subject missing")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+run_case pack-consumer-comment-is-refused "$case_root" 1
+
+case_root="$scratch/delegated-consumer-scalar"
+seed "$case_root"
+python3 - "$case_root/.github/workflows/runner-spike-delegated.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = """      - name: Retain delegated proof attestation bundle
+        if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp "${{ steps.attest-proof-pack.outputs.bundle-path }}" \\
+            "$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD/attestation-bundle.json"
+          {
+            echo "- attestation-bundle: assay-runner-proof-upload/attestation-bundle.json"
+            echo "- attestation-url: ${{ steps.attest-proof-pack.outputs.attestation-url }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+"""
+new = """      - name: Retain delegated proof attestation bundle
+        NOTE: steps.attest-proof-pack.outputs.bundle-path
+"""
+if text.count(old) != 1:
+    raise SystemExit("delegated-consumer-scalar subject missing")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+run_case delegated-consumer-scalar-is-refused "$case_root" 1
+
+case_root="$scratch/pack-attest-if-false"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "        id: attest
+        uses: actions/attest@${OWNER_SHA} # v4.2.2" \
+  "        id: attest
+        if: false
+        uses: actions/attest@${OWNER_SHA} # v4.2.2"
+run_case pack-attest-if-false-is-refused "$case_root" 1
+
+case_root="$scratch/delegated-consumer-if-false"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "        if: always() && steps.attest-proof-pack.outputs.bundle-path != ''" \
+  "        if: false"
+run_case delegated-consumer-if-false-is-refused "$case_root" 1
+
+case_root="$scratch/pack-consumer-other-job"
+seed "$case_root"
+python3 - "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+consumer = """      - name: Retain attestation bundle
+        env:
+          ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+          test -n "$ATTESTATION_BUNDLE"
+          cp "$ATTESTATION_BUNDLE" release/attestation-bundle.json
+
+"""
+if text.count(consumer) != 1:
+    raise SystemExit("pack-consumer-other-job subject missing")
+text = text.replace(consumer, "", 1)
+text += """
+  retain-elsewhere:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Retain attestation bundle
+        env:
+          ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+          test -n "$ATTESTATION_BUNDLE"
+          cp "$ATTESTATION_BUNDLE" release/attestation-bundle.json
+"""
+path.write_text(text, encoding="utf-8")
+PY
+run_case pack-consumer-other-job-is-refused "$case_root" 1
+
+case_root="$scratch/inert-note-census"
+seed "$case_root"
+cat >>"$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<YAML
+
+NOTE: "actions/attest@${OWNER_SHA}"
+YAML
+run_case inert-note-attest-is-not-a-callsite "$case_root" 0
+
+case_root="$scratch/missing-ruby"
+seed "$case_root"
+norb="$scratch/norb/bin"
+mkdir -p "$norb"
+ln -sfn "$(command -v python3)" "$norb/python3"
+if PATH="$norb" command -v ruby >/dev/null 2>&1; then
+  echo "FAIL: ruby-free PATH still locates ruby" >&2
+  exit 1
+fi
+status=0
+(cd "$case_root" && PATH="$norb" python3 "$CHECKER") >"$scratch/missing-ruby.log" 2>&1 || status=$?
+if [[ "$status" -ne 1 ]]; then
+  cat "$scratch/missing-ruby.log" >&2
+  echo "FAIL: missing-ruby exited $status, wanted 1" >&2
+  exit 1
+fi
+if ! grep -q "yaml parser unavailable" "$scratch/missing-ruby.log"; then
+  cat "$scratch/missing-ruby.log" >&2
+  echo "FAIL: missing-ruby did not fail-closed on parser unavailability" >&2
+  exit 1
+fi
+echo "ok    missing-ruby-is-refused (exit $status)"
 
 printf 'PASS: actions/attest lockstep battery\n'


### PR DESCRIPTION
## Summary

Direct `actions/attest` patch slice for #2474. The two owning producers stay on owner pin `1e69f48acb82d1966a394da916b4c1698aa569d6` (`# v4.2.2`). This head binds each `subject-checksums` path to the real earlier same-job producer, requires a reachable later bundle consumer in that same job, counts callsites from structural `jobs.*.steps[].uses` only, and lets the directly invoked contract test pin hook `entry` and `files:`.

- Exact head: `e4eb6e9dbc334348747479ed8a4530c7a2f3dd9d`
- Exact base: `3dd32b8f452f48d7aac736b781a68ccc3417edc4`

Prior exact-head proof on `61cfee5126b730a3a76ed41f2f1136e4e42a56da` does not carry. Hosted/delegated proof was not redispatched. New CI from this push is pending and is not claimed green.

This is the #2474 direct-attest slice only. It does not close #2474.

## Files

- `.github/workflows/runner-spike-delegated.yml` (`uses:` SHA/tag comment only; production pins/permissions/conditions/subjects/outputs/consumers unchanged)
- `.github/workflows/privileged-mcp-action-pack-release.yml` (same)
- `scripts/ci/check-actions-attest-lockstep.py`
- `scripts/ci/test-actions-attest-lockstep.sh`
- `.pre-commit-config.yaml` (hook `entry` unchanged; `files:` now includes `scripts/ci/assay_runner_delegated_proof_pack.py`)

`scripts/ci/assay_runner_delegated_proof_pack.py` is in hook files-scope only. It was not modified.

## RED / GREEN / mutations

Production lockstep stayed as-is at `61cfee5` until the new cases failed.

| Stage | Evidence |
|---|---|
| RED 1 — subject production | Retarget/delete release `sha256sum … > SHA256SUMS` and retarget/delete delegated `python3 scripts/ci/assay_runner_delegated_proof_pack.py` left the checker green (`ok 2 actions/attest callsites`). Hook `files:` omitted the delegated producer script. |
| RED 2 — bundle consumer | Comment witness, inert `NOTE:` scalar, `if: false` on action/consumer, and consumer moved to another job left the checker green (raw-text `bundle-path` still present). |
| RED 3 — hook self-wash | Contract test did not pin exact `entry`. `files:` did not match the required selector (missing `assay_runner_delegated_proof_pack.py`). |
| RED 4 — P2 census | Inert `NOTE: "actions/attest@SHA"` was counted as a second reference (`found 2 … but only 1 canonical pin`). |
| GREEN | Checker binds each subject to the earlier same-job producer (release SHA256SUMS / delegated proof-pack invocation) and requires a reachable later consumer in that job with the existing output/condition contract. Census is structural `jobs.*.steps[].uses` only. Contract test pins exact hook `entry` and `files:`. |
| 1. Remove/retarget subject producer | Refused (pack `sha256sum` retarget/delete; delegated proof-pack retarget/delete). Control green after restore. |
| 2. Consumer comment / inert scalar | Refused (pack comment; delegated `NOTE:` scalar). Control green after restore. |
| 3. Action/consumer `if: false` | Refused (pack attest `if: false`; delegated consumer `if: false`). Control green after restore. |
| 4. Consumer other job | Refused (pack retain step moved to `retain-elsewhere`). Control green after restore. |
| 5. Hook `entry: true` | Refused (`entry 'true', want 'bash scripts/ci/test-actions-attest-lockstep.sh'`). Control green after restore. |
| 6. Inert `NOTE: actions/attest@SHA` | Not a callsite (checker stays green). |
| Prior | Drift SHA, remove producer `uses:`, remove hook/`files:` coverage, malformed YAML fail-closed, SHA-only unwired `with:`, missing Ruby fail-closed. Control green after each restore. |

Focused checker: `ok 2 actions/attest callsites @1e69f48… # v4.2.2`. Battery / hook entry / `pre-commit run actions-attest-lockstep`: `PASS`. actionlint clean on both producer workflows. `python3 -c` import / `py_compile` clean. `git diff --check` clean. No Cargo in this slice.

## Test plan

- [x] Focused checker + self-test / hook entry
- [x] Live mutation restore cycle (control green after each)
- [x] Structural `uses:` census; inert NOTE is not a callsite
- [x] Same-job subject producer + reachable consumer
- [x] Hook `entry` and `files:` pinned by the contract test
- [x] Malformed YAML / missing-Ruby fail-closed
- [x] actionlint on both producer workflows
- [x] `git diff --check`
- [ ] Independent exact-head review on `e4eb6e9dbc334348747479ed8a4530c7a2f3dd9d` (not this builder)
- [ ] Delegated proof when lane policy requires it; not redispatched here; delegated green is not pack-release proof

## Non-claims

- Does not close #2474 as a whole issue
- Not the release-wrapper / `attest-build-provenance` decision
- Not jsonschema or base64
- Not a FIPS or SLSA claim
- Delegated green ≠ pack-release producer witness
- SHA grep ≠ attestation
- Remains draft; not ready; not merge
- Hosted/delegated proof not redispatched; pending CI is not claimed green
- `61cfee5` exact-head proof does not carry to this head