### PR TITLE
fix(ci): surface S1b leaf cleanup residue

### DIFF
--- a/scripts/ci/run-send-syscall-matrix.sh
+++ b/scripts/ci/run-send-syscall-matrix.sh
@@ -122,17 +122,32 @@ remove_owned_workdir() {
 }
 
 cleanup() {
-  local pid
+  local incoming_status="${1:-0}" leaf_residue=0 pid
   for pid in "${MONITOR_PID:-}" "${HARNESS_PID:-}"; do
     reap_pid "$pid"
   done
   [[ -z "${FIFO:-}" ]] || rm -f "$FIFO"
   if [[ -n "${LEAF:-}" && -d "$LEAF" ]]; then
-    rmdir "$LEAF" 2>/dev/null || true
+    if ! rmdir "$LEAF" 2>/dev/null; then
+      printf 'S1B_LEAF_RESIDUE path=%s\n' "$LEAF" >&2
+      leaf_residue=1
+    fi
   fi
   remove_owned_workdir "${WORKDIR:-}"
+  [[ "$incoming_status" -eq 0 ]] || return "$incoming_status"
+  [[ "$leaf_residue" -eq 0 ]]
 }
-trap cleanup EXIT
+
+cleanup_on_exit() {
+  local incoming_status="$1" cleanup_status
+  trap - EXIT
+  set +e
+  cleanup "$incoming_status"
+  cleanup_status=$?
+  exit "$cleanup_status"
+}
+
+trap 'cleanup_on_exit "$?"' EXIT
 trap 'exit 143' TERM
 trap 'exit 130' INT
 
@@ -473,6 +488,14 @@ case "$MODE" in
     rm -rf "$bad"
     WORKDIR=""
     echo "ok: cleanup-selftest" ;;
+  cleanup-leaf-status-selftest)
+    [[ -n "${2:-}" && -d "$2" ]] || fail "cleanup leaf selftest requires an existing leaf directory"
+    [[ "${3:-}" =~ ^([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$ ]] \
+      || fail "cleanup leaf selftest requires an exit status in 0..255"
+    LEAF="$2"
+    WORKDIR=$(mktemp -d /tmp/s1b-leaf-status-XXXXXX)
+    printf 'SELFTEST_WORKDIR=%s\n' "$WORKDIR"
+    exit "$3" ;;
   coverage-gate) coverage_gate "${2:?coverage-gate requires a JSON path}" ;;
   mutation-selftest) mutation_selftest ;;
   endpoint-line-selftest)

--- a/scripts/ci/run-send-syscall-matrix.sh
+++ b/scripts/ci/run-send-syscall-matrix.sh
@@ -490,6 +490,8 @@ case "$MODE" in
     echo "ok: cleanup-selftest" ;;
   cleanup-leaf-status-selftest)
     [[ -n "${2:-}" && -d "$2" ]] || fail "cleanup leaf selftest requires an existing leaf directory"
+    [[ -n "$(find "$2" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
+      || fail "cleanup leaf selftest requires a non-empty leaf directory"
     [[ "${3:-}" =~ ^([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$ ]] \
       || fail "cleanup leaf selftest requires an exit status in 0..255"
     LEAF="$2"

--- a/scripts/ci/test-s1b-coverage-gate.sh
+++ b/scripts/ci/test-s1b-coverage-gate.sh
@@ -641,6 +641,59 @@ cec=$?
 set -e
 [[ "$cec" -eq 0 ]] || fail "cleanup-selftest ec=$cec err=$(cat "$tmp/cleanup.err")"
 grep -q 'ok: cleanup-selftest' "$tmp/cleanup.out" || fail "cleanup-selftest missing ok"
+
+run_leaf_residue_case() {
+  local driver="$1" label="$2" incoming="$3" expected="$4"
+  local leaf="$tmp/leaf-$label-$incoming" out="$tmp/leaf-$label-$incoming.out" err="$tmp/leaf-$label-$incoming.err"
+  local actual workdir
+  mkdir "$leaf"
+  printf 'busy\n' >"$leaf/member"
+  set +e
+  run_bounded 12 bash "$driver" cleanup-leaf-status-selftest "$leaf" "$incoming" >"$out" 2>"$err"
+  actual=$?
+  set -e
+  [[ "$actual" -eq "$expected" ]] \
+    || fail "leaf residue incoming=$incoming returned $actual, expected $expected"
+  grep -qxF "S1B_LEAF_RESIDUE path=$leaf" "$err" \
+    || fail "leaf residue incoming=$incoming missing named diagnostic"
+  workdir=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$out")
+  [[ -n "$workdir" ]] || fail "leaf residue incoming=$incoming missing selftest workdir"
+  [[ ! -e "$workdir" ]] || fail "leaf residue incoming=$incoming skipped workdir cleanup: $workdir"
+  [[ -f "$leaf/member" ]] || fail "leaf residue fixture unexpectedly disappeared: $leaf"
+}
+
+run_leaf_residue_case "$DRIVER" production 0 1
+run_leaf_residue_case "$DRIVER" production 23 23
+
+noop_cleanup_driver="$tmp/noop-cleanup-driver.sh"
+cp "$DRIVER" "$noop_cleanup_driver"
+printf '\n# comment-only cleanup control\n' >>"$noop_cleanup_driver"
+run_leaf_residue_case "$noop_cleanup_driver" noop 0 1
+
+silent_cleanup_driver="$tmp/silent-cleanup-driver.sh"
+cp "$DRIVER" "$silent_cleanup_driver"
+python3 - "$silent_cleanup_driver" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = '''    if ! rmdir "$LEAF" 2>/dev/null; then
+      printf 'S1B_LEAF_RESIDUE path=%s\\n' "$LEAF" >&2
+      leaf_residue=1
+    fi'''
+new = '''    rmdir "$LEAF" 2>/dev/null || true'''
+if text.count(old) != 1:
+    raise SystemExit("silent cleanup mutation target must occur exactly once")
+path.write_text(text.replace(old, new), encoding="utf-8")
+PY
+set +e
+( run_leaf_residue_case "$silent_cleanup_driver" silent 0 1 ) \
+  >"$tmp/silent-contract.out" 2>"$tmp/silent-contract.err"
+silent_contract_ec=$?
+set -e
+[[ "$silent_contract_ec" -ne 0 ]] \
+  || fail "restoring silent leaf cleanup did not break the residue contract"
 echo "ok: mutation-selftest and cleanup-selftest"
 
 wf="$(cd "$(dirname "$0")/../.." && pwd)/.github/workflows/monitor-attach-smoke.yml"

--- a/scripts/ci/test-s1b-coverage-gate.sh
+++ b/scripts/ci/test-s1b-coverage-gate.sh
@@ -645,7 +645,7 @@ grep -q 'ok: cleanup-selftest' "$tmp/cleanup.out" || fail "cleanup-selftest miss
 run_leaf_residue_case() {
   local driver="$1" label="$2" incoming="$3" expected="$4"
   local leaf="$tmp/leaf-$label-$incoming" out="$tmp/leaf-$label-$incoming.out" err="$tmp/leaf-$label-$incoming.err"
-  local actual diagnostic_count workdir
+  local actual diagnostic_count workdir_count workdir
   mkdir "$leaf"
   printf 'busy\n' >"$leaf/member"
   set +e
@@ -657,8 +657,10 @@ run_leaf_residue_case() {
   diagnostic_count=$(grep -cFx "S1B_LEAF_RESIDUE path=$leaf" "$err" || true)
   [[ "$diagnostic_count" -eq 1 ]] \
     || fail "leaf residue incoming=$incoming emitted $diagnostic_count named diagnostics, expected 1"
+  workdir_count=$(grep -c '^SELFTEST_WORKDIR=' "$out" || true)
+  [[ "$workdir_count" -eq 1 ]] \
+    || fail "leaf residue incoming=$incoming emitted $workdir_count selftest workdir markers, expected 1"
   workdir=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$out")
-  [[ -n "$workdir" ]] || fail "leaf residue incoming=$incoming missing selftest workdir"
   [[ ! -e "$workdir" ]] || fail "leaf residue incoming=$incoming skipped workdir cleanup: $workdir"
   [[ -f "$leaf/member" ]] || fail "leaf residue fixture unexpectedly disappeared: $leaf"
 }
@@ -707,6 +709,31 @@ set -e
 grep -qxF 'FAIL: leaf residue incoming=0 emitted 2 named diagnostics, expected 1' \
   "$tmp/duplicate-contract.err" \
   || fail "duplicate leaf residue mutation failed for an unrelated reason"
+
+duplicate_workdir_driver="$tmp/duplicate-workdir-driver.sh"
+cp "$DRIVER" "$duplicate_workdir_driver"
+python3 - "$duplicate_workdir_driver" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = '''    printf 'SELFTEST_WORKDIR=%s\\n' "$WORKDIR"'''
+new = old + "\n" + old
+if text.count(old) != 1:
+    raise SystemExit("duplicate workdir mutation target must occur exactly once")
+path.write_text(text.replace(old, new), encoding="utf-8")
+PY
+set +e
+( run_leaf_residue_case "$duplicate_workdir_driver" duplicate-workdir 0 1 ) \
+  >"$tmp/duplicate-workdir-contract.out" 2>"$tmp/duplicate-workdir-contract.err"
+duplicate_workdir_contract_ec=$?
+set -e
+[[ "$duplicate_workdir_contract_ec" -ne 0 ]] \
+  || fail "duplicate selftest workdir marker satisfied the contract"
+grep -qxF 'FAIL: leaf residue incoming=0 emitted 2 selftest workdir markers, expected 1' \
+  "$tmp/duplicate-workdir-contract.err" \
+  || fail "duplicate workdir mutation failed for an unrelated reason"
 
 silent_cleanup_driver="$tmp/silent-cleanup-driver.sh"
 cp "$DRIVER" "$silent_cleanup_driver"

--- a/scripts/ci/test-s1b-coverage-gate.sh
+++ b/scripts/ci/test-s1b-coverage-gate.sh
@@ -665,6 +665,18 @@ run_leaf_residue_case() {
 run_leaf_residue_case "$DRIVER" production 0 1
 run_leaf_residue_case "$DRIVER" production 23 23
 
+empty_leaf="$tmp/empty-selftest-leaf"
+mkdir "$empty_leaf"
+set +e
+run_bounded 12 bash "$DRIVER" cleanup-leaf-status-selftest "$empty_leaf" 0 \
+  >"$tmp/empty-leaf.out" 2>"$tmp/empty-leaf.err"
+empty_leaf_ec=$?
+set -e
+[[ "$empty_leaf_ec" -ne 0 ]] || fail "cleanup leaf selftest accepted an empty leaf"
+grep -Fq 'cleanup leaf selftest requires a non-empty leaf directory' "$tmp/empty-leaf.err" \
+  || fail "empty cleanup leaf refusal missing diagnostic"
+[[ -d "$empty_leaf" ]] || fail "cleanup leaf selftest removed an empty caller path"
+
 noop_cleanup_driver="$tmp/noop-cleanup-driver.sh"
 cp "$DRIVER" "$noop_cleanup_driver"
 printf '\n# comment-only cleanup control\n' >>"$noop_cleanup_driver"

--- a/scripts/ci/test-s1b-coverage-gate.sh
+++ b/scripts/ci/test-s1b-coverage-gate.sh
@@ -645,7 +645,7 @@ grep -q 'ok: cleanup-selftest' "$tmp/cleanup.out" || fail "cleanup-selftest miss
 run_leaf_residue_case() {
   local driver="$1" label="$2" incoming="$3" expected="$4"
   local leaf="$tmp/leaf-$label-$incoming" out="$tmp/leaf-$label-$incoming.out" err="$tmp/leaf-$label-$incoming.err"
-  local actual workdir
+  local actual diagnostic_count workdir
   mkdir "$leaf"
   printf 'busy\n' >"$leaf/member"
   set +e
@@ -654,8 +654,9 @@ run_leaf_residue_case() {
   set -e
   [[ "$actual" -eq "$expected" ]] \
     || fail "leaf residue incoming=$incoming returned $actual, expected $expected"
-  grep -qxF "S1B_LEAF_RESIDUE path=$leaf" "$err" \
-    || fail "leaf residue incoming=$incoming missing named diagnostic"
+  diagnostic_count=$(grep -cFx "S1B_LEAF_RESIDUE path=$leaf" "$err" || true)
+  [[ "$diagnostic_count" -eq 1 ]] \
+    || fail "leaf residue incoming=$incoming emitted $diagnostic_count named diagnostics, expected 1"
   workdir=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$out")
   [[ -n "$workdir" ]] || fail "leaf residue incoming=$incoming missing selftest workdir"
   [[ ! -e "$workdir" ]] || fail "leaf residue incoming=$incoming skipped workdir cleanup: $workdir"
@@ -682,6 +683,31 @@ cp "$DRIVER" "$noop_cleanup_driver"
 printf '\n# comment-only cleanup control\n' >>"$noop_cleanup_driver"
 run_leaf_residue_case "$noop_cleanup_driver" noop 0 1
 
+duplicate_cleanup_driver="$tmp/duplicate-cleanup-driver.sh"
+cp "$DRIVER" "$duplicate_cleanup_driver"
+python3 - "$duplicate_cleanup_driver" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = '''      printf 'S1B_LEAF_RESIDUE path=%s\\n' "$LEAF" >&2'''
+new = old + "\n" + old
+if text.count(old) != 1:
+    raise SystemExit("duplicate cleanup mutation target must occur exactly once")
+path.write_text(text.replace(old, new), encoding="utf-8")
+PY
+set +e
+( run_leaf_residue_case "$duplicate_cleanup_driver" duplicate 0 1 ) \
+  >"$tmp/duplicate-contract.out" 2>"$tmp/duplicate-contract.err"
+duplicate_contract_ec=$?
+set -e
+[[ "$duplicate_contract_ec" -ne 0 ]] \
+  || fail "duplicate leaf residue diagnostic satisfied the contract"
+grep -qxF 'FAIL: leaf residue incoming=0 emitted 2 named diagnostics, expected 1' \
+  "$tmp/duplicate-contract.err" \
+  || fail "duplicate leaf residue mutation failed for an unrelated reason"
+
 silent_cleanup_driver="$tmp/silent-cleanup-driver.sh"
 cp "$DRIVER" "$silent_cleanup_driver"
 python3 - "$silent_cleanup_driver" <<'PY'
@@ -704,8 +730,16 @@ set +e
   >"$tmp/silent-contract.out" 2>"$tmp/silent-contract.err"
 silent_contract_ec=$?
 set -e
-[[ "$silent_contract_ec" -ne 0 ]] \
-  || fail "restoring silent leaf cleanup did not break the residue contract"
+[[ "$silent_contract_ec" -eq 1 ]] \
+  || fail "silent leaf cleanup contract returned $silent_contract_ec, expected 1"
+grep -qxF 'FAIL: leaf residue incoming=0 returned 0, expected 1' "$tmp/silent-contract.err" \
+  || fail "silent leaf cleanup mutation failed for an unrelated reason"
+[[ ! -s "$tmp/leaf-silent-0.err" ]] \
+  || fail "silent leaf cleanup mutation unexpectedly emitted a diagnostic"
+silent_workdir=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$tmp/leaf-silent-0.out")
+[[ -n "$silent_workdir" ]] || fail "silent leaf cleanup mutation did not execute the selftest"
+[[ ! -e "$silent_workdir" ]] || fail "silent leaf cleanup mutation skipped workdir cleanup"
+[[ -f "$tmp/leaf-silent-0/member" ]] || fail "silent leaf cleanup mutation removed the residue fixture"
 echo "ok: mutation-selftest and cleanup-selftest"
 
 wf="$(cd "$(dirname "$0")/../.." && pwd)/.github/workflows/monitor-attach-smoke.yml"


### PR DESCRIPTION
## Summary

Closes the first, leaf-cleanup slice of #2349.

- makes an unremovable S1b leaf visible as `S1B_LEAF_RESIDUE`;
- preserves an existing nonzero exit status while turning an otherwise successful run nonzero;
- continues the existing workdir cleanup attempt after leaf removal fails;
- exercises the real driver and EXIT trap through a selftest-only mode.

## RED -> GREEN

Base: `2b1339e309c7027d63970dd5913b28b3bab36409`.

Initial RED before the production change:

```text
FAIL: leaf residue incoming=0 missing named diagnostic
```

The final review repair was also RED first. A mutant that printed two `SELFTEST_WORKDIR` lines passed the old oracle and produced:

```text
FAIL: duplicate selftest workdir marker satisfied the contract
```

GREEN at `4fbbf5a692fd9246d50fd80989214d6215bff64d`:

- `bash scripts/ci/test-s1b-coverage-gate.sh`: pass;
- `bash -n` on both changed scripts: pass;
- exact `s1b-coverage-gate-contract` pre-commit hook: pass;
- commit and pre-push hook catalogues, including shellcheck, cargo fmt, clippy, and the Linux compile gate: pass;
- `git diff --check`: pass.

The behavioral table pins:

| Incoming | Non-empty leaf |
| --- | --- |
| 0 | exit 1, exactly one named residue diagnostic |
| 23 | exit 23, exactly one named residue diagnostic |

Both cases prove workdir cleanup still ran and require exactly one `SELFTEST_WORKDIR` witness. The selftest refuses an empty caller directory and leaves it present.

## Mutation evidence

- Comment-only driver copy: contract stays green.
- Silent `rmdir`: red for the intended false-clean state.
- Duplicate residue diagnostic: red for exact diagnostic cardinality.
- Status-precedence bypass: red.
- Dropped workdir cleanup: red.
- Removed non-empty precondition: red.
- Duplicate `SELFTEST_WORKDIR` marker: red for exact witness cardinality.

## Scope and non-claims

The exit-precedence claim is bounded to leaf-removal failure after process reaping. Pre-existing reaper or workdir-cleanup failures retain their existing fail behavior and are not reclassified by this slice.

This does not change workdir ownership, `RUNNER_TEMP` propagation, process reaping, the S1b observation matrix, or product behavior. It adds no environment-controlled production fault seam. The portable fixture is an ordinary directory and does not prove cgroup-v2 behavior, cross-run isolation, or that a genuine cgroup leak was observed. The second ownership/residue slice remains separate.

All reviews on earlier heads are stale. A fresh independent review is required on the final head above.
