### PR TITLE
ci: bind S1b workdir cleanup to created object

### DIFF
--- a/scripts/ci/run-send-syscall-matrix.sh
+++ b/scripts/ci/run-send-syscall-matrix.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 # S1b driver: cgroup/PID isolate, start monitor, GO, assert effects + telemetry.
 set -euo pipefail
+S1B_OWNED_WORKDIR=
+S1B_OWNED_ID=
+S1B_OWNED_SAVED_PWD=
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MODE="${1:-}"
 ASSAY_BIN="${ASSAY_BIN:-$ROOT/target/release/assay}"
 ASSAY_EBPF="${ASSAY_EBPF:-$ROOT/target/assay-ebpf.o}"
 HARNESS_BIN="${HARNESS_BIN:-}"
-WORKDIR="${WORKDIR:-${RUNNER_TEMP:-/tmp}/s1b-send-matrix}"
+WORKDIR="${WORKDIR:-}"
 # Bound: C GO_FIFO_TIMEOUT_MS >= WAIT_LOG_MAX_BEFORE_GO * WAIT_LOG_ITERS * WAIT_LOG_SLEEP_S * 1000 + GO_TIMEOUT_MARGIN_MS
 WAIT_LOG_ITERS=60
 WAIT_LOG_SLEEP_S=0.5
@@ -101,28 +104,92 @@ reap_pid() {
   kill -0 "$pid" 2>/dev/null && fail "pid $pid still alive after SIGKILL bound; hang is not clean"
 }
 
-s1b_owned_workdir() {
-  local wd="$1"
-  [[ -n "$wd" && "$wd" == /* ]] || return 1
-  case "$wd" in
-    *'/../'*|*/..|..) return 1 ;;
+s1b_stat_id() {
+  local target="$1"
+  case "$(uname -s)" in
+    Linux) stat -c '%d:%i' "$target" ;;
+    *) stat -f '%d:%i' "$target" ;;
   esac
-  if [[ -n "${RUNNER_TEMP:-}" && "$wd" == "${RUNNER_TEMP}/s1b-"* ]]; then
-    return 0
+}
+
+s1b_release_owned_cwd() {
+  if [[ -n "${S1B_OWNED_SAVED_PWD:-}" && -d "$S1B_OWNED_SAVED_PWD" ]]; then
+    cd "$S1B_OWNED_SAVED_PWD" || cd /
+  else
+    cd / || true
   fi
-  [[ "$wd" == /tmp/s1b-* ]]
+}
+
+s1b_path_is_owned_object() {
+  local wd="$1" path_id
+  [[ -n "${S1B_OWNED_ID:-}" && -n "$wd" ]] || return 1
+  path_id=$(s1b_stat_id "$wd" 2>/dev/null) || return 1
+  [[ "$path_id" == "$S1B_OWNED_ID" ]]
+}
+
+s1b_owned_workdir() {
+  local wd="$1" cwd_id
+  [[ -n "$wd" && "$wd" == "${S1B_OWNED_WORKDIR:-}" && -n "${S1B_OWNED_ID:-}" ]] \
+    || return 1
+  cwd_id=$(s1b_stat_id . 2>/dev/null) || return 1
+  [[ "$cwd_id" == "$S1B_OWNED_ID" ]]
+}
+
+create_owned_workdir() {
+  local rt="${RUNNER_TEMP:-}" wd="${WORKDIR:-}" base parent
+  [[ -n "$rt" ]] || fail "RUNNER_TEMP required for S1b workdir ownership"
+  [[ "$rt" == /* && -d "$rt" ]] || fail "invalid RUNNER_TEMP=$rt"
+  case "$rt" in
+    *'/../'*|*/..|..) fail "refusing RUNNER_TEMP with traversal: $rt" ;;
+  esac
+  if [[ -z "$wd" ]]; then
+    wd=$(mktemp -d "$rt/s1b-${MODE:-run}-XXXXXX") || fail "mktemp owned WORKDIR"
+  else
+    [[ "$wd" == /* ]] || fail "refusing relative WORKDIR=$wd"
+    case "$wd" in
+      *'/../'*|*/..|..) fail "refusing WORKDIR with traversal: $wd" ;;
+    esac
+    base="${wd##*/}"
+    parent="${wd%/*}"
+    [[ "$base" == s1b-* && "$parent" == "$rt" ]] \
+      || fail "refusing WORKDIR outside RUNNER_TEMP namespace: $wd"
+    [[ ! -e "$wd" && ! -L "$wd" ]] || fail "refusing existing WORKDIR=$wd"
+    mkdir "$wd" || fail "mkdir WORKDIR=$wd"
+  fi
+  WORKDIR="$wd"
+  S1B_OWNED_WORKDIR="$wd"
+  S1B_OWNED_ID=$(s1b_stat_id "$wd") || fail "stat owned WORKDIR=$wd"
+  S1B_OWNED_SAVED_PWD=$PWD
+  cd "$wd" || fail "enter owned WORKDIR=$wd"
 }
 
 remove_owned_workdir() {
-  local wd="${1:-}"
-  [[ -n "$wd" && -d "$wd" ]] || return 0
-  s1b_owned_workdir "$wd" || fail "refusing to remove unowned WORKDIR=$wd"
-  rm -rf "$wd"
-  [[ ! -e "$wd" ]] || fail "WORKDIR leftover $wd"
+  local wd="${1:-}" contents_residue=0
+  [[ -n "$wd" ]] || return 0
+  [[ -n "${S1B_OWNED_WORKDIR:-}" ]] || return 0
+  if ! s1b_owned_workdir "$wd"; then
+    s1b_release_owned_cwd
+    printf 'S1B_WORKDIR_RESIDUE path=%s reason=lost_object\n' "$wd" >&2
+    return 1
+  fi
+  find . -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + || contents_residue=1
+  if find . -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+    contents_residue=1
+  fi
+  s1b_release_owned_cwd
+  if [[ "$contents_residue" -ne 0 ]]; then
+    printf 'S1B_WORKDIR_RESIDUE path=%s reason=contents\n' "$wd" >&2
+    return 1
+  fi
+  if ! s1b_path_is_owned_object "$wd"; then
+    printf 'S1B_WORKDIR_RESIDUE path=%s reason=path_rebound\n' "$wd" >&2
+    return 1
+  fi
+  printf 'S1B_WORKDIR_RETAINED path=%s\n' "$wd"
 }
 
 cleanup() {
-  local incoming_status="${1:-0}" leaf_residue=0 pid
+  local incoming_status="${1:-0}" leaf_residue=0 workdir_residue=0 pid
   for pid in "${MONITOR_PID:-}" "${HARNESS_PID:-}"; do
     reap_pid "$pid"
   done
@@ -133,9 +200,9 @@ cleanup() {
       leaf_residue=1
     fi
   fi
-  remove_owned_workdir "${WORKDIR:-}"
+  remove_owned_workdir "${WORKDIR:-}" || workdir_residue=1
   [[ "$incoming_status" -eq 0 ]] || return "$incoming_status"
-  [[ "$leaf_residue" -eq 0 ]]
+  [[ "$leaf_residue" -eq 0 && "$workdir_residue" -eq 0 ]]
 }
 
 cleanup_on_exit() {
@@ -241,7 +308,7 @@ isolate_pid() {
 
 run_matrix() {
   local expect_send="$1" n=0 hpid="" hc=0 mc=0 p2 p3
-  mkdir -p "$WORKDIR"
+  create_owned_workdir
   FIFO="$WORKDIR/go.fifo"
   LOG="$WORKDIR/monitor.log"
   HOUT="$WORKDIR/harness.out"
@@ -445,7 +512,10 @@ case "$MODE" in
       "$ASSAY_BIN" || fail "ASSAY_BIN is not the mutated rebuild (missing s1b-cell7-disabled)"
     run_matrix no ;;
   cleanup-selftest)
-    WORKDIR=$(mktemp -d /tmp/s1b-cleanup-selftest-XXXXXX)
+    selftest_rt=$(mktemp -d)
+    RUNNER_TEMP="$selftest_rt"
+    WORKDIR="$RUNNER_TEMP/s1b-cleanup-selftest-$$"
+    create_owned_workdir
     s1b_owned_workdir "$WORKDIR" || fail "cleanup-selftest WORKDIR is not an owned S1b path: $WORKDIR"
     FIFO=$WORKDIR/go.fifo
     mkfifo "$FIFO"
@@ -473,7 +543,11 @@ case "$MODE" in
     [[ ! -e "$fifo" ]] || fail "FIFO leftover $fifo"
     [[ ! -d "$leaf" ]] || fail "leaf leftover $leaf"
     wd=$WORKDIR
-    [[ ! -e "$wd" ]] || fail "WORKDIR leftover $wd"
+    [[ -d "$wd" ]] || fail "retained WORKDIR root missing $wd"
+    [[ -z "$(find "$wd" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
+      || fail "retained WORKDIR contents $wd"
+    rmdir "$wd" || fail "consume retained WORKDIR=$wd"
+    rmdir "$selftest_rt" || fail "consume cleanup selftest RUNNER_TEMP=$selftest_rt"
     bad=$(mktemp -d)
     printf 'keep\n' >"$bad/keep"
     if s1b_owned_workdir "$bad"; then
@@ -486,7 +560,7 @@ case "$MODE" in
     [[ "$rec" -ne 0 ]] || fail "remove_owned_workdir deleted unowned path $bad"
     [[ -f "$bad/keep" ]] || fail "unowned WORKDIR was deleted: $bad"
     rm -rf "$bad"
-    WORKDIR=""
+    WORKDIR="" S1B_OWNED_WORKDIR="" S1B_OWNED_ID="" S1B_OWNED_SAVED_PWD=""
     echo "ok: cleanup-selftest" ;;
   cleanup-leaf-status-selftest)
     [[ -n "${2:-}" && -d "$2" ]] || fail "cleanup leaf selftest requires an existing leaf directory"
@@ -495,9 +569,35 @@ case "$MODE" in
     [[ "${3:-}" =~ ^([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$ ]] \
       || fail "cleanup leaf selftest requires an exit status in 0..255"
     LEAF="$2"
-    WORKDIR=$(mktemp -d /tmp/s1b-leaf-status-XXXXXX)
+    WORKDIR=""
+    create_owned_workdir
     printf 'SELFTEST_WORKDIR=%s\n' "$WORKDIR"
     exit "$3" ;;
+  workdir-create-selftest)
+    create_owned_workdir
+    printf 'SELFTEST_WORKDIR=%s\n' "$WORKDIR"
+    printf 'owned\n' >"$WORKDIR/selftest-owned"
+    foreign="$RUNNER_TEMP/s1b-foreign-$$"
+    [[ ! -e "$foreign" ]] || fail "foreign selftest path exists: $foreign"
+    mkdir "$foreign"
+    printf 'keep\n' >"$foreign/keep"
+    if s1b_owned_workdir "$foreign"; then
+      fail "foreign S1b sibling considered owned: $foreign"
+    fi
+    printf 'SELFTEST_FOREIGN_WORKDIR=%s\n' "$foreign"
+    exit 0 ;;
+  workdir-rebind-selftest)
+    create_owned_workdir
+    owned=$WORKDIR
+    moved="${WORKDIR}-moved"
+    [[ ! -e "$moved" ]] || fail "rebind target exists: $moved"
+    printf 'owned\n' >"$WORKDIR/selftest-owned"
+    mv "$owned" "$moved"
+    mkdir "$owned"
+    printf 'foreign\n' >"$owned/foreign"
+    printf 'SELFTEST_WORKDIR=%s\n' "$owned"
+    printf 'SELFTEST_REBOUND_WORKDIR=%s\n' "$moved"
+    exit 0 ;;
   coverage-gate) coverage_gate "${2:?coverage-gate requires a JSON path}" ;;
   mutation-selftest) mutation_selftest ;;
   endpoint-line-selftest)
@@ -526,5 +626,5 @@ case "$MODE" in
     LOG="${2:?}"
     HOUT="${3:?}"
     fail "diagnostics-selftest" ;;
-  *) fail "usage: $0 positive|attach-disabled|disable-send-attach|cleanup-selftest|coverage-gate|mutation-selftest|endpoint-line-selftest|harness-ok-selftest|ringbuf-drop-selftest|send-observation-selftest|monitor-shutdown-selftest|diagnostics-selftest" ;;
+  *) fail "usage: $0 positive|attach-disabled|disable-send-attach|cleanup-selftest|cleanup-leaf-status-selftest|workdir-create-selftest|workdir-rebind-selftest|coverage-gate|mutation-selftest|endpoint-line-selftest|harness-ok-selftest|ringbuf-drop-selftest|send-observation-selftest|monitor-shutdown-selftest|diagnostics-selftest" ;;
 esac

--- a/scripts/ci/run-send-syscall-matrix.sh
+++ b/scripts/ci/run-send-syscall-matrix.sh
@@ -305,15 +305,18 @@ isolate_pid() {
   echo "$leaf"
 }
 
+prepare_matrix_artifacts() {
+  FIFO=go.fifo
+  LOG=monitor.log
+  HOUT=harness.out
+  OH=observation-health.json
+  mkfifo "$FIFO"
+}
+
 run_matrix() {
   local expect_send="$1" n=0 hpid="" hc=0 mc=0 p2 p3
   create_owned_workdir
-  FIFO="$WORKDIR/go.fifo"
-  LOG="$WORKDIR/monitor.log"
-  HOUT="$WORKDIR/harness.out"
-  OH="$WORKDIR/observation-health.json"
-  rm -f "$FIFO" "$LOG" "$HOUT" "$OH"
-  mkfifo "$FIFO"
+  prepare_matrix_artifacts
 
   echo "kernel=$(uname -r) host=$(uname -n) mode=$MODE"
   echo "object=$(sha256sum "$ASSAY_EBPF" | awk '{print $1}')"
@@ -600,6 +603,20 @@ case "$MODE" in
     printf 'SELFTEST_WORKDIR=%s\n' "$owned"
     printf 'SELFTEST_REBOUND_WORKDIR=%s\n' "$moved"
     exit 0 ;;
+  workdir-startup-rebind-selftest)
+    create_owned_workdir
+    owned=$WORKDIR
+    moved="${WORKDIR}-moved"
+    [[ ! -e "$moved" ]] || fail "startup rebind target exists: $moved"
+    mv "$owned" "$moved"
+    mkdir "$owned"
+    for artifact in go.fifo monitor.log harness.out observation-health.json; do
+      printf 'foreign:%s\n' "$artifact" >"$owned/$artifact"
+    done
+    prepare_matrix_artifacts
+    printf 'SELFTEST_WORKDIR=%s\n' "$owned"
+    printf 'SELFTEST_REBOUND_WORKDIR=%s\n' "$moved"
+    exit 0 ;;
   coverage-gate) coverage_gate "${2:?coverage-gate requires a JSON path}" ;;
   mutation-selftest) mutation_selftest ;;
   endpoint-line-selftest)
@@ -628,5 +645,5 @@ case "$MODE" in
     LOG="${2:?}"
     HOUT="${3:?}"
     fail "diagnostics-selftest" ;;
-  *) fail "usage: $0 positive|attach-disabled|disable-send-attach|cleanup-selftest|cleanup-leaf-status-selftest|workdir-create-selftest|workdir-rebind-selftest|coverage-gate|mutation-selftest|endpoint-line-selftest|harness-ok-selftest|ringbuf-drop-selftest|send-observation-selftest|monitor-shutdown-selftest|diagnostics-selftest" ;;
+  *) fail "usage: $0 positive|attach-disabled|disable-send-attach|cleanup-selftest|cleanup-leaf-status-selftest|workdir-create-selftest|workdir-rebind-selftest|workdir-startup-rebind-selftest|coverage-gate|mutation-selftest|endpoint-line-selftest|harness-ok-selftest|ringbuf-drop-selftest|send-observation-selftest|monitor-shutdown-selftest|diagnostics-selftest" ;;
 esac

--- a/scripts/ci/run-send-syscall-matrix.sh
+++ b/scripts/ci/run-send-syscall-matrix.sh
@@ -193,7 +193,6 @@ cleanup() {
   for pid in "${MONITOR_PID:-}" "${HARNESS_PID:-}"; do
     reap_pid "$pid"
   done
-  [[ -z "${FIFO:-}" ]] || rm -f "$FIFO"
   if [[ -n "${LEAF:-}" && -d "$LEAF" ]]; then
     if ! rmdir "$LEAF" 2>/dev/null; then
       printf 'S1B_LEAF_RESIDUE path=%s\n' "$LEAF" >&2
@@ -591,10 +590,13 @@ case "$MODE" in
     owned=$WORKDIR
     moved="${WORKDIR}-moved"
     [[ ! -e "$moved" ]] || fail "rebind target exists: $moved"
+    FIFO="$WORKDIR/go.fifo"
+    mkfifo "$FIFO"
     printf 'owned\n' >"$WORKDIR/selftest-owned"
     mv "$owned" "$moved"
     mkdir "$owned"
     printf 'foreign\n' >"$owned/foreign"
+    mkfifo "$owned/go.fifo"
     printf 'SELFTEST_WORKDIR=%s\n' "$owned"
     printf 'SELFTEST_REBOUND_WORKDIR=%s\n' "$moved"
     exit 0 ;;

--- a/scripts/ci/s1b-attach-disabled.sh
+++ b/scripts/ci/s1b-attach-disabled.sh
@@ -66,5 +66,5 @@ python3 -c 'import pathlib,sys; sys.exit(0 if b"s1b-cell7-disabled" in pathlib.P
   echo "FAIL: ASSAY_BIN is not the mutated rebuild (missing s1b-cell7-disabled)" >&2
   exit 1
 }
-sudo -E env HARNESS_BIN="$RUNNER_TEMP/s1b-harness" WORKDIR="$RUNNER_TEMP/s1b-disabled" \
+sudo -E env RUNNER_TEMP="$RUNNER_TEMP" HARNESS_BIN="$RUNNER_TEMP/s1b-harness" \
   bash scripts/ci/run-send-syscall-matrix.sh attach-disabled

--- a/scripts/ci/s1b-positive-matrix.sh
+++ b/scripts/ci/s1b-positive-matrix.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
 test -f target/assay-ebpf.o
-exec sudo -E env HARNESS_BIN="${RUNNER_TEMP:?}/s1b-harness" WORKDIR="${RUNNER_TEMP:?}/s1b-positive" bash scripts/ci/run-send-syscall-matrix.sh positive
+exec sudo -E env RUNNER_TEMP="${RUNNER_TEMP:?}" HARNESS_BIN="${RUNNER_TEMP:?}/s1b-harness" bash scripts/ci/run-send-syscall-matrix.sh positive

--- a/scripts/ci/test-s1b-coverage-gate.sh
+++ b/scripts/ci/test-s1b-coverage-gate.sh
@@ -862,6 +862,7 @@ rebind_residue_count=$(grep -cFx \
 [[ "$rebind_residue_count" -eq 1 ]] \
   || fail "workdir rebind emitted $rebind_residue_count named residue dispositions, expected 1"
 [[ -f "$rebind_owned/foreign" ]] || fail "rebound foreign replacement was modified or deleted"
+[[ -p "$rebind_owned/go.fifo" ]] || fail "rebound foreign FIFO was modified or deleted"
 [[ -d "$rebind_moved" ]] || fail "rebound owned object missing: $rebind_moved"
 [[ -z "$(find "$rebind_moved" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
   || fail "rebound owned object contents were not cleaned"

--- a/scripts/ci/test-s1b-coverage-gate.sh
+++ b/scripts/ci/test-s1b-coverage-gate.sh
@@ -803,8 +803,10 @@ created_workdir_count=$(grep -c '^SELFTEST_WORKDIR=' "$tmp/workdir-create.out" |
 created_workdir=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$tmp/workdir-create.out")
 [[ "$created_workdir" == "$ownership_rt"/s1b-workdir-create-* ]] \
   || fail "workdir create escaped RUNNER_TEMP: $created_workdir"
-grep -qxF "S1B_WORKDIR_RETAINED path=$created_workdir" "$tmp/workdir-create.out" \
-  || fail "workdir create missing retained-root disposition"
+retained_count=$(grep -cFx "S1B_WORKDIR_RETAINED path=$created_workdir" \
+  "$tmp/workdir-create.out" || true)
+[[ "$retained_count" -eq 1 ]] \
+  || fail "workdir create emitted $retained_count retained-root dispositions, expected 1"
 [[ -d "$created_workdir" ]] || fail "retained workdir root missing: $created_workdir"
 [[ -z "$(find "$created_workdir" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
   || fail "retained workdir root is not empty: $created_workdir"
@@ -854,9 +856,11 @@ rebind_moved_count=$(grep -c '^SELFTEST_REBOUND_WORKDIR=' "$tmp/workdir-rebind.o
   || fail "workdir rebind witness cardinality drifted"
 rebind_owned=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$tmp/workdir-rebind.out")
 rebind_moved=$(sed -n 's/^SELFTEST_REBOUND_WORKDIR=//p' "$tmp/workdir-rebind.out")
-grep -qxF "S1B_WORKDIR_RESIDUE path=$rebind_owned reason=path_rebound" \
-  "$tmp/workdir-rebind.err" \
-  || fail "workdir rebind missing named residue disposition"
+rebind_residue_count=$(grep -cFx \
+  "S1B_WORKDIR_RESIDUE path=$rebind_owned reason=path_rebound" \
+  "$tmp/workdir-rebind.err" || true)
+[[ "$rebind_residue_count" -eq 1 ]] \
+  || fail "workdir rebind emitted $rebind_residue_count named residue dispositions, expected 1"
 [[ -f "$rebind_owned/foreign" ]] || fail "rebound foreign replacement was modified or deleted"
 [[ -d "$rebind_moved" ]] || fail "rebound owned object missing: $rebind_moved"
 [[ -z "$(find "$rebind_moved" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
@@ -989,6 +993,71 @@ set -e
 grep -qxF 'FAIL: pathname cleanup deleted the foreign replacement' \
   "$tmp/mut-pathname-contract.err" \
   || fail "pathname cleanup mutant failed for an unrelated reason"
+
+duplicate_retained_driver="$tmp/duplicate-retained-driver.sh"
+cp "$DRIVER" "$duplicate_retained_driver"
+python3 - "$duplicate_retained_driver" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = '''  printf 'S1B_WORKDIR_RETAINED path=%s\\n' "$wd"'''
+new = old + "\n" + old
+if text.count(old) != 1:
+    raise SystemExit("retained disposition mutation target must occur exactly once")
+path.write_text(text.replace(old, new), encoding="utf-8")
+PY
+set +e
+(
+  RUNNER_TEMP="$ownership_rt" run_bounded 12 bash "$duplicate_retained_driver" \
+    workdir-create-selftest >"$tmp/mut-retained.out" 2>"$tmp/mut-retained.err"
+  workdir=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$tmp/mut-retained.out")
+  count=$(grep -cFx "S1B_WORKDIR_RETAINED path=$workdir" "$tmp/mut-retained.out" || true)
+  [[ "$count" -eq 1 ]] \
+    || fail "workdir create emitted $count retained-root dispositions, expected 1"
+) >"$tmp/mut-retained-contract.out" 2>"$tmp/mut-retained-contract.err"
+mut_retained_contract_ec=$?
+set -e
+[[ "$mut_retained_contract_ec" -ne 0 ]] || fail "duplicate retained disposition mutant survived"
+grep -qxF 'FAIL: workdir create emitted 2 retained-root dispositions, expected 1' \
+  "$tmp/mut-retained-contract.err" \
+  || fail "duplicate retained disposition mutant failed for an unrelated reason"
+
+duplicate_residue_driver="$tmp/duplicate-residue-driver.sh"
+cp "$DRIVER" "$duplicate_residue_driver"
+python3 - "$duplicate_residue_driver" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = '''    printf 'S1B_WORKDIR_RESIDUE path=%s reason=path_rebound\\n' "$wd" >&2'''
+new = old + "\n" + old
+if text.count(old) != 1:
+    raise SystemExit("residue disposition mutation target must occur exactly once")
+path.write_text(text.replace(old, new), encoding="utf-8")
+PY
+set +e
+(
+  set +e
+  RUNNER_TEMP="$ownership_rt" run_bounded 12 bash "$duplicate_residue_driver" \
+    workdir-rebind-selftest >"$tmp/mut-residue.out" 2>"$tmp/mut-residue.err"
+  actual=$?
+  set -e
+  [[ "$actual" -eq 1 ]] || fail "workdir rebind returned $actual, expected 1"
+  workdir=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$tmp/mut-residue.out")
+  count=$(grep -cFx "S1B_WORKDIR_RESIDUE path=$workdir reason=path_rebound" \
+    "$tmp/mut-residue.err" || true)
+  [[ "$count" -eq 1 ]] \
+    || fail "workdir rebind emitted $count named residue dispositions, expected 1"
+) >"$tmp/mut-residue-contract.out" 2>"$tmp/mut-residue-contract.err"
+mut_residue_contract_ec=$?
+set -e
+[[ "$mut_residue_contract_ec" -ne 0 ]] || fail "duplicate residue disposition mutant survived"
+grep -qxF 'FAIL: workdir rebind emitted 2 named residue dispositions, expected 1' \
+  "$tmp/mut-residue-contract.err" \
+  || fail "duplicate residue disposition mutant failed for an unrelated reason"
 
 ownership_noop_driver="$tmp/ownership-noop-driver.sh"
 cp "$DRIVER" "$ownership_noop_driver"

--- a/scripts/ci/test-s1b-coverage-gate.sh
+++ b/scripts/ci/test-s1b-coverage-gate.sh
@@ -291,7 +291,7 @@ run_matrix_active=$(fn_active run_matrix)
 want_run_matrix=$(cat <<'EOF'
 run_matrix() {
 local expect_send="$1" n=0 hpid="" hc=0 mc=0 p2 p3
-mkdir -p "$WORKDIR"
+create_owned_workdir
 FIFO="$WORKDIR/go.fifo"
 LOG="$WORKDIR/monitor.log"
 HOUT="$WORKDIR/harness.out"
@@ -649,7 +649,8 @@ run_leaf_residue_case() {
   mkdir "$leaf"
   printf 'busy\n' >"$leaf/member"
   set +e
-  run_bounded 12 bash "$driver" cleanup-leaf-status-selftest "$leaf" "$incoming" >"$out" 2>"$err"
+  RUNNER_TEMP="$tmp" run_bounded 12 bash "$driver" cleanup-leaf-status-selftest \
+    "$leaf" "$incoming" >"$out" 2>"$err"
   actual=$?
   set -e
   [[ "$actual" -eq "$expected" ]] \
@@ -661,7 +662,12 @@ run_leaf_residue_case() {
   [[ "$workdir_count" -eq 1 ]] \
     || fail "leaf residue incoming=$incoming emitted $workdir_count selftest workdir markers, expected 1"
   workdir=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$out")
-  [[ ! -e "$workdir" ]] || fail "leaf residue incoming=$incoming skipped workdir cleanup: $workdir"
+  grep -qxF "S1B_WORKDIR_RETAINED path=$workdir" "$out" \
+    || fail "leaf residue incoming=$incoming missing retained workdir disposition"
+  [[ -d "$workdir" ]] || fail "leaf residue incoming=$incoming retained root missing: $workdir"
+  [[ -z "$(find "$workdir" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
+    || fail "leaf residue incoming=$incoming skipped workdir contents cleanup: $workdir"
+  rmdir "$workdir" || fail "leaf residue incoming=$incoming could not consume retained root: $workdir"
   [[ -f "$leaf/member" ]] || fail "leaf residue fixture unexpectedly disappeared: $leaf"
 }
 
@@ -718,8 +724,16 @@ import sys
 
 path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
-old = '''    printf 'SELFTEST_WORKDIR=%s\\n' "$WORKDIR"'''
-new = old + "\n" + old
+old = '''    LEAF="$2"
+    WORKDIR=""
+    create_owned_workdir
+    printf 'SELFTEST_WORKDIR=%s\\n' "$WORKDIR"
+    exit "$3" ;;'''
+new = old.replace(
+    '''    printf 'SELFTEST_WORKDIR=%s\\n' "$WORKDIR"''',
+    '''    printf 'SELFTEST_WORKDIR=%s\\n' "$WORKDIR"
+    printf 'SELFTEST_WORKDIR=%s\\n' "$WORKDIR"''',
+)
 if text.count(old) != 1:
     raise SystemExit("duplicate workdir mutation target must occur exactly once")
 path.write_text(text.replace(old, new), encoding="utf-8")
@@ -765,8 +779,229 @@ grep -qxF 'FAIL: leaf residue incoming=0 returned 0, expected 1' "$tmp/silent-co
   || fail "silent leaf cleanup mutation unexpectedly emitted a diagnostic"
 silent_workdir=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$tmp/leaf-silent-0.out")
 [[ -n "$silent_workdir" ]] || fail "silent leaf cleanup mutation did not execute the selftest"
-[[ ! -e "$silent_workdir" ]] || fail "silent leaf cleanup mutation skipped workdir cleanup"
+grep -qxF "S1B_WORKDIR_RETAINED path=$silent_workdir" "$tmp/leaf-silent-0.out" \
+  || fail "silent leaf cleanup mutation missed retained workdir disposition"
+[[ -d "$silent_workdir" ]] || fail "silent leaf cleanup mutation lost retained workdir root"
+[[ -z "$(find "$silent_workdir" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
+  || fail "silent leaf cleanup mutation skipped workdir contents cleanup"
+rmdir "$silent_workdir" || fail "silent leaf cleanup mutation retained root could not be consumed"
 [[ -f "$tmp/leaf-silent-0/member" ]] || fail "silent leaf cleanup mutation removed the residue fixture"
+
+ownership_rt="$tmp/runner-temp"
+mkdir "$ownership_rt"
+
+set +e
+RUNNER_TEMP="$ownership_rt" run_bounded 12 bash "$DRIVER" workdir-create-selftest \
+  >"$tmp/workdir-create.out" 2>"$tmp/workdir-create.err"
+workdir_create_ec=$?
+set -e
+[[ "$workdir_create_ec" -eq 0 ]] \
+  || fail "workdir create selftest returned $workdir_create_ec: $(cat "$tmp/workdir-create.err")"
+created_workdir_count=$(grep -c '^SELFTEST_WORKDIR=' "$tmp/workdir-create.out" || true)
+[[ "$created_workdir_count" -eq 1 ]] \
+  || fail "workdir create emitted $created_workdir_count workdir witnesses, expected 1"
+created_workdir=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$tmp/workdir-create.out")
+[[ "$created_workdir" == "$ownership_rt"/s1b-workdir-create-* ]] \
+  || fail "workdir create escaped RUNNER_TEMP: $created_workdir"
+grep -qxF "S1B_WORKDIR_RETAINED path=$created_workdir" "$tmp/workdir-create.out" \
+  || fail "workdir create missing retained-root disposition"
+[[ -d "$created_workdir" ]] || fail "retained workdir root missing: $created_workdir"
+[[ -z "$(find "$created_workdir" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
+  || fail "retained workdir root is not empty: $created_workdir"
+foreign_workdir_count=$(grep -c '^SELFTEST_FOREIGN_WORKDIR=' "$tmp/workdir-create.out" || true)
+[[ "$foreign_workdir_count" -eq 1 ]] \
+  || fail "workdir create emitted $foreign_workdir_count foreign witnesses, expected 1"
+foreign_workdir=$(sed -n 's/^SELFTEST_FOREIGN_WORKDIR=//p' "$tmp/workdir-create.out")
+[[ "$foreign_workdir" == "$ownership_rt"/s1b-foreign-* ]] \
+  || fail "foreign workdir witness escaped RUNNER_TEMP: $foreign_workdir"
+[[ -f "$foreign_workdir/keep" ]] || fail "foreign S1b sibling was modified or deleted"
+
+collision="$ownership_rt/s1b-foreign"
+mkdir "$collision"
+printf 'keep\n' >"$collision/keep"
+set +e
+RUNNER_TEMP="$ownership_rt" WORKDIR="$collision" \
+  run_bounded 12 bash "$DRIVER" workdir-create-selftest \
+  >"$tmp/workdir-collision.out" 2>"$tmp/workdir-collision.err"
+collision_ec=$?
+set -e
+[[ "$collision_ec" -ne 0 ]] || fail "pre-existing S1b path was accepted as owned"
+grep -qxF "FAIL: refusing existing WORKDIR=$collision" "$tmp/workdir-collision.err" \
+  || fail "existing collision refusal missing exact diagnostic"
+[[ -f "$collision/keep" ]] || fail "pre-existing S1b collision was modified or deleted"
+
+stripped="$ownership_rt/s1b-stripped"
+set +e
+run_bounded 12 env -u RUNNER_TEMP WORKDIR="$stripped" \
+  bash "$DRIVER" workdir-create-selftest \
+  >"$tmp/workdir-stripped.out" 2>"$tmp/workdir-stripped.err"
+stripped_ec=$?
+set -e
+[[ "$stripped_ec" -ne 0 ]] || fail "workdir creation accepted stripped RUNNER_TEMP"
+grep -qxF 'FAIL: RUNNER_TEMP required for S1b workdir ownership' "$tmp/workdir-stripped.err" \
+  || fail "stripped RUNNER_TEMP refusal missing exact diagnostic"
+[[ ! -e "$stripped" ]] || fail "stripped RUNNER_TEMP path was created: $stripped"
+
+set +e
+RUNNER_TEMP="$ownership_rt" run_bounded 12 bash "$DRIVER" workdir-rebind-selftest \
+  >"$tmp/workdir-rebind.out" 2>"$tmp/workdir-rebind.err"
+rebind_ec=$?
+set -e
+[[ "$rebind_ec" -eq 1 ]] || fail "workdir rebind returned $rebind_ec, expected 1"
+rebind_owned_count=$(grep -c '^SELFTEST_WORKDIR=' "$tmp/workdir-rebind.out" || true)
+rebind_moved_count=$(grep -c '^SELFTEST_REBOUND_WORKDIR=' "$tmp/workdir-rebind.out" || true)
+[[ "$rebind_owned_count" -eq 1 && "$rebind_moved_count" -eq 1 ]] \
+  || fail "workdir rebind witness cardinality drifted"
+rebind_owned=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$tmp/workdir-rebind.out")
+rebind_moved=$(sed -n 's/^SELFTEST_REBOUND_WORKDIR=//p' "$tmp/workdir-rebind.out")
+grep -qxF "S1B_WORKDIR_RESIDUE path=$rebind_owned reason=path_rebound" \
+  "$tmp/workdir-rebind.err" \
+  || fail "workdir rebind missing named residue disposition"
+[[ -f "$rebind_owned/foreign" ]] || fail "rebound foreign replacement was modified or deleted"
+[[ -d "$rebind_moved" ]] || fail "rebound owned object missing: $rebind_moved"
+[[ -z "$(find "$rebind_moved" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
+  || fail "rebound owned object contents were not cleaned"
+
+prefix_owner_driver="$tmp/prefix-owner-driver.sh"
+cp "$DRIVER" "$prefix_owner_driver"
+python3 - "$prefix_owner_driver" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = '"$wd" == "${S1B_OWNED_WORKDIR:-}"'
+new = '"$wd" == "${RUNNER_TEMP}/s1b-"*'
+if text.count(old) != 1:
+    raise SystemExit("prefix ownership mutation target must occur exactly once")
+path.write_text(text.replace(old, new), encoding="utf-8")
+PY
+set +e
+RUNNER_TEMP="$ownership_rt" run_bounded 12 bash "$prefix_owner_driver" \
+  workdir-create-selftest >"$tmp/prefix-owner.out" 2>"$tmp/prefix-owner.err"
+prefix_owner_ec=$?
+set -e
+[[ "$prefix_owner_ec" -ne 0 ]] || fail "prefix ownership mutant survived"
+grep -Eq '^FAIL: foreign S1b sibling considered owned: ' "$tmp/prefix-owner.err" \
+  || fail "prefix ownership mutant failed for an unrelated reason"
+
+collision_owner_driver="$tmp/collision-owner-driver.sh"
+cp "$DRIVER" "$collision_owner_driver"
+python3 - "$collision_owner_driver" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = '''    [[ ! -e "$wd" && ! -L "$wd" ]] || fail "refusing existing WORKDIR=$wd"
+    mkdir "$wd" || fail "mkdir WORKDIR=$wd"'''
+new = '''    mkdir -p "$wd" || fail "mkdir WORKDIR=$wd"'''
+if text.count(old) != 1:
+    raise SystemExit("collision ownership mutation target must occur exactly once")
+path.write_text(text.replace(old, new), encoding="utf-8")
+PY
+mut_collision="$ownership_rt/s1b-mut-collision"
+mkdir "$mut_collision"
+printf 'keep\n' >"$mut_collision/keep"
+set +e
+(
+  set +e
+  RUNNER_TEMP="$ownership_rt" WORKDIR="$mut_collision" \
+    run_bounded 12 bash "$collision_owner_driver" workdir-create-selftest \
+    >"$tmp/mut-collision.out" 2>"$tmp/mut-collision.err"
+  actual=$?
+  set -e
+  [[ "$actual" -ne 0 ]] || fail "pre-existing S1b path was accepted as owned"
+  grep -qxF "FAIL: refusing existing WORKDIR=$mut_collision" "$tmp/mut-collision.err" \
+    || fail "existing collision refusal missing exact diagnostic"
+  [[ -f "$mut_collision/keep" ]] || fail "pre-existing S1b collision was modified or deleted"
+) >"$tmp/mut-collision-contract.out" 2>"$tmp/mut-collision-contract.err"
+mut_collision_contract_ec=$?
+set -e
+[[ "$mut_collision_contract_ec" -ne 0 ]] || fail "collision ownership mutant satisfied the contract"
+grep -qxF 'FAIL: pre-existing S1b path was accepted as owned' \
+  "$tmp/mut-collision-contract.err" \
+  || fail "collision ownership mutant failed for an unrelated reason"
+
+rebind_guard_driver="$tmp/rebind-guard-driver.sh"
+cp "$DRIVER" "$rebind_guard_driver"
+python3 - "$rebind_guard_driver" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = '''  if ! s1b_path_is_owned_object "$wd"; then
+    printf 'S1B_WORKDIR_RESIDUE path=%s reason=path_rebound\\n' "$wd" >&2
+    return 1
+  fi'''
+new = '''  if false; then
+    printf 'S1B_WORKDIR_RESIDUE path=%s reason=path_rebound\\n' "$wd" >&2
+    return 1
+  fi'''
+if text.count(old) != 1:
+    raise SystemExit("rebind guard mutation target must occur exactly once")
+path.write_text(text.replace(old, new), encoding="utf-8")
+PY
+set +e
+(
+  set +e
+  RUNNER_TEMP="$ownership_rt" run_bounded 12 bash "$rebind_guard_driver" \
+    workdir-rebind-selftest >"$tmp/mut-rebind.out" 2>"$tmp/mut-rebind.err"
+  actual=$?
+  set -e
+  [[ "$actual" -eq 1 ]] || fail "workdir rebind returned $actual, expected 1"
+) >"$tmp/mut-rebind-contract.out" 2>"$tmp/mut-rebind-contract.err"
+mut_rebind_contract_ec=$?
+set -e
+[[ "$mut_rebind_contract_ec" -ne 0 ]] || fail "rebind guard mutant satisfied the contract"
+grep -qxF 'FAIL: workdir rebind returned 0, expected 1' "$tmp/mut-rebind-contract.err" \
+  || fail "rebind guard mutant failed for an unrelated reason"
+
+pathname_cleanup_driver="$tmp/pathname-cleanup-driver.sh"
+cp "$DRIVER" "$pathname_cleanup_driver"
+python3 - "$pathname_cleanup_driver" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = '''  find . -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + || contents_residue=1'''
+new = '''  rm -rf "$wd" || contents_residue=1'''
+if text.count(old) != 1:
+    raise SystemExit("pathname cleanup mutation target must occur exactly once")
+path.write_text(text.replace(old, new), encoding="utf-8")
+PY
+set +e
+(
+  set +e
+  RUNNER_TEMP="$ownership_rt" run_bounded 12 bash "$pathname_cleanup_driver" \
+    workdir-rebind-selftest >"$tmp/mut-pathname.out" 2>"$tmp/mut-pathname.err"
+  actual=$?
+  set -e
+  [[ "$actual" -eq 1 ]] || fail "pathname cleanup rebind returned $actual, expected 1"
+  rebound=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$tmp/mut-pathname.out")
+  [[ -f "$rebound/foreign" ]] || fail "pathname cleanup deleted the foreign replacement"
+) >"$tmp/mut-pathname-contract.out" 2>"$tmp/mut-pathname-contract.err"
+mut_pathname_contract_ec=$?
+set -e
+[[ "$mut_pathname_contract_ec" -ne 0 ]] || fail "pathname cleanup mutant satisfied the contract"
+grep -qxF 'FAIL: pathname cleanup deleted the foreign replacement' \
+  "$tmp/mut-pathname-contract.err" \
+  || fail "pathname cleanup mutant failed for an unrelated reason"
+
+ownership_noop_driver="$tmp/ownership-noop-driver.sh"
+cp "$DRIVER" "$ownership_noop_driver"
+printf '\n# comment-only ownership control\n' >>"$ownership_noop_driver"
+RUNNER_TEMP="$ownership_rt" run_bounded 12 bash "$ownership_noop_driver" \
+  workdir-create-selftest >"$tmp/ownership-noop.out" 2>"$tmp/ownership-noop.err" \
+  || fail "comment-only ownership control went red: $(cat "$tmp/ownership-noop.err")"
+grep -q '^S1B_WORKDIR_RETAINED path=' "$tmp/ownership-noop.out" \
+  || fail "comment-only ownership control missed retained-root disposition"
+
+if grep -Fq 'S1B_EMPTY_SWAP' "$DRIVER"; then
+  fail "production driver contains the parked environment-controlled empty-swap seam"
+fi
 echo "ok: mutation-selftest and cleanup-selftest"
 
 wf="$(cd "$(dirname "$0")/../.." && pwd)/.github/workflows/monitor-attach-smoke.yml"
@@ -870,7 +1105,7 @@ want_pos=$(printf '%s\n' \
   'ROOT="$(cd "$(dirname "$0")/../.." && pwd)"' \
   'cd "$ROOT"' \
   'test -f target/assay-ebpf.o' \
-  'exec sudo -E env HARNESS_BIN="${RUNNER_TEMP:?}/s1b-harness" WORKDIR="${RUNNER_TEMP:?}/s1b-positive" bash scripts/ci/run-send-syscall-matrix.sh positive')
+  'exec sudo -E env RUNNER_TEMP="${RUNNER_TEMP:?}" HARNESS_BIN="${RUNNER_TEMP:?}/s1b-harness" bash scripts/ci/run-send-syscall-matrix.sh positive')
 [[ "$pos_active" == "$want_pos" ]] \
   || fail "positive wrapper active lines must match the closed six-line shape ending in exec"
 COMPILE="$(cd "$(dirname "$0")" && pwd)/s1b-compile-and-contract.sh"
@@ -1181,7 +1416,7 @@ python3 -c 'import pathlib,sys; sys.exit(0 if b"s1b-cell7-disabled" in pathlib.P
 echo "FAIL: ASSAY_BIN is not the mutated rebuild (missing s1b-cell7-disabled)" >&2
 exit 1
 }
-sudo -E env HARNESS_BIN="$RUNNER_TEMP/s1b-harness" WORKDIR="$RUNNER_TEMP/s1b-disabled" \
+sudo -E env RUNNER_TEMP="$RUNNER_TEMP" HARNESS_BIN="$RUNNER_TEMP/s1b-harness" \
 bash scripts/ci/run-send-syscall-matrix.sh attach-disabled
 EOF
 )

--- a/scripts/ci/test-s1b-coverage-gate.sh
+++ b/scripts/ci/test-s1b-coverage-gate.sh
@@ -292,12 +292,7 @@ want_run_matrix=$(cat <<'EOF'
 run_matrix() {
 local expect_send="$1" n=0 hpid="" hc=0 mc=0 p2 p3
 create_owned_workdir
-FIFO="$WORKDIR/go.fifo"
-LOG="$WORKDIR/monitor.log"
-HOUT="$WORKDIR/harness.out"
-OH="$WORKDIR/observation-health.json"
-rm -f "$FIFO" "$LOG" "$HOUT" "$OH"
-mkfifo "$FIFO"
+prepare_matrix_artifacts
 echo "kernel=$(uname -r) host=$(uname -n) mode=$MODE"
 echo "object=$(sha256sum "$ASSAY_EBPF" | awk '{print $1}')"
 "$HARNESS_BIN" "$FIFO" >"$HOUT" 2>&1 &
@@ -343,6 +338,19 @@ EOF
 )
 [[ "$run_matrix_active" == "$want_run_matrix" ]] \
   || fail "run_matrix active body must be the closed startup-then-assert shape"
+prepare_matrix_active=$(fn_active prepare_matrix_artifacts)
+want_prepare_matrix=$(cat <<'EOF'
+prepare_matrix_artifacts() {
+FIFO=go.fifo
+LOG=monitor.log
+HOUT=harness.out
+OH=observation-health.json
+mkfifo "$FIFO"
+}
+EOF
+)
+[[ "$prepare_matrix_active" == "$want_prepare_matrix" ]] \
+  || fail "prepare_matrix_artifacts active body must match the closed artifact setup"
 wait_ep_block=$(printf '%s\n' \
   'wait_endpoint "$hpid" sendto "127.0.0.1" "$p2"' \
   'wait_endpoint "$hpid" sendmsg "127.0.0.1" "$p3"')
@@ -866,6 +874,30 @@ rebind_residue_count=$(grep -cFx \
 [[ -d "$rebind_moved" ]] || fail "rebound owned object missing: $rebind_moved"
 [[ -z "$(find "$rebind_moved" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
   || fail "rebound owned object contents were not cleaned"
+
+set +e
+RUNNER_TEMP="$ownership_rt" run_bounded 12 bash "$DRIVER" workdir-startup-rebind-selftest \
+  >"$tmp/workdir-startup-rebind.out" 2>"$tmp/workdir-startup-rebind.err"
+startup_rebind_ec=$?
+set -e
+[[ "$startup_rebind_ec" -eq 1 ]] \
+  || fail "workdir startup rebind returned $startup_rebind_ec, expected 1"
+startup_owned=$(sed -n 's/^SELFTEST_WORKDIR=//p' "$tmp/workdir-startup-rebind.out")
+startup_moved=$(sed -n 's/^SELFTEST_REBOUND_WORKDIR=//p' "$tmp/workdir-startup-rebind.out")
+startup_residue_count=$(grep -cFx \
+  "S1B_WORKDIR_RESIDUE path=$startup_owned reason=path_rebound" \
+  "$tmp/workdir-startup-rebind.err" || true)
+[[ "$startup_residue_count" -eq 1 ]] \
+  || fail "workdir startup rebind emitted $startup_residue_count named residue dispositions, expected 1"
+for artifact in go.fifo monitor.log harness.out observation-health.json; do
+  [[ -f "$startup_owned/$artifact" ]] \
+    || fail "startup cleanup deleted rebound foreign artifact: $artifact"
+  grep -qxF "foreign:$artifact" "$startup_owned/$artifact" \
+    || fail "startup cleanup replaced rebound foreign artifact: $artifact"
+done
+[[ -d "$startup_moved" ]] || fail "startup rebound owned object missing: $startup_moved"
+[[ -z "$(find "$startup_moved" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
+  || fail "startup rebound owned object contents were not cleaned"
 
 prefix_owner_driver="$tmp/prefix-owner-driver.sh"
 cp "$DRIVER" "$prefix_owner_driver"


### PR DESCRIPTION
Closes #2349.

## What changed

- require an existing absolute `RUNNER_TEMP` for live S1b workdirs;
- atomically create one per-run directory and bind ownership to its exact path plus device/inode;
- clean contents through the anchored owned cwd instead of `rm -rf "$WORKDIR"`;
- retain an empty owned root with `S1B_WORKDIR_RETAINED`, while lost identity, incomplete cleanup, or pathname rebind emits `S1B_WORKDIR_RESIDUE` and fails an otherwise clean run;
- pass `RUNNER_TEMP` explicitly through both live `sudo -E env` wrappers.

## Behavioral proof

RED before production changes:

```text
FAIL: workdir create selftest returned 1: FAIL: usage: ...
FAIL: workdir create emitted 0 foreign witnesses, expected 1
FAIL: duplicate retained disposition mutant survived
FAIL: rebound foreign FIFO was modified or deleted
FAIL: startup cleanup deleted rebound foreign artifact: go.fifo
```

GREEN on `4945625bec5776a66c8a9fbcb2818db0e5fafc2b`:

- `bash scripts/ci/test-s1b-coverage-gate.sh`
- all applicable pre-commit hooks, including shellcheck and `cargo fmt --check`
- pre-push workspace clippy and Linux cross-target compile gate
- `/bin/bash -n` on the driver and live wrappers
- `git diff --check`

The contract kills prefix ownership, pre-existing-directory adoption, dropped rebind detection, and pathname cleanup. A comment-only control remains green. It also rejects stripped `RUNNER_TEMP` and any production `S1B_EMPTY_SWAP` seam.

## Non-claims

- No live cgroup-v2, sudo-policy, or cross-run collision was reproduced by this PR.
- Empty-root retention is an explicit shell-safety disposition, not persistent-runner isolation.
- This does not change Assay product behavior or the syscall/effect claims established by #2345.
- Hosted gates and independent exact-head review are still pending.




