### PR TITLE
ci: close direct actions/attest lockstep false-greens (#2474)

### DIFF
--- a/.github/workflows/privileged-mcp-action-pack-release.yml
+++ b/.github/workflows/privileged-mcp-action-pack-release.yml
@@ -65,10 +65,13 @@ jobs:
             --source-commit "$source_commit" \
             --output /tmp/pack-second.tar.gz
           cmp release/privileged-mcp-action-v0-clean-room.tar.gz /tmp/pack-second.tar.gz
-          (
-            cd release
-            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS
-          )
+
+      - name: Build release checksums
+        id: build-release-checksums
+        working-directory: release
+        run: |
+          set -euo pipefail
+          sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS
 
       - name: Run pack contract tests
         run: |
@@ -127,6 +130,7 @@ jobs:
           show-summary: true
 
       - name: Retain attestation bundle
+        id: retain-release-attestation
         env:
           ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
         run: |

--- a/.github/workflows/privileged-mcp-action-pack-release.yml
+++ b/.github/workflows/privileged-mcp-action-pack-release.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Build release checksums
         id: build-release-checksums
+        shell: bash
         working-directory: release
         run: |
           set -euo pipefail
@@ -131,6 +132,7 @@ jobs:
 
       - name: Retain attestation bundle
         id: retain-release-attestation
+        shell: bash
         env:
           ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
         run: |

--- a/.github/workflows/privileged-mcp-action-pack-release.yml
+++ b/.github/workflows/privileged-mcp-action-pack-release.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Attest release pack
         id: attest
-        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-checksums: release/SHA256SUMS
           show-summary: true

--- a/.github/workflows/privileged-mcp-action-pack-release.yml
+++ b/.github/workflows/privileged-mcp-action-pack-release.yml
@@ -133,6 +133,7 @@ jobs:
       - name: Retain attestation bundle
         id: retain-release-attestation
         shell: bash
+        working-directory: ${{ github.workspace }}
         env:
           ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
         run: |

--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -311,6 +311,7 @@ jobs:
         id: retain-proof-attestation
         if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
         shell: bash
+        working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
           cp "${{ steps.attest-proof-pack.outputs.bundle-path }}" \

--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -298,7 +298,7 @@ jobs:
       - name: Attest delegated proof pack subjects
         id: attest-proof-pack
         if: always() && hashFiles('assay-runner-proof-upload/subject-checksums.txt') != ''
-        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-checksums: assay-runner-proof-upload/subject-checksums.txt
           show-summary: true

--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -267,26 +267,30 @@ jobs:
             "$PWD/scripts/ci/runner-spike-gemini-google-genai-three-run-determinism.sh"
 
       - name: Build delegated proof pack
+        id: build-proof-pack
         if: always()
         shell: bash
         run: |
           set -euo pipefail
-          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          workflow_sha="${GITHUB_WORKFLOW_SHA:-$GITHUB_SHA}"
           python3 scripts/ci/assay_runner_delegated_proof_pack.py \
             --proof-root "$ASSAY_RUNNER_DELEGATED_PROOF_ROOT" \
             --gates "${{ inputs.gates }}" \
             --build-ebpf "${{ inputs.build_ebpf }}" \
             --run-id "$GITHUB_RUN_ID" \
             --run-attempt "$GITHUB_RUN_ATTEMPT" \
-            --run-url "$run_url" \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             --ref "$GITHUB_REF" \
             --head-sha "$GITHUB_SHA" \
-            --workflow-sha "$workflow_sha" \
+            --workflow-sha "${GITHUB_WORKFLOW_SHA:-$GITHUB_SHA}" \
             --workflow-name "$GITHUB_WORKFLOW" \
             --workflow-path ".github/workflows/runner-spike-delegated.yml" \
             --repository "$GITHUB_REPOSITORY" \
             --retention-days 365
+
+      - name: Summarize delegated proof pack
+        if: always() && steps.build-proof-pack.outcome == 'success'
+        shell: bash
+        run: |
           {
             echo "### Delegated proof pack"
             echo "- artifact: assay-runner-delegated-proof-pack-${GITHUB_RUN_ID}"
@@ -304,12 +308,18 @@ jobs:
           show-summary: true
 
       - name: Retain delegated proof attestation bundle
+        id: retain-proof-attestation
         if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
         shell: bash
         run: |
           set -euo pipefail
           cp "${{ steps.attest-proof-pack.outputs.bundle-path }}" \
             "$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD/attestation-bundle.json"
+
+      - name: Summarize delegated proof attestation
+        if: always() && steps.retain-proof-attestation.outcome == 'success'
+        shell: bash
+        run: |
           {
             echo "- attestation-bundle: assay-runner-proof-upload/attestation-bundle.json"
             echo "- attestation-url: ${{ steps.attest-proof-pack.outputs.attestation-url }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -422,6 +422,13 @@ repos:
         pass_filenames: false
         files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(check-codeql-upload-sarif-lockstep\.py|test-codeql-upload-sarif-lockstep\.sh)|\.pre-commit-config\.yaml)$
 
+      - id: actions-attest-lockstep
+        name: Direct actions/attest producer lockstep
+        entry: bash scripts/ci/test-actions-attest-lockstep.sh
+        language: system
+        pass_filenames: false
+        files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$
+
       - id: crosswalk-generator-contract
         name: Configuration crosswalk generator contract
         entry: bash scripts/ci/test-crosswalk-generator.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -427,7 +427,7 @@ repos:
         entry: bash scripts/ci/test-actions-attest-lockstep.sh
         language: system
         pass_filenames: false
-        files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$
+        files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(assay_runner_delegated_proof_pack\.py|check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$
 
       - id: crosswalk-generator-contract
         name: Configuration crosswalk generator contract

--- a/scripts/ci/check-actions-attest-lockstep.py
+++ b/scripts/ci/check-actions-attest-lockstep.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -19,7 +20,14 @@ USES_RE = re.compile(
     r"(?P<sha>[0-9a-f]{40})(?P=quote)[ \t]+"
     r"#[ \t]+(?P<tag>v\d+\.\d+\.\d+)[ \t]*$"
 )
-DIRECT_USES_SHA_RE = re.compile(r"^actions/attest@([0-9a-f]{40})$", re.IGNORECASE)
+DIRECT_ATTEST_USES_RE = re.compile(r"^actions/attest@[^\s]+$", re.IGNORECASE)
+EXPRESSION_WRAPPER_RE = re.compile(r"^\$\{\{\s*(?P<body>.*?)\s*\}\}$")
+NONEMPTY_OUTPUT_TERM_RE = re.compile(
+    r"^(?:"
+    r"steps\.[A-Za-z0-9_-]+\.outputs\.[A-Za-z0-9_-]+|"
+    r"hashFiles\('[^'\r\n]+'\)"
+    r")\s*!=\s*''$"
+)
 
 
 class Producer(NamedTuple):
@@ -31,6 +39,7 @@ class Producer(NamedTuple):
     bundle_output: str
     consumer_if: str | None
     consumer_env: tuple[str, str] | None
+    consumer_copy: tuple[str, str]
 
 
 class WorkflowParseError(Exception):
@@ -47,6 +56,10 @@ PRODUCERS = (
         bundle_output="steps.attest-proof-pack.outputs.bundle-path",
         consumer_if="always() && steps.attest-proof-pack.outputs.bundle-path != ''",
         consumer_env=None,
+        consumer_copy=(
+            "${{ steps.attest-proof-pack.outputs.bundle-path }}",
+            "$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD/attestation-bundle.json",
+        ),
     ),
     Producer(
         path=Path(".github/workflows/privileged-mcp-action-pack-release.yml"),
@@ -61,6 +74,10 @@ PRODUCERS = (
         consumer_env=(
             "ATTESTATION_BUNDLE",
             "${{ steps.attest.outputs.bundle-path }}",
+        ),
+        consumer_copy=(
+            "$ATTESTATION_BUNDLE",
+            "release/attestation-bundle.json",
         ),
     ),
 )
@@ -132,7 +149,10 @@ def iter_jobs(document: object) -> list[tuple[str, dict[str, object]]]:
 
 
 def is_direct_attest_uses(uses: object) -> bool:
-    return isinstance(uses, str) and DIRECT_USES_SHA_RE.fullmatch(uses.strip()) is not None
+    return (
+        isinstance(uses, str)
+        and DIRECT_ATTEST_USES_RE.fullmatch(uses.strip()) is not None
+    )
 
 
 def structural_attest_steps(
@@ -146,14 +166,38 @@ def structural_attest_steps(
     return found
 
 
-def condition_is_false(value: object) -> bool:
-    return value is False or (
-        isinstance(value, str) and value.strip().casefold() in {"false", "${{ false }}"}
-    )
+def condition_may_run(value: object) -> bool:
+    """Recognize only the small condition grammar used by these producers.
+
+    Missing conditions, true, always(), and conjunctions with a non-empty
+    step output or hashFiles result may run. False terms and every unsupported
+    expression fail closed rather than being mistaken for reachable workflow.
+    """
+    if value is None or value is True:
+        return True
+    if value is False or not isinstance(value, str):
+        return False
+    expression = value.strip()
+    wrapper = EXPRESSION_WRAPPER_RE.fullmatch(expression)
+    if wrapper is not None:
+        expression = wrapper.group("body").strip()
+    terms = [term.strip() for term in expression.split("&&")]
+    if not terms or any(not term for term in terms):
+        return False
+    for term in terms:
+        folded = term.casefold()
+        if folded == "false":
+            return False
+        if folded in {"true", "always()"}:
+            continue
+        if NONEMPTY_OUTPUT_TERM_RE.fullmatch(term) is not None:
+            continue
+        return False
+    return True
 
 
 def is_reachable(node: dict[str, object]) -> bool:
-    return not condition_is_false(node.get("if"))
+    return condition_may_run(node.get("if"))
 
 
 def step_run_text(step: dict[str, object]) -> str:
@@ -161,13 +205,46 @@ def step_run_text(step: dict[str, object]) -> str:
     return run if isinstance(run, str) else ""
 
 
-def step_has_bundle_expression(step: dict[str, object], expression: str) -> bool:
-    if expression in step_run_text(step):
-        return True
-    env = step.get("env")
-    if not isinstance(env, dict):
-        return False
-    return any(isinstance(value, str) and expression in value for value in env.values())
+def shell_command_tokens(run: str) -> list[list[str]]:
+    """Tokenize simple logical shell lines; this is not a shell evaluator."""
+    commands: list[list[str]] = []
+    logical_line = ""
+    for raw_line in run.splitlines():
+        stripped = raw_line.strip()
+        if not logical_line and (not stripped or stripped.startswith("#")):
+            continue
+        continued = stripped.endswith("\\")
+        fragment = stripped[:-1].rstrip() if continued else stripped
+        logical_line = f"{logical_line} {fragment}".strip()
+        if continued:
+            continue
+        try:
+            tokens = shlex.split(logical_line, comments=True, posix=True)
+        except ValueError:
+            tokens = []
+        if tokens:
+            commands.append(tokens)
+        logical_line = ""
+    if logical_line:
+        try:
+            tokens = shlex.split(logical_line, comments=True, posix=True)
+        except ValueError:
+            tokens = []
+        if tokens:
+            commands.append(tokens)
+    return commands
+
+
+def step_runs_command(step: dict[str, object], expected: str) -> bool:
+    expected_tokens = shlex.split(expected, comments=False, posix=True)
+    return any(
+        command[: len(expected_tokens)] == expected_tokens
+        for command in shell_command_tokens(step_run_text(step))
+    )
+
+
+def step_copies_value(step: dict[str, object], source: str, destination: str) -> bool:
+    return ["cp", source, destination] in shell_command_tokens(step_run_text(step))
 
 
 def producer_contract_errors(producer: Producer, document: object) -> list[str]:
@@ -212,7 +289,7 @@ def producer_contract_errors(producer: Producer, document: object) -> list[str]:
         )
     same_job_steps = job_steps(job)
     earlier = same_job_steps[:attest_index]
-    if not any(producer.subject_producer in step_run_text(item) for item in earlier):
+    if not any(step_runs_command(item, producer.subject_producer) for item in earlier):
         errors.append(
             f"{producer.path}: subject {producer.subject_checksums} is not produced "
             f"earlier in job {producer.job_id!r} by {producer.subject_producer!r}"
@@ -230,9 +307,10 @@ def producer_contract_errors(producer: Producer, document: object) -> list[str]:
             key, value = producer.consumer_env
             if not isinstance(env, dict) or env.get(key) != value:
                 continue
-        if not step_has_bundle_expression(consumer, expression):
+        source, destination = producer.consumer_copy
+        if producer.consumer_env is None and source != expression:
             continue
-        if not step_run_text(consumer):
+        if not step_copies_value(consumer, source, destination):
             continue
         found_consumer = True
         break

--- a/scripts/ci/check-actions-attest-lockstep.py
+++ b/scripts/ci/check-actions-attest-lockstep.py
@@ -36,10 +36,12 @@ class Producer(NamedTuple):
     step_id: str
     subject_checksums: str
     producer_step_id: str
+    producer_shell: str
     producer_working_directory: str | None
     producer_commands: tuple[str, ...]
     bundle_output: str
     consumer_step_id: str
+    consumer_shell: str
     consumer_if: str | None
     consumer_env: tuple[str, str] | None
     consumer_commands: tuple[str, ...]
@@ -56,6 +58,7 @@ PRODUCERS = (
         step_id="attest-proof-pack",
         subject_checksums="assay-runner-proof-upload/subject-checksums.txt",
         producer_step_id="build-proof-pack",
+        producer_shell="bash",
         producer_working_directory=None,
         producer_commands=(
             "set -euo pipefail",
@@ -80,6 +83,7 @@ PRODUCERS = (
         ),
         bundle_output="steps.attest-proof-pack.outputs.bundle-path",
         consumer_step_id="retain-proof-attestation",
+        consumer_shell="bash",
         consumer_if="always() && steps.attest-proof-pack.outputs.bundle-path != ''",
         consumer_env=None,
         consumer_commands=(
@@ -96,6 +100,7 @@ PRODUCERS = (
         step_id="attest",
         subject_checksums="release/SHA256SUMS",
         producer_step_id="build-release-checksums",
+        producer_shell="bash",
         producer_working_directory="release",
         producer_commands=(
             "set -euo pipefail",
@@ -103,6 +108,7 @@ PRODUCERS = (
         ),
         bundle_output="steps.attest.outputs.bundle-path",
         consumer_step_id="retain-release-attestation",
+        consumer_shell="bash",
         consumer_if=None,
         consumer_env=(
             "ATTESTATION_BUNDLE",
@@ -345,6 +351,11 @@ def producer_contract_errors(producer: Producer, document: object) -> list[str]:
                 f"{producer.path}: producer step {producer.producer_step_id!r} "
                 "is not reachable"
             )
+        if producer_step.get("shell") != producer.producer_shell:
+            errors.append(
+                f"{producer.path}: producer shell "
+                f"{producer_step.get('shell')!r}, want {producer.producer_shell!r}"
+            )
         if (
             producer_step.get("working-directory")
             != producer.producer_working_directory
@@ -381,6 +392,11 @@ def producer_contract_errors(producer: Producer, document: object) -> list[str]:
             errors.append(
                 f"{producer.path}: consumer step {producer.consumer_step_id!r} "
                 "is not reachable"
+            )
+        if consumer.get("shell") != producer.consumer_shell:
+            errors.append(
+                f"{producer.path}: consumer shell "
+                f"{consumer.get('shell')!r}, want {producer.consumer_shell!r}"
             )
         if consumer.get("if") != producer.consumer_if:
             errors.append(

--- a/scripts/ci/check-actions-attest-lockstep.py
+++ b/scripts/ci/check-actions-attest-lockstep.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Pin Assay's two direct actions/attest producers in lockstep."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+EXPECTED_SHA = "1e69f48acb82d1966a394da916b4c1698aa569d6"
+EXPECTED_TAG = "v4.2.2"
+WORKFLOW_DIR = Path(".github/workflows")
+ATTEST_ACTION = "actions/attest@"
+YAML_HEX_ESCAPE_RE = re.compile(
+    r"\\(?:x([0-9a-fA-F]{2})|u([0-9a-fA-F]{4})|U([0-9a-fA-F]{8}))"
+)
+USES_RE = re.compile(
+    r"^[ \t]*(?:-[ \t]+)?uses:[ \t]+"
+    r"(?P<quote>['\"]?)actions/attest@"
+    r"(?P<sha>[0-9a-f]{40})(?P=quote)[ \t]+"
+    r"#[ \t]+(?P<tag>v\d+\.\d+\.\d+)[ \t]*$"
+)
+DIRECT_USES_SHA_RE = re.compile(r"^actions/attest@([0-9a-f]{40})$")
+
+
+class Producer(NamedTuple):
+    path: Path
+    step_id: str
+    subject_checksums: str
+    bundle_output: str
+
+
+class WorkflowParseError(Exception):
+    """A producer workflow could not be loaded, so the contract cannot pass."""
+
+
+PRODUCERS = (
+    Producer(
+        path=Path(".github/workflows/runner-spike-delegated.yml"),
+        step_id="attest-proof-pack",
+        subject_checksums="assay-runner-proof-upload/subject-checksums.txt",
+        bundle_output="steps.attest-proof-pack.outputs.bundle-path",
+    ),
+    Producer(
+        path=Path(".github/workflows/privileged-mcp-action-pack-release.yml"),
+        step_id="attest",
+        subject_checksums="release/SHA256SUMS",
+        bundle_output="steps.attest.outputs.bundle-path",
+    ),
+)
+
+
+def decode_hex_escape(match: re.Match[str]) -> str:
+    codepoint = next(group for group in match.groups() if group is not None)
+    try:
+        return chr(int(codepoint, 16))
+    except ValueError:
+        return "\N{REPLACEMENT CHARACTER}"
+
+
+def active_attest_pins(text: str) -> list[tuple[str, str]]:
+    pins: list[tuple[str, str]] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = USES_RE.match(line)
+        if match:
+            pins.append((match.group("sha"), match.group("tag")))
+    return pins
+
+
+def active_attest_references(text: str) -> int:
+    active_text = "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+    # GitHub resolves repository names case-insensitively, and YAML double-quoted
+    # scalars decode hexadecimal escapes and escaped line breaks before dispatch.
+    # Needle is actions/attest@, which does not match attest-build-provenance@.
+    normalized = re.sub(r"\\\r?\n[ \t]*", "", active_text)
+    normalized = YAML_HEX_ESCAPE_RE.sub(decode_hex_escape, normalized)
+    normalized = normalized.casefold()
+    return normalized.count(ATTEST_ACTION)
+
+
+def has_active_attest_callsite(text: str) -> bool:
+    return active_attest_references(text) > 0
+
+
+def load_workflow_mapping(path: Path) -> object:
+    try:
+        completed = subprocess.run(
+            [
+                "ruby",
+                "-ryaml",
+                "-rjson",
+                "-e",
+                "puts JSON.generate(YAML.load_file(ARGV[0]))",
+                str(path),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise WorkflowParseError(f"{path}: yaml parser unavailable: {error}") from error
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or (
+            f"exit {completed.returncode}"
+        )
+        raise WorkflowParseError(f"{path}: malformed workflow YAML: {detail}")
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise WorkflowParseError(
+            f"{path}: yaml parser returned non-JSON: {error}"
+        ) from error
+
+
+def iter_steps(document: object) -> list[dict[str, object]]:
+    if not isinstance(document, dict):
+        raise WorkflowParseError("workflow root is not a mapping")
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict):
+        raise WorkflowParseError("workflow jobs is not a mapping")
+    steps: list[dict[str, object]] = []
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        raw_steps = job.get("steps") or []
+        if not isinstance(raw_steps, list):
+            continue
+        for step in raw_steps:
+            if isinstance(step, dict):
+                steps.append(step)
+    return steps
+
+
+def direct_attest_steps(document: object) -> list[dict[str, object]]:
+    found: list[dict[str, object]] = []
+    for step in iter_steps(document):
+        uses = step.get("uses")
+        if isinstance(uses, str) and DIRECT_USES_SHA_RE.fullmatch(uses.strip()):
+            found.append(step)
+    return found
+
+
+def producer_contract_errors(producer: Producer, text: str, document: object) -> list[str]:
+    errors: list[str] = []
+    steps = direct_attest_steps(document)
+    if len(steps) != 1:
+        errors.append(
+            f"{producer.path}: want exactly one direct actions/attest step, "
+            f"found {len(steps)}"
+        )
+        return errors
+    step = steps[0]
+    if step.get("id") != producer.step_id:
+        errors.append(
+            f"{producer.path}: attest step id {step.get('id')!r}, "
+            f"want {producer.step_id!r}"
+        )
+    with_block = step.get("with")
+    if not isinstance(with_block, dict):
+        errors.append(
+            f"{producer.path}: SHA pin is unwired; missing with.subject-checksums "
+            f"{producer.subject_checksums}"
+        )
+    elif with_block.get("subject-checksums") != producer.subject_checksums:
+        errors.append(
+            f"{producer.path}: subject-checksums {with_block.get('subject-checksums')!r}, "
+            f"want {producer.subject_checksums!r}"
+        )
+    if producer.bundle_output not in text:
+        errors.append(
+            f"{producer.path}: missing bundle consumer {producer.bundle_output}"
+        )
+    return errors
+
+
+def check() -> list[str]:
+    errors: list[str] = []
+    expected = (EXPECTED_SHA, EXPECTED_TAG)
+    expected_paths = {producer.path for producer in PRODUCERS}
+
+    discovered: set[Path] = set()
+    for pattern in ("*.yml", "*.yaml"):
+        for workflow in WORKFLOW_DIR.glob(pattern):
+            if has_active_attest_callsite(workflow.read_text(encoding="utf-8")):
+                discovered.add(workflow)
+    for workflow in sorted(discovered - expected_paths):
+        errors.append(f"unexpected actions/attest workflow callsite: {workflow}")
+
+    for producer in PRODUCERS:
+        workflow = producer.path
+        if not workflow.is_file():
+            errors.append(f"workflow missing: {workflow}")
+            continue
+        text = workflow.read_text(encoding="utf-8")
+        pins = active_attest_pins(text)
+        references = active_attest_references(text)
+        if references != len(pins):
+            errors.append(
+                f"{workflow}: found {references} actions/attest reference(s), "
+                f"but only {len(pins)} canonical pin(s)"
+            )
+        if len(pins) != 1:
+            errors.append(
+                f"{workflow}: want exactly one active actions/attest SHA pin, "
+                f"found {len(pins)}"
+            )
+        elif pins[0] != expected:
+            errors.append(
+                f"{workflow}: pin @{pins[0][0]} # {pins[0][1]}, "
+                f"want @{EXPECTED_SHA} # {EXPECTED_TAG}"
+            )
+        try:
+            document = load_workflow_mapping(workflow)
+        except WorkflowParseError as error:
+            errors.append(str(error))
+            continue
+        errors.extend(producer_contract_errors(producer, text, document))
+    return errors
+
+
+def main() -> int:
+    errors = check()
+    if errors:
+        print("FAIL: actions/attest workflow pins", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+    print(
+        f"ok    {len(PRODUCERS)} actions/attest callsites "
+        f"@{EXPECTED_SHA} # {EXPECTED_TAG}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check-actions-attest-lockstep.py
+++ b/scripts/ci/check-actions-attest-lockstep.py
@@ -33,17 +33,19 @@ NONEMPTY_OUTPUT_TERM_RE = re.compile(
 class Producer(NamedTuple):
     path: Path
     job_id: str
+    job_env: tuple[tuple[str, str], ...]
     step_id: str
     subject_checksums: str
     producer_step_id: str
     producer_shell: str
+    producer_env: tuple[tuple[str, str], ...] | None
     producer_working_directory: str | None
     producer_commands: tuple[str, ...]
     bundle_output: str
     consumer_step_id: str
     consumer_shell: str
     consumer_if: str | None
-    consumer_env: tuple[str, str] | None
+    consumer_env: tuple[tuple[str, str], ...] | None
     consumer_commands: tuple[str, ...]
 
 
@@ -55,10 +57,21 @@ PRODUCERS = (
     Producer(
         path=Path(".github/workflows/runner-spike-delegated.yml"),
         job_id="phase1-delegated-gates",
+        job_env=(
+            (
+                "ASSAY_RUNNER_DELEGATED_PROOF_ROOT",
+                "/tmp/assay-runner-proof-${{ github.run_id }}",
+            ),
+            (
+                "ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD",
+                "${{ github.workspace }}/assay-runner-proof-upload",
+            ),
+        ),
         step_id="attest-proof-pack",
         subject_checksums="assay-runner-proof-upload/subject-checksums.txt",
         producer_step_id="build-proof-pack",
         producer_shell="bash",
+        producer_env=None,
         producer_working_directory=None,
         producer_commands=(
             "set -euo pipefail",
@@ -97,10 +110,12 @@ PRODUCERS = (
     Producer(
         path=Path(".github/workflows/privileged-mcp-action-pack-release.yml"),
         job_id="release-pack",
+        job_env=(),
         step_id="attest",
         subject_checksums="release/SHA256SUMS",
         producer_step_id="build-release-checksums",
         producer_shell="bash",
+        producer_env=None,
         producer_working_directory="release",
         producer_commands=(
             "set -euo pipefail",
@@ -111,8 +126,10 @@ PRODUCERS = (
         consumer_shell="bash",
         consumer_if=None,
         consumer_env=(
-            "ATTESTATION_BUNDLE",
-            "${{ steps.attest.outputs.bundle-path }}",
+            (
+                "ATTESTATION_BUNDLE",
+                "${{ steps.attest.outputs.bundle-path }}",
+            ),
         ),
         consumer_commands=(
             "set -euo pipefail",
@@ -133,6 +150,14 @@ def active_attest_pins(text: str) -> list[tuple[str, str]]:
         if match:
             pins.append((match.group("sha"), match.group("tag")))
     return pins
+
+
+def has_exact_step_env(
+    value: object, expected: tuple[tuple[str, str], ...] | None
+) -> bool:
+    if expected is None:
+        return value is None
+    return value == dict(expected)
 
 
 def load_workflow_mapping(path: Path) -> object:
@@ -308,6 +333,13 @@ def producer_contract_errors(producer: Producer, document: object) -> list[str]:
         return errors
     if not is_reachable(job):
         errors.append(f"{producer.path}: job {producer.job_id!r} is not reachable")
+    if producer.job_env:
+        job_env = job.get("env")
+        for key, value in producer.job_env:
+            if not isinstance(job_env, dict) or job_env.get(key) != value:
+                errors.append(
+                    f"{producer.path}: job env {key!r} is not bound to {value!r}"
+                )
     if not is_reachable(step):
         errors.append(
             f"{producer.path}: attest step {producer.step_id!r} is not reachable"
@@ -356,6 +388,16 @@ def producer_contract_errors(producer: Producer, document: object) -> list[str]:
                 f"{producer.path}: producer shell "
                 f"{producer_step.get('shell')!r}, want {producer.producer_shell!r}"
             )
+        if not has_exact_step_env(producer_step.get("env"), producer.producer_env):
+            expected_env = (
+                dict(producer.producer_env)
+                if producer.producer_env is not None
+                else None
+            )
+            errors.append(
+                f"{producer.path}: producer env {producer_step.get('env')!r}, "
+                f"want {expected_env!r}"
+            )
         if (
             producer_step.get("working-directory")
             != producer.producer_working_directory
@@ -403,13 +445,16 @@ def producer_contract_errors(producer: Producer, document: object) -> list[str]:
                 f"{producer.path}: consumer condition {consumer.get('if')!r}, "
                 f"want {producer.consumer_if!r}"
             )
-        if producer.consumer_env is not None:
-            env = consumer.get("env")
-            key, value = producer.consumer_env
-            if not isinstance(env, dict) or env.get(key) != value:
-                errors.append(
-                    f"{producer.path}: consumer env {key!r} is not bound to {value!r}"
-                )
+        if not has_exact_step_env(consumer.get("env"), producer.consumer_env):
+            expected_env = (
+                dict(producer.consumer_env)
+                if producer.consumer_env is not None
+                else None
+            )
+            errors.append(
+                f"{producer.path}: consumer env {consumer.get('env')!r}, "
+                f"want {expected_env!r}"
+            )
         if not step_runs_exact_commands(consumer, producer.consumer_commands):
             errors.append(
                 f"{producer.path}: consumer step {producer.consumer_step_id!r} "

--- a/scripts/ci/check-actions-attest-lockstep.py
+++ b/scripts/ci/check-actions-attest-lockstep.py
@@ -13,24 +13,24 @@ from typing import NamedTuple
 EXPECTED_SHA = "1e69f48acb82d1966a394da916b4c1698aa569d6"
 EXPECTED_TAG = "v4.2.2"
 WORKFLOW_DIR = Path(".github/workflows")
-ATTEST_ACTION = "actions/attest@"
-YAML_HEX_ESCAPE_RE = re.compile(
-    r"\\(?:x([0-9a-fA-F]{2})|u([0-9a-fA-F]{4})|U([0-9a-fA-F]{8}))"
-)
 USES_RE = re.compile(
     r"^[ \t]*(?:-[ \t]+)?uses:[ \t]+"
     r"(?P<quote>['\"]?)actions/attest@"
     r"(?P<sha>[0-9a-f]{40})(?P=quote)[ \t]+"
     r"#[ \t]+(?P<tag>v\d+\.\d+\.\d+)[ \t]*$"
 )
-DIRECT_USES_SHA_RE = re.compile(r"^actions/attest@([0-9a-f]{40})$")
+DIRECT_USES_SHA_RE = re.compile(r"^actions/attest@([0-9a-f]{40})$", re.IGNORECASE)
 
 
 class Producer(NamedTuple):
     path: Path
+    job_id: str
     step_id: str
     subject_checksums: str
+    subject_producer: str
     bundle_output: str
+    consumer_if: str | None
+    consumer_env: tuple[str, str] | None
 
 
 class WorkflowParseError(Exception):
@@ -40,25 +40,30 @@ class WorkflowParseError(Exception):
 PRODUCERS = (
     Producer(
         path=Path(".github/workflows/runner-spike-delegated.yml"),
+        job_id="phase1-delegated-gates",
         step_id="attest-proof-pack",
         subject_checksums="assay-runner-proof-upload/subject-checksums.txt",
+        subject_producer="python3 scripts/ci/assay_runner_delegated_proof_pack.py",
         bundle_output="steps.attest-proof-pack.outputs.bundle-path",
+        consumer_if="always() && steps.attest-proof-pack.outputs.bundle-path != ''",
+        consumer_env=None,
     ),
     Producer(
         path=Path(".github/workflows/privileged-mcp-action-pack-release.yml"),
+        job_id="release-pack",
         step_id="attest",
         subject_checksums="release/SHA256SUMS",
+        subject_producer=(
+            "sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS"
+        ),
         bundle_output="steps.attest.outputs.bundle-path",
+        consumer_if=None,
+        consumer_env=(
+            "ATTESTATION_BUNDLE",
+            "${{ steps.attest.outputs.bundle-path }}",
+        ),
     ),
 )
-
-
-def decode_hex_escape(match: re.Match[str]) -> str:
-    codepoint = next(group for group in match.groups() if group is not None)
-    try:
-        return chr(int(codepoint, 16))
-    except ValueError:
-        return "\N{REPLACEMENT CHARACTER}"
 
 
 def active_attest_pins(text: str) -> list[tuple[str, str]]:
@@ -71,23 +76,6 @@ def active_attest_pins(text: str) -> list[tuple[str, str]]:
         if match:
             pins.append((match.group("sha"), match.group("tag")))
     return pins
-
-
-def active_attest_references(text: str) -> int:
-    active_text = "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
-    # GitHub resolves repository names case-insensitively, and YAML double-quoted
-    # scalars decode hexadecimal escapes and escaped line breaks before dispatch.
-    # Needle is actions/attest@, which does not match attest-build-provenance@.
-    normalized = re.sub(r"\\\r?\n[ \t]*", "", active_text)
-    normalized = YAML_HEX_ESCAPE_RE.sub(decode_hex_escape, normalized)
-    normalized = normalized.casefold()
-    return normalized.count(ATTEST_ACTION)
-
-
-def has_active_attest_callsite(text: str) -> bool:
-    return active_attest_references(text) > 0
 
 
 def load_workflow_mapping(path: Path) -> object:
@@ -120,44 +108,92 @@ def load_workflow_mapping(path: Path) -> object:
         ) from error
 
 
-def iter_steps(document: object) -> list[dict[str, object]]:
-    if not isinstance(document, dict):
-        raise WorkflowParseError("workflow root is not a mapping")
-    jobs = document.get("jobs")
-    if not isinstance(jobs, dict):
-        raise WorkflowParseError("workflow jobs is not a mapping")
-    steps: list[dict[str, object]] = []
-    for job in jobs.values():
-        if not isinstance(job, dict):
-            continue
-        raw_steps = job.get("steps") or []
-        if not isinstance(raw_steps, list):
-            continue
-        for step in raw_steps:
-            if isinstance(step, dict):
-                steps.append(step)
-    return steps
+def mapping(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise WorkflowParseError(f"{label} is not a mapping")
+    return value
 
 
-def direct_attest_steps(document: object) -> list[dict[str, object]]:
-    found: list[dict[str, object]] = []
-    for step in iter_steps(document):
-        uses = step.get("uses")
-        if isinstance(uses, str) and DIRECT_USES_SHA_RE.fullmatch(uses.strip()):
-            found.append(step)
+def job_steps(job: dict[str, object]) -> list[dict[str, object]]:
+    raw_steps = job.get("steps") or []
+    if not isinstance(raw_steps, list):
+        return []
+    return [step for step in raw_steps if isinstance(step, dict)]
+
+
+def iter_jobs(document: object) -> list[tuple[str, dict[str, object]]]:
+    root = mapping(document, "workflow root")
+    jobs = mapping(root.get("jobs"), "workflow jobs")
+    named: list[tuple[str, dict[str, object]]] = []
+    for name, job in jobs.items():
+        if isinstance(name, str) and isinstance(job, dict):
+            named.append((name, job))
+    return named
+
+
+def is_direct_attest_uses(uses: object) -> bool:
+    return isinstance(uses, str) and DIRECT_USES_SHA_RE.fullmatch(uses.strip()) is not None
+
+
+def structural_attest_steps(
+    document: object,
+) -> list[tuple[str, int, dict[str, object]]]:
+    found: list[tuple[str, int, dict[str, object]]] = []
+    for job_id, job in iter_jobs(document):
+        for index, step in enumerate(job_steps(job)):
+            if is_direct_attest_uses(step.get("uses")):
+                found.append((job_id, index, step))
     return found
 
 
-def producer_contract_errors(producer: Producer, text: str, document: object) -> list[str]:
+def condition_is_false(value: object) -> bool:
+    return value is False or (
+        isinstance(value, str) and value.strip().casefold() in {"false", "${{ false }}"}
+    )
+
+
+def is_reachable(node: dict[str, object]) -> bool:
+    return not condition_is_false(node.get("if"))
+
+
+def step_run_text(step: dict[str, object]) -> str:
+    run = step.get("run")
+    return run if isinstance(run, str) else ""
+
+
+def step_has_bundle_expression(step: dict[str, object], expression: str) -> bool:
+    if expression in step_run_text(step):
+        return True
+    env = step.get("env")
+    if not isinstance(env, dict):
+        return False
+    return any(isinstance(value, str) and expression in value for value in env.values())
+
+
+def producer_contract_errors(producer: Producer, document: object) -> list[str]:
     errors: list[str] = []
-    steps = direct_attest_steps(document)
-    if len(steps) != 1:
+    attest_steps = structural_attest_steps(document)
+    if len(attest_steps) != 1:
         errors.append(
             f"{producer.path}: want exactly one direct actions/attest step, "
-            f"found {len(steps)}"
+            f"found {len(attest_steps)}"
         )
         return errors
-    step = steps[0]
+    job_id, attest_index, step = attest_steps[0]
+    jobs = dict(iter_jobs(document))
+    job = jobs.get(producer.job_id)
+    if job_id != producer.job_id or job is None:
+        errors.append(
+            f"{producer.path}: attest step is in job {job_id!r}, "
+            f"want {producer.job_id!r}"
+        )
+        return errors
+    if not is_reachable(job):
+        errors.append(f"{producer.path}: job {producer.job_id!r} is not reachable")
+    if not is_reachable(step):
+        errors.append(
+            f"{producer.path}: attest step {producer.step_id!r} is not reachable"
+        )
     if step.get("id") != producer.step_id:
         errors.append(
             f"{producer.path}: attest step id {step.get('id')!r}, "
@@ -174,9 +210,36 @@ def producer_contract_errors(producer: Producer, text: str, document: object) ->
             f"{producer.path}: subject-checksums {with_block.get('subject-checksums')!r}, "
             f"want {producer.subject_checksums!r}"
         )
-    if producer.bundle_output not in text:
+    same_job_steps = job_steps(job)
+    earlier = same_job_steps[:attest_index]
+    if not any(producer.subject_producer in step_run_text(item) for item in earlier):
         errors.append(
-            f"{producer.path}: missing bundle consumer {producer.bundle_output}"
+            f"{producer.path}: subject {producer.subject_checksums} is not produced "
+            f"earlier in job {producer.job_id!r} by {producer.subject_producer!r}"
+        )
+    later = same_job_steps[attest_index + 1 :]
+    expression = "${{ " + producer.bundle_output + " }}"
+    found_consumer = False
+    for consumer in later:
+        if not is_reachable(consumer):
+            continue
+        if producer.consumer_if is not None and consumer.get("if") != producer.consumer_if:
+            continue
+        if producer.consumer_env is not None:
+            env = consumer.get("env")
+            key, value = producer.consumer_env
+            if not isinstance(env, dict) or env.get(key) != value:
+                continue
+        if not step_has_bundle_expression(consumer, expression):
+            continue
+        if not step_run_text(consumer):
+            continue
+        found_consumer = True
+        break
+    if not found_consumer:
+        errors.append(
+            f"{producer.path}: missing reachable same-job consumer "
+            f"{producer.bundle_output}"
         )
     return errors
 
@@ -186,13 +249,16 @@ def check() -> list[str]:
     expected = (EXPECTED_SHA, EXPECTED_TAG)
     expected_paths = {producer.path for producer in PRODUCERS}
 
-    discovered: set[Path] = set()
     for pattern in ("*.yml", "*.yaml"):
-        for workflow in WORKFLOW_DIR.glob(pattern):
-            if has_active_attest_callsite(workflow.read_text(encoding="utf-8")):
-                discovered.add(workflow)
-    for workflow in sorted(discovered - expected_paths):
-        errors.append(f"unexpected actions/attest workflow callsite: {workflow}")
+        for workflow in sorted(WORKFLOW_DIR.glob(pattern)):
+            if workflow in expected_paths:
+                continue
+            try:
+                document = load_workflow_mapping(workflow)
+            except WorkflowParseError:
+                continue
+            if structural_attest_steps(document):
+                errors.append(f"unexpected actions/attest workflow callsite: {workflow}")
 
     for producer in PRODUCERS:
         workflow = producer.path
@@ -201,12 +267,6 @@ def check() -> list[str]:
             continue
         text = workflow.read_text(encoding="utf-8")
         pins = active_attest_pins(text)
-        references = active_attest_references(text)
-        if references != len(pins):
-            errors.append(
-                f"{workflow}: found {references} actions/attest reference(s), "
-                f"but only {len(pins)} canonical pin(s)"
-            )
         if len(pins) != 1:
             errors.append(
                 f"{workflow}: want exactly one active actions/attest SHA pin, "
@@ -222,7 +282,7 @@ def check() -> list[str]:
         except WorkflowParseError as error:
             errors.append(str(error))
             continue
-        errors.extend(producer_contract_errors(producer, text, document))
+        errors.extend(producer_contract_errors(producer, document))
     return errors
 
 

--- a/scripts/ci/check-actions-attest-lockstep.py
+++ b/scripts/ci/check-actions-attest-lockstep.py
@@ -44,6 +44,7 @@ class Producer(NamedTuple):
     bundle_output: str
     consumer_step_id: str
     consumer_shell: str
+    consumer_working_directory: str
     consumer_if: str | None
     consumer_env: tuple[tuple[str, str], ...] | None
     consumer_commands: tuple[str, ...]
@@ -97,6 +98,7 @@ PRODUCERS = (
         bundle_output="steps.attest-proof-pack.outputs.bundle-path",
         consumer_step_id="retain-proof-attestation",
         consumer_shell="bash",
+        consumer_working_directory="${{ github.workspace }}",
         consumer_if="always() && steps.attest-proof-pack.outputs.bundle-path != ''",
         consumer_env=None,
         consumer_commands=(
@@ -124,6 +126,7 @@ PRODUCERS = (
         bundle_output="steps.attest.outputs.bundle-path",
         consumer_step_id="retain-release-attestation",
         consumer_shell="bash",
+        consumer_working_directory="${{ github.workspace }}",
         consumer_if=None,
         consumer_env=(
             (
@@ -439,6 +442,12 @@ def producer_contract_errors(producer: Producer, document: object) -> list[str]:
             errors.append(
                 f"{producer.path}: consumer shell "
                 f"{consumer.get('shell')!r}, want {producer.consumer_shell!r}"
+            )
+        if consumer.get("working-directory") != producer.consumer_working_directory:
+            errors.append(
+                f"{producer.path}: consumer working-directory "
+                f"{consumer.get('working-directory')!r}, "
+                f"want {producer.consumer_working_directory!r}"
             )
         if consumer.get("if") != producer.consumer_if:
             errors.append(

--- a/scripts/ci/check-actions-attest-lockstep.py
+++ b/scripts/ci/check-actions-attest-lockstep.py
@@ -35,11 +35,14 @@ class Producer(NamedTuple):
     job_id: str
     step_id: str
     subject_checksums: str
-    subject_producer: str
+    producer_step_id: str
+    producer_working_directory: str | None
+    producer_commands: tuple[str, ...]
     bundle_output: str
+    consumer_step_id: str
     consumer_if: str | None
     consumer_env: tuple[str, str] | None
-    consumer_copy: tuple[str, str]
+    consumer_commands: tuple[str, ...]
 
 
 class WorkflowParseError(Exception):
@@ -52,13 +55,39 @@ PRODUCERS = (
         job_id="phase1-delegated-gates",
         step_id="attest-proof-pack",
         subject_checksums="assay-runner-proof-upload/subject-checksums.txt",
-        subject_producer="python3 scripts/ci/assay_runner_delegated_proof_pack.py",
+        producer_step_id="build-proof-pack",
+        producer_working_directory=None,
+        producer_commands=(
+            "set -euo pipefail",
+            (
+                "python3 scripts/ci/assay_runner_delegated_proof_pack.py "
+                "--proof-root $ASSAY_RUNNER_DELEGATED_PROOF_ROOT "
+                "--gates '${{ inputs.gates }}' "
+                "--build-ebpf '${{ inputs.build_ebpf }}' "
+                "--run-id $GITHUB_RUN_ID "
+                "--run-attempt $GITHUB_RUN_ATTEMPT "
+                "--run-url "
+                "'${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/"
+                "${GITHUB_RUN_ID}' "
+                "--ref $GITHUB_REF "
+                "--head-sha $GITHUB_SHA "
+                "--workflow-sha '${GITHUB_WORKFLOW_SHA:-$GITHUB_SHA}' "
+                "--workflow-name '$GITHUB_WORKFLOW' "
+                "--workflow-path .github/workflows/runner-spike-delegated.yml "
+                "--repository $GITHUB_REPOSITORY "
+                "--retention-days 365"
+            ),
+        ),
         bundle_output="steps.attest-proof-pack.outputs.bundle-path",
+        consumer_step_id="retain-proof-attestation",
         consumer_if="always() && steps.attest-proof-pack.outputs.bundle-path != ''",
         consumer_env=None,
-        consumer_copy=(
-            "${{ steps.attest-proof-pack.outputs.bundle-path }}",
-            "$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD/attestation-bundle.json",
+        consumer_commands=(
+            "set -euo pipefail",
+            (
+                "cp '${{ steps.attest-proof-pack.outputs.bundle-path }}' "
+                "'$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD/attestation-bundle.json'"
+            ),
         ),
     ),
     Producer(
@@ -66,18 +95,23 @@ PRODUCERS = (
         job_id="release-pack",
         step_id="attest",
         subject_checksums="release/SHA256SUMS",
-        subject_producer=(
-            "sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS"
+        producer_step_id="build-release-checksums",
+        producer_working_directory="release",
+        producer_commands=(
+            "set -euo pipefail",
+            "sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS",
         ),
         bundle_output="steps.attest.outputs.bundle-path",
+        consumer_step_id="retain-release-attestation",
         consumer_if=None,
         consumer_env=(
             "ATTESTATION_BUNDLE",
             "${{ steps.attest.outputs.bundle-path }}",
         ),
-        consumer_copy=(
-            "$ATTESTATION_BUNDLE",
-            "release/attestation-bundle.json",
+        consumer_commands=(
+            "set -euo pipefail",
+            "test -n '$ATTESTATION_BUNDLE'",
+            "cp '$ATTESTATION_BUNDLE' release/attestation-bundle.json",
         ),
     ),
 )
@@ -103,7 +137,11 @@ def load_workflow_mapping(path: Path) -> object:
                 "-ryaml",
                 "-rjson",
                 "-e",
-                "puts JSON.generate(YAML.load_file(ARGV[0]))",
+                (
+                    "document = YAML.safe_load(File.read(ARGV[0]), "
+                    "permitted_classes: [], permitted_symbols: [], aliases: true); "
+                    "puts JSON.generate(document)"
+                ),
                 str(path),
             ],
             check=False,
@@ -235,16 +273,13 @@ def shell_command_tokens(run: str) -> list[list[str]]:
     return commands
 
 
-def step_runs_command(step: dict[str, object], expected: str) -> bool:
-    expected_tokens = shlex.split(expected, comments=False, posix=True)
-    return any(
-        command[: len(expected_tokens)] == expected_tokens
-        for command in shell_command_tokens(step_run_text(step))
-    )
-
-
-def step_copies_value(step: dict[str, object], source: str, destination: str) -> bool:
-    return ["cp", source, destination] in shell_command_tokens(step_run_text(step))
+def step_runs_exact_commands(
+    step: dict[str, object], expected: tuple[str, ...]
+) -> bool:
+    expected_tokens = [
+        shlex.split(command, comments=False, posix=True) for command in expected
+    ]
+    return shell_command_tokens(step_run_text(step)) == expected_tokens
 
 
 def producer_contract_errors(producer: Producer, document: object) -> list[str]:
@@ -288,37 +323,83 @@ def producer_contract_errors(producer: Producer, document: object) -> list[str]:
             f"want {producer.subject_checksums!r}"
         )
     same_job_steps = job_steps(job)
-    earlier = same_job_steps[:attest_index]
-    if not any(step_runs_command(item, producer.subject_producer) for item in earlier):
+    producer_steps = [
+        (index, item)
+        for index, item in enumerate(same_job_steps)
+        if item.get("id") == producer.producer_step_id
+    ]
+    if len(producer_steps) != 1:
         errors.append(
-            f"{producer.path}: subject {producer.subject_checksums} is not produced "
-            f"earlier in job {producer.job_id!r} by {producer.subject_producer!r}"
+            f"{producer.path}: want exactly one producer step "
+            f"{producer.producer_step_id!r}, found {len(producer_steps)}"
         )
-    later = same_job_steps[attest_index + 1 :]
-    expression = "${{ " + producer.bundle_output + " }}"
-    found_consumer = False
-    for consumer in later:
+    else:
+        producer_index, producer_step = producer_steps[0]
+        if producer_index >= attest_index:
+            errors.append(
+                f"{producer.path}: producer step {producer.producer_step_id!r} "
+                "does not precede attestation"
+            )
+        if not is_reachable(producer_step):
+            errors.append(
+                f"{producer.path}: producer step {producer.producer_step_id!r} "
+                "is not reachable"
+            )
+        if (
+            producer_step.get("working-directory")
+            != producer.producer_working_directory
+        ):
+            errors.append(
+                f"{producer.path}: producer working-directory "
+                f"{producer_step.get('working-directory')!r}, "
+                f"want {producer.producer_working_directory!r}"
+            )
+        if not step_runs_exact_commands(producer_step, producer.producer_commands):
+            errors.append(
+                f"{producer.path}: producer step {producer.producer_step_id!r} "
+                "does not run the exact command sequence"
+            )
+
+    consumer_steps = [
+        (index, item)
+        for index, item in enumerate(same_job_steps)
+        if item.get("id") == producer.consumer_step_id
+    ]
+    if len(consumer_steps) != 1:
+        errors.append(
+            f"{producer.path}: want exactly one consumer step "
+            f"{producer.consumer_step_id!r}, found {len(consumer_steps)}"
+        )
+    else:
+        consumer_index, consumer = consumer_steps[0]
+        if consumer_index <= attest_index:
+            errors.append(
+                f"{producer.path}: consumer step {producer.consumer_step_id!r} "
+                "does not follow attestation"
+            )
         if not is_reachable(consumer):
-            continue
-        if producer.consumer_if is not None and consumer.get("if") != producer.consumer_if:
-            continue
+            errors.append(
+                f"{producer.path}: consumer step {producer.consumer_step_id!r} "
+                "is not reachable"
+            )
+        if consumer.get("if") != producer.consumer_if:
+            errors.append(
+                f"{producer.path}: consumer condition {consumer.get('if')!r}, "
+                f"want {producer.consumer_if!r}"
+            )
         if producer.consumer_env is not None:
             env = consumer.get("env")
             key, value = producer.consumer_env
             if not isinstance(env, dict) or env.get(key) != value:
-                continue
-        source, destination = producer.consumer_copy
-        if producer.consumer_env is None and source != expression:
-            continue
-        if not step_copies_value(consumer, source, destination):
-            continue
-        found_consumer = True
-        break
-    if not found_consumer:
-        errors.append(
-            f"{producer.path}: missing reachable same-job consumer "
-            f"{producer.bundle_output}"
-        )
+                errors.append(
+                    f"{producer.path}: consumer env {key!r} is not bound to {value!r}"
+                )
+        if not step_runs_exact_commands(consumer, producer.consumer_commands):
+            errors.append(
+                f"{producer.path}: consumer step {producer.consumer_step_id!r} "
+                f"does not preserve {producer.bundle_output} with the exact "
+                "command sequence"
+            )
     return errors
 
 
@@ -333,7 +414,8 @@ def check() -> list[str]:
                 continue
             try:
                 document = load_workflow_mapping(workflow)
-            except WorkflowParseError:
+            except WorkflowParseError as error:
+                errors.append(str(error))
                 continue
             if structural_attest_steps(document):
                 errors.append(f"unexpected actions/attest workflow callsite: {workflow}")

--- a/scripts/ci/check-actions-attest-lockstep.py
+++ b/scripts/ci/check-actions-attest-lockstep.py
@@ -210,6 +210,16 @@ def job_steps(job: dict[str, object]) -> list[dict[str, object]]:
     return [step for step in raw_steps if isinstance(step, dict)]
 
 
+def steps_with_id(
+    steps: list[dict[str, object]], step_id: str
+) -> list[tuple[int, dict[str, object]]]:
+    return [
+        (index, step)
+        for index, step in enumerate(steps)
+        if step.get("id") == step_id
+    ]
+
+
 def iter_jobs(document: object) -> list[tuple[str, dict[str, object]]]:
     root = mapping(document, "workflow root")
     jobs = mapping(root.get("jobs"), "workflow jobs")
@@ -364,11 +374,13 @@ def producer_contract_errors(producer: Producer, document: object) -> list[str]:
             f"want {producer.subject_checksums!r}"
         )
     same_job_steps = job_steps(job)
-    producer_steps = [
-        (index, item)
-        for index, item in enumerate(same_job_steps)
-        if item.get("id") == producer.producer_step_id
-    ]
+    attest_id_steps = steps_with_id(same_job_steps, producer.step_id)
+    if len(attest_id_steps) != 1:
+        errors.append(
+            f"{producer.path}: want exactly one step owning attest id "
+            f"{producer.step_id!r}, found {len(attest_id_steps)}"
+        )
+    producer_steps = steps_with_id(same_job_steps, producer.producer_step_id)
     if len(producer_steps) != 1:
         errors.append(
             f"{producer.path}: want exactly one producer step "
@@ -416,11 +428,7 @@ def producer_contract_errors(producer: Producer, document: object) -> list[str]:
                 "does not run the exact command sequence"
             )
 
-    consumer_steps = [
-        (index, item)
-        for index, item in enumerate(same_job_steps)
-        if item.get("id") == producer.consumer_step_id
-    ]
+    consumer_steps = steps_with_id(same_job_steps, producer.consumer_step_id)
     if len(consumer_steps) != 1:
         errors.append(
             f"{producer.path}: want exactly one consumer step "

--- a/scripts/ci/test-actions-attest-lockstep.sh
+++ b/scripts/ci/test-actions-attest-lockstep.sh
@@ -450,11 +450,25 @@ seed "$case_root"
 mutate_once \
   "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
   "        id: build-release-checksums
+        shell: bash
         working-directory: release" \
   "        id: build-release-checksums
         if: false
+        shell: bash
         working-directory: release"
 run_case pack-producer-if-false-is-refused "$case_root" 1
+
+case_root="$scratch/pack-producer-custom-shell"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "        id: build-release-checksums
+        shell: bash
+        working-directory: release" \
+  "        id: build-release-checksums
+        shell: \"true {0}\"
+        working-directory: release"
+run_case pack-producer-custom-shell-is-refused "$case_root" 1
 
 case_root="$scratch/pack-producer-never-called-function"
 seed "$case_root"
@@ -499,6 +513,18 @@ mutate_once \
   "          python3 scripts/ci/assay_runner_delegated_proof_pack.py --help \\"
 run_case delegated-producer-help-is-refused "$case_root" 1
 
+case_root="$scratch/delegated-producer-custom-shell"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "        id: build-proof-pack
+        if: always()
+        shell: bash" \
+  "        id: build-proof-pack
+        if: always()
+        shell: \"true {0}\""
+run_case delegated-producer-custom-shell-is-refused "$case_root" 1
+
 case_root="$scratch/delete-delegated-proof-pack"
 seed "$case_root"
 mutate_once \
@@ -517,6 +543,7 @@ path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
 old = """      - name: Retain attestation bundle
         id: retain-release-attestation
+        shell: bash
         env:
           ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
         run: |
@@ -552,6 +579,18 @@ if text.count(old) != 1:
 path.write_text(text.replace(old, new, 1), encoding="utf-8")
 PY
 run_case pack-consumer-inert-is-refused "$case_root" 1
+
+case_root="$scratch/pack-consumer-custom-shell"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "        id: retain-release-attestation
+        shell: bash
+        env:" \
+  "        id: retain-release-attestation
+        shell: \"true {0}\"
+        env:"
+run_case pack-consumer-custom-shell-is-refused "$case_root" 1
 
 case_root="$scratch/pack-consumer-if-false"
 seed "$case_root"
@@ -598,6 +637,18 @@ if text.count(old) != 1:
 path.write_text(text.replace(old, new, 1), encoding="utf-8")
 PY
 run_case delegated-consumer-scalar-is-refused "$case_root" 1
+
+case_root="$scratch/delegated-consumer-custom-shell"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "        id: retain-proof-attestation
+        if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
+        shell: bash" \
+  "        id: retain-proof-attestation
+        if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
+        shell: \"true {0}\""
+run_case delegated-consumer-custom-shell-is-refused "$case_root" 1
 
 case_root="$scratch/pack-attest-if-false"
 seed "$case_root"
@@ -672,6 +723,7 @@ path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
 consumer = """      - name: Retain attestation bundle
         id: retain-release-attestation
+        shell: bash
         env:
           ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
         run: |

--- a/scripts/ci/test-actions-attest-lockstep.sh
+++ b/scripts/ci/test-actions-attest-lockstep.sh
@@ -295,6 +295,19 @@ jobs:
 YAML
 run_case foreign-workflow-callsite-is-refused "$case_root" 1
 
+case_root="$scratch/tag-pinned-foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/tagged-attest.yml" <<'YAML'
+name: Mutated tag-pinned actions/attest
+on: workflow_dispatch
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/attest@v4.2.2
+YAML
+run_case tag-pinned-foreign-workflow-is-refused "$case_root" 1
+
 case_root="$scratch/quoted-foreign-workflow"
 seed "$case_root"
 cat >"$case_root/.github/workflows/quoted-attest.yaml" <<YAML
@@ -421,6 +434,14 @@ mutate_once \
   ""
 run_case delete-pack-sha256sum-is-refused "$case_root" 1
 
+case_root="$scratch/comment-only-pack-sha256sum"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS" \
+  "            # sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS"
+run_case comment-only-pack-sha256sum-is-refused "$case_root" 1
+
 case_root="$scratch/retarget-delegated-proof-pack"
 seed "$case_root"
 mutate_once \
@@ -461,6 +482,27 @@ path.write_text(text.replace(old, new, 1), encoding="utf-8")
 PY
 run_case pack-consumer-comment-is-refused "$case_root" 1
 
+case_root="$scratch/pack-consumer-inert"
+seed "$case_root"
+python3 - "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = """        run: |
+          set -euo pipefail
+          test -n "$ATTESTATION_BUNDLE"
+          cp "$ATTESTATION_BUNDLE" release/attestation-bundle.json
+"""
+new = """        run: echo inert
+"""
+if text.count(old) != 1:
+    raise SystemExit("pack-consumer-inert subject missing")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+run_case pack-consumer-inert-is-refused "$case_root" 1
+
 case_root="$scratch/delegated-consumer-scalar"
 seed "$case_root"
 python3 - "$case_root/.github/workflows/runner-spike-delegated.yml" <<'PY'
@@ -500,6 +542,48 @@ mutate_once \
         if: false
         uses: actions/attest@${OWNER_SHA} # v4.2.2"
 run_case pack-attest-if-false-is-refused "$case_root" 1
+
+case_root="$scratch/pack-attest-if-compound-false"
+seed "$case_root"
+python3 - "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = """        id: attest
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+"""
+new = """        id: attest
+        if: ${{ false && always() }}
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+"""
+if text.count(old) != 1:
+    raise SystemExit("compound-false attest subject missing")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+run_case pack-attest-if-compound-false-is-refused "$case_root" 1
+
+case_root="$scratch/pack-attest-if-unsupported"
+seed "$case_root"
+python3 - "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = """        id: attest
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+"""
+new = """        id: attest
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+"""
+if text.count(old) != 1:
+    raise SystemExit("unsupported attest condition subject missing")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+run_case pack-attest-if-unsupported-is-refused "$case_root" 1
 
 case_root="$scratch/delegated-consumer-if-false"
 seed "$case_root"
@@ -552,6 +636,14 @@ cat >>"$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<YA
 NOTE: "actions/attest@${OWNER_SHA}"
 YAML
 run_case inert-note-attest-is-not-a-callsite "$case_root" 0
+
+case_root="$scratch/comment-only-control"
+seed "$case_root"
+cat >>"$case_root/.github/workflows/runner-spike-delegated.yml" <<'YAML'
+
+# No-op mutation control: executable producer and consumer steps are unchanged.
+YAML
+run_case comment-only-control-is-green "$case_root" 0
 
 case_root="$scratch/missing-ruby"
 seed "$case_root"

--- a/scripts/ci/test-actions-attest-lockstep.sh
+++ b/scripts/ci/test-actions-attest-lockstep.sh
@@ -588,6 +588,7 @@ text = path.read_text(encoding="utf-8")
 old = """      - name: Retain attestation bundle
         id: retain-release-attestation
         shell: bash
+        working-directory: ${{ github.workspace }}
         env:
           ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
         run: |
@@ -630,11 +631,25 @@ mutate_once \
   "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
   "        id: retain-release-attestation
         shell: bash
+        working-directory: \${{ github.workspace }}
         env:" \
   "        id: retain-release-attestation
         shell: \"true {0}\"
+        working-directory: \${{ github.workspace }}
         env:"
 run_case pack-consumer-custom-shell-is-refused "$case_root" 1
+
+case_root="$scratch/pack-consumer-cwd-retarget"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "        id: retain-release-attestation
+        shell: bash
+        working-directory: \${{ github.workspace }}" \
+  "        id: retain-release-attestation
+        shell: bash
+        working-directory: /tmp"
+run_case pack-consumer-cwd-retarget-is-refused "$case_root" 1
 
 case_root="$scratch/pack-consumer-extra-env"
 seed "$case_root"
@@ -677,6 +692,7 @@ old = """      - name: Retain delegated proof attestation bundle
         id: retain-proof-attestation
         if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
         shell: bash
+        working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
           cp "${{ steps.attest-proof-pack.outputs.bundle-path }}" \\
@@ -702,6 +718,20 @@ mutate_once \
         if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
         shell: \"true {0}\""
 run_case delegated-consumer-custom-shell-is-refused "$case_root" 1
+
+case_root="$scratch/delegated-consumer-cwd-retarget"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "        id: retain-proof-attestation
+        if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
+        shell: bash
+        working-directory: \${{ github.workspace }}" \
+  "        id: retain-proof-attestation
+        if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
+        shell: bash
+        working-directory: /tmp"
+run_case delegated-consumer-cwd-retarget-is-refused "$case_root" 1
 
 case_root="$scratch/delegated-consumer-step-env-retarget"
 seed "$case_root"
@@ -791,6 +821,7 @@ text = path.read_text(encoding="utf-8")
 consumer = """      - name: Retain attestation bundle
         id: retain-release-attestation
         shell: bash
+        working-directory: ${{ github.workspace }}
         env:
           ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
         run: |
@@ -842,6 +873,14 @@ cat >>"$case_root/.github/workflows/runner-spike-delegated.yml" <<'YAML'
 # ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD remains owned by the delegated job env.
 YAML
 run_case env-comment-only-control-is-green "$case_root" 0
+
+case_root="$scratch/cwd-comment-only-control"
+seed "$case_root"
+cat >>"$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<'YAML'
+
+# Retention commands remain explicitly workspace-bound.
+YAML
+run_case cwd-comment-only-control-is-green "$case_root" 0
 
 case_root="$scratch/missing-ruby"
 seed "$case_root"

--- a/scripts/ci/test-actions-attest-lockstep.sh
+++ b/scripts/ci/test-actions-attest-lockstep.sh
@@ -470,6 +470,20 @@ mutate_once \
         working-directory: release"
 run_case pack-producer-custom-shell-is-refused "$case_root" 1
 
+case_root="$scratch/pack-producer-extra-env"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "        id: build-release-checksums
+        shell: bash
+        working-directory: release" \
+  "        id: build-release-checksums
+        shell: bash
+        env:
+          INERT: value
+        working-directory: release"
+run_case pack-producer-extra-env-is-refused "$case_root" 1
+
 case_root="$scratch/pack-producer-never-called-function"
 seed "$case_root"
 mutate_once \
@@ -524,6 +538,36 @@ mutate_once \
         if: always()
         shell: \"true {0}\""
 run_case delegated-producer-custom-shell-is-refused "$case_root" 1
+
+case_root="$scratch/delegated-producer-extra-env"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "        id: build-proof-pack
+        if: always()
+        shell: bash" \
+  "        id: build-proof-pack
+        if: always()
+        shell: bash
+        env:
+          ASSAY_RUNNER_DELEGATED_PROOF_ROOT: /tmp"
+run_case delegated-producer-extra-env-is-refused "$case_root" 1
+
+case_root="$scratch/delegated-job-root-env-retarget"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  '      ASSAY_RUNNER_DELEGATED_PROOF_ROOT: /tmp/assay-runner-proof-${{ github.run_id }}' \
+  '      ASSAY_RUNNER_DELEGATED_PROOF_ROOT: /tmp'
+run_case delegated-job-root-env-retarget-is-refused "$case_root" 1
+
+case_root="$scratch/delegated-job-upload-env-retarget"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  '      ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD: ${{ github.workspace }}/assay-runner-proof-upload' \
+  '      ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD: /tmp'
+run_case delegated-job-upload-env-retarget-is-refused "$case_root" 1
 
 case_root="$scratch/delete-delegated-proof-pack"
 seed "$case_root"
@@ -592,6 +636,15 @@ mutate_once \
         env:"
 run_case pack-consumer-custom-shell-is-refused "$case_root" 1
 
+case_root="$scratch/pack-consumer-extra-env"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  '          ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}' \
+  '          ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+          INERT: value'
+run_case pack-consumer-extra-env-is-refused "$case_root" 1
+
 case_root="$scratch/pack-consumer-if-false"
 seed "$case_root"
 mutate_once \
@@ -649,6 +702,20 @@ mutate_once \
         if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
         shell: \"true {0}\""
 run_case delegated-consumer-custom-shell-is-refused "$case_root" 1
+
+case_root="$scratch/delegated-consumer-step-env-retarget"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "        id: retain-proof-attestation
+        if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
+        shell: bash" \
+  "        id: retain-proof-attestation
+        if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
+        shell: bash
+        env:
+          ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD: /tmp"
+run_case delegated-consumer-step-env-retarget-is-refused "$case_root" 1
 
 case_root="$scratch/pack-attest-if-false"
 seed "$case_root"
@@ -767,6 +834,14 @@ cat >>"$case_root/.github/workflows/runner-spike-delegated.yml" <<'YAML'
 # No-op mutation control: executable producer and consumer steps are unchanged.
 YAML
 run_case comment-only-control-is-green "$case_root" 0
+
+case_root="$scratch/env-comment-only-control"
+seed "$case_root"
+cat >>"$case_root/.github/workflows/runner-spike-delegated.yml" <<'YAML'
+
+# ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD remains owned by the delegated job env.
+YAML
+run_case env-comment-only-control-is-green "$case_root" 0
 
 case_root="$scratch/missing-ruby"
 seed "$case_root"

--- a/scripts/ci/test-actions-attest-lockstep.sh
+++ b/scripts/ci/test-actions-attest-lockstep.sh
@@ -253,6 +253,11 @@ seed "$case_root"
 printf '\n{ [ }\n' >>"$case_root/.github/workflows/privileged-mcp-action-pack-release.yml"
 run_case malformed-pack-is-refused "$case_root" 1
 
+case_root="$scratch/malformed-foreign-workflow"
+seed "$case_root"
+printf '{ [ }\n' >"$case_root/.github/workflows/malformed-foreign.yml"
+run_case malformed-foreign-workflow-is-refused "$case_root" 1
+
 case_root="$scratch/provenance-is-not-attest"
 seed "$case_root"
 cat >"$case_root/.github/workflows/release-wrapper.yml" <<'YAML'
@@ -307,6 +312,21 @@ jobs:
       - uses: actions/attest@v4.2.2
 YAML
 run_case tag-pinned-foreign-workflow-is-refused "$case_root" 1
+
+case_root="$scratch/alias-foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/alias-attest.yml" <<'YAML'
+name: Mutated alias actions/attest
+on: workflow_dispatch
+env:
+  ATTEST_ACTION: &attest-action actions/attest@v4.2.2
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: *attest-action
+YAML
+run_case alias-foreign-workflow-is-refused "$case_root" 1
 
 case_root="$scratch/quoted-foreign-workflow"
 seed "$case_root"
@@ -421,15 +441,36 @@ case_root="$scratch/retarget-pack-sha256sum"
 seed "$case_root"
 mutate_once \
   "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
-  "            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS" \
-  "            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > OTHERSUMS"
+  "          sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS" \
+  "          sha256sum privileged-mcp-action-v0-clean-room.tar.gz > OTHERSUMS"
 run_case retarget-pack-sha256sum-is-refused "$case_root" 1
+
+case_root="$scratch/pack-producer-if-false"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "        id: build-release-checksums
+        working-directory: release" \
+  "        id: build-release-checksums
+        if: false
+        working-directory: release"
+run_case pack-producer-if-false-is-refused "$case_root" 1
+
+case_root="$scratch/pack-producer-never-called-function"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "          sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS" \
+  "          make_checksums() {
+            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS
+          }"
+run_case pack-producer-never-called-function-is-refused "$case_root" 1
 
 case_root="$scratch/delete-pack-sha256sum"
 seed "$case_root"
 mutate_once \
   "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
-  "            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS
+  "          sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS
 " \
   ""
 run_case delete-pack-sha256sum-is-refused "$case_root" 1
@@ -438,8 +479,8 @@ case_root="$scratch/comment-only-pack-sha256sum"
 seed "$case_root"
 mutate_once \
   "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
-  "            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS" \
-  "            # sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS"
+  "          sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS" \
+  "          # sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS"
 run_case comment-only-pack-sha256sum-is-refused "$case_root" 1
 
 case_root="$scratch/retarget-delegated-proof-pack"
@@ -449,6 +490,14 @@ mutate_once \
   "          python3 scripts/ci/assay_runner_delegated_proof_pack.py \\" \
   "          python3 scripts/ci/other_delegated_proof_pack.py \\"
 run_case retarget-delegated-proof-pack-is-refused "$case_root" 1
+
+case_root="$scratch/delegated-producer-help"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "          python3 scripts/ci/assay_runner_delegated_proof_pack.py \\" \
+  "          python3 scripts/ci/assay_runner_delegated_proof_pack.py --help \\"
+run_case delegated-producer-help-is-refused "$case_root" 1
 
 case_root="$scratch/delete-delegated-proof-pack"
 seed "$case_root"
@@ -467,6 +516,7 @@ import sys
 path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
 old = """      - name: Retain attestation bundle
+        id: retain-release-attestation
         env:
           ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
         run: |
@@ -503,6 +553,26 @@ path.write_text(text.replace(old, new, 1), encoding="utf-8")
 PY
 run_case pack-consumer-inert-is-refused "$case_root" 1
 
+case_root="$scratch/pack-consumer-if-false"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  '          cp "$ATTESTATION_BUNDLE" release/attestation-bundle.json' \
+  '          if false; then
+            cp "$ATTESTATION_BUNDLE" release/attestation-bundle.json
+          fi'
+run_case pack-consumer-if-false-is-refused "$case_root" 1
+
+case_root="$scratch/pack-consumer-never-called-function"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  '          cp "$ATTESTATION_BUNDLE" release/attestation-bundle.json' \
+  '          retain_bundle() {
+            cp "$ATTESTATION_BUNDLE" release/attestation-bundle.json
+          }'
+run_case pack-consumer-never-called-function-is-refused "$case_root" 1
+
 case_root="$scratch/delegated-consumer-scalar"
 seed "$case_root"
 python3 - "$case_root/.github/workflows/runner-spike-delegated.yml" <<'PY'
@@ -512,16 +582,13 @@ import sys
 path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
 old = """      - name: Retain delegated proof attestation bundle
+        id: retain-proof-attestation
         if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
         shell: bash
         run: |
           set -euo pipefail
           cp "${{ steps.attest-proof-pack.outputs.bundle-path }}" \\
             "$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD/attestation-bundle.json"
-          {
-            echo "- attestation-bundle: assay-runner-proof-upload/attestation-bundle.json"
-            echo "- attestation-url: ${{ steps.attest-proof-pack.outputs.attestation-url }}"
-          } >> "$GITHUB_STEP_SUMMARY"
 """
 new = """      - name: Retain delegated proof attestation bundle
         NOTE: steps.attest-proof-pack.outputs.bundle-path
@@ -589,8 +656,10 @@ case_root="$scratch/delegated-consumer-if-false"
 seed "$case_root"
 mutate_once \
   "$case_root/.github/workflows/runner-spike-delegated.yml" \
-  "        if: always() && steps.attest-proof-pack.outputs.bundle-path != ''" \
-  "        if: false"
+  "        id: retain-proof-attestation
+        if: always() && steps.attest-proof-pack.outputs.bundle-path != ''" \
+  "        id: retain-proof-attestation
+        if: false"
 run_case delegated-consumer-if-false-is-refused "$case_root" 1
 
 case_root="$scratch/pack-consumer-other-job"
@@ -602,6 +671,7 @@ import sys
 path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
 consumer = """      - name: Retain attestation bundle
+        id: retain-release-attestation
         env:
           ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
         run: |
@@ -618,6 +688,7 @@ text += """
     runs-on: ubuntu-24.04
     steps:
       - name: Retain attestation bundle
+        id: retain-release-attestation
         env:
           ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
         run: |

--- a/scripts/ci/test-actions-attest-lockstep.sh
+++ b/scripts/ci/test-actions-attest-lockstep.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# Mutation battery for the closed two-workflow actions/attest pin set.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="scripts/ci/check-actions-attest-lockstep.py"
+PRECOMMIT=".pre-commit-config.yaml"
+WORKFLOWS=(
+  .github/workflows/runner-spike-delegated.yml
+  .github/workflows/privileged-mcp-action-pack-release.yml
+)
+OWNER_SHA="1e69f48acb82d1966a394da916b4c1698aa569d6"
+DRIFT_SHA="d1ba80a13dd99fba24a470575428917156a28b43"
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+seed() {
+  local dest="$1" path
+  mkdir -p "$dest/scripts/ci" "$dest/.github/workflows"
+  cp "$ROOT/$CHECKER" "$dest/$CHECKER"
+  cp "$ROOT/$PRECOMMIT" "$dest/$PRECOMMIT"
+  for path in "${WORKFLOWS[@]}"; do
+    cp "$ROOT/$path" "$dest/$path"
+  done
+}
+
+check_hook_scope() {
+  local root="$1"
+  python3 - "$root/$PRECOMMIT" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+if "- id: actions-attest-lockstep" not in text:
+    raise SystemExit("actions/attest lockstep hook is missing")
+block = text.split("- id: actions-attest-lockstep", 1)[1].split("\n      - id:", 1)[0]
+match = re.search(r"^[ \t]*files:[ \t]*(.+)$", block, re.MULTILINE)
+if match is None:
+    raise SystemExit("actions/attest lockstep hook has no files selector")
+pattern = match.group(1).strip()
+required = (
+    ".github/workflows/third-attest.yml",
+    ".github/workflows/third-attest.yaml",
+    "scripts/ci/check-actions-attest-lockstep.py",
+    "scripts/ci/test-actions-attest-lockstep.sh",
+    ".pre-commit-config.yaml",
+)
+missing = [path for path in required if re.search(pattern, path) is None]
+if missing:
+    raise SystemExit(f"actions/attest lockstep hook does not trigger for: {', '.join(missing)}")
+PY
+}
+
+run_hook_scope_case() {
+  local name="$1" root="$2" expected="$3" status=0
+  check_hook_scope "$root" >"$scratch/$name.log" 2>&1 || status=$?
+  if [[ "$status" -ne "$expected" ]]; then
+    cat "$scratch/$name.log" >&2
+    echo "FAIL: $name exited $status, wanted $expected" >&2
+    exit 1
+  fi
+  echo "ok    $name (exit $status)"
+}
+
+run_case() {
+  local name="$1" root="$2" expected="$3" status=0
+  (cd "$root" && python3 "$CHECKER") >"$scratch/$name.log" 2>&1 || status=$?
+  if [[ "$status" -ne "$expected" ]]; then
+    cat "$scratch/$name.log" >&2
+    echo "FAIL: $name exited $status, wanted $expected" >&2
+    exit 1
+  fi
+  echo "ok    $name (exit $status)"
+}
+
+mutate_once() {
+  local path="$1" old="$2" new="$3"
+  python3 - "$path" "$old" "$new" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+old, new = sys.argv[2], sys.argv[3]
+text = path.read_text(encoding="utf-8")
+if text.count(old) != 1:
+    raise SystemExit(f"mutation subject count is {text.count(old)}, want 1: {old}")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+}
+
+case_root="$scratch/control"
+seed "$case_root"
+run_case control-is-green "$case_root" 0
+run_hook_scope_case hook-scope-covers-all-workflows "$case_root" 0
+
+case_root="$scratch/narrow-hook-scope"
+seed "$case_root"
+mutate_once \
+  "$case_root/$PRECOMMIT" \
+  'files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$' \
+  'files: ^(\.github/workflows/(runner-spike-delegated|privileged-mcp-action-pack-release)\.yml|scripts/ci/(check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$'
+run_hook_scope_case narrow-hook-scope-is-refused "$case_root" 1
+
+case_root="$scratch/missing-hook"
+seed "$case_root"
+python3 - "$case_root/$PRECOMMIT" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+start = text.find("      - id: actions-attest-lockstep")
+if start < 0:
+    raise SystemExit("hook block missing")
+end = text.find("      - id:", start + 1)
+if end < 0:
+    raise SystemExit("next hook id missing")
+path.write_text(text[:start] + text[end:], encoding="utf-8")
+PY
+run_hook_scope_case missing-hook-is-refused "$case_root" 1
+
+case_root="$scratch/one-laggard"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "$OWNER_SHA" \
+  "$DRIFT_SHA"
+run_case one-laggard-is-refused "$case_root" 1
+
+case_root="$scratch/tag-drift"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "# v4.2.2" \
+  "# v4.2.1"
+run_case tag-drift-is-refused "$case_root" 1
+
+case_root="$scratch/retarget-delegated-subject"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "          subject-checksums: assay-runner-proof-upload/subject-checksums.txt" \
+  "          subject-checksums: assay-runner-proof-upload/retargeted-checksums.txt"
+run_case retarget-delegated-subject-is-refused "$case_root" 1
+
+case_root="$scratch/retarget-pack-subject"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "subject-checksums: release/SHA256SUMS" \
+  "subject-checksums: release/OTHERSUMS"
+run_case retarget-pack-subject-is-refused "$case_root" 1
+
+case_root="$scratch/delete-delegated-subject"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "          subject-checksums: assay-runner-proof-upload/subject-checksums.txt
+" \
+  ""
+run_case delete-delegated-subject-is-refused "$case_root" 1
+
+case_root="$scratch/delete-pack-subject"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "          subject-checksums: release/SHA256SUMS
+" \
+  ""
+run_case delete-pack-subject-is-refused "$case_root" 1
+
+case_root="$scratch/unwired-with"
+seed "$case_root"
+python3 - "$case_root/.github/workflows/runner-spike-delegated.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = """        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-checksums: assay-runner-proof-upload/subject-checksums.txt
+          show-summary: true
+"""
+new = """        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+"""
+if text.count(old) != 1:
+    raise SystemExit("unwired-with subject missing")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+run_case sha-only-unwired-with-is-refused "$case_root" 1
+
+case_root="$scratch/remove-delegated-uses"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "        uses: actions/attest@${OWNER_SHA} # v4.2.2" \
+  "        run: echo bypassed-attest"
+run_case remove-delegated-uses-is-refused "$case_root" 1
+
+case_root="$scratch/remove-pack-uses"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "        uses: actions/attest@${OWNER_SHA} # v4.2.2" \
+  "        run: echo bypassed-attest"
+run_case remove-pack-uses-is-refused "$case_root" 1
+
+case_root="$scratch/remove-delegated-workflow"
+seed "$case_root"
+rm "$case_root/.github/workflows/runner-spike-delegated.yml"
+run_case remove-delegated-workflow-is-refused "$case_root" 1
+
+case_root="$scratch/remove-pack-workflow"
+seed "$case_root"
+rm "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml"
+run_case remove-pack-workflow-is-refused "$case_root" 1
+
+case_root="$scratch/malformed-delegated"
+seed "$case_root"
+printf '\n{ [ }\n' >>"$case_root/.github/workflows/runner-spike-delegated.yml"
+run_case malformed-delegated-is-refused "$case_root" 1
+
+case_root="$scratch/malformed-pack"
+seed "$case_root"
+printf '\n{ [ }\n' >>"$case_root/.github/workflows/privileged-mcp-action-pack-release.yml"
+run_case malformed-pack-is-refused "$case_root" 1
+
+case_root="$scratch/provenance-is-not-attest"
+seed "$case_root"
+cat >"$case_root/.github/workflows/release-wrapper.yml" <<'YAML'
+name: Wrapper is a different action
+on: workflow_dispatch
+jobs:
+  provenance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+YAML
+run_case provenance-wrapper-is-not-a-callsite "$case_root" 0
+
+case_root="$scratch/extra-callsite"
+seed "$case_root"
+cat >>"$case_root/.github/workflows/runner-spike-delegated.yml" <<YAML
+
+# Mutation: a second active attest is outside the closed one-callsite contract.
+uses: actions/attest@${OWNER_SHA} # v4.2.2
+YAML
+run_case extra-callsite-is-refused "$case_root" 1
+
+case_root="$scratch/quoted-duplicate"
+seed "$case_root"
+cat >>"$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<YAML
+
+# Mutation: quoted uses values are valid workflow YAML and remain active.
+uses: "actions/attest@${OWNER_SHA}" # v4.2.2
+YAML
+run_case quoted-duplicate-is-refused "$case_root" 1
+
+case_root="$scratch/foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/third-attest.yml" <<YAML
+name: Mutated third actions/attest
+jobs:
+  attest:
+    steps:
+      - uses: actions/attest@${OWNER_SHA} # v4.2.2
+YAML
+run_case foreign-workflow-callsite-is-refused "$case_root" 1
+
+case_root="$scratch/quoted-foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/quoted-attest.yaml" <<YAML
+name: Mutated quoted actions/attest
+jobs:
+  attest:
+    steps:
+      - uses: 'actions/attest@${OWNER_SHA}' # v4.2.2
+YAML
+run_case quoted-foreign-workflow-callsite-is-refused "$case_root" 1
+
+case_root="$scratch/flow-mapping-foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/flow-attest.yml" <<YAML
+name: Mutated flow-mapping actions/attest
+on: workflow_dispatch
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - {uses: actions/attest@${OWNER_SHA}}
+YAML
+run_case flow-mapping-foreign-workflow-is-refused "$case_root" 1
+
+case_root="$scratch/quoted-key-foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/quoted-key-attest.yml" <<YAML
+name: Mutated quoted-key actions/attest
+on: workflow_dispatch
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - "uses": actions/attest@${OWNER_SHA}
+YAML
+run_case quoted-key-foreign-workflow-is-refused "$case_root" 1
+
+case_root="$scratch/hex-escaped-action"
+seed "$case_root"
+cat >"$case_root/.github/workflows/hex-escaped-attest.yml" <<YAML
+name: Mutated hex-escaped actions/attest
+on: workflow_dispatch
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/attest\\x40${OWNER_SHA}"
+YAML
+run_case hex-escaped-action-is-refused "$case_root" 1
+
+case_root="$scratch/unicode-escaped-action"
+seed "$case_root"
+cat >"$case_root/.github/workflows/unicode-escaped-attest.yml" <<YAML
+name: Mutated Unicode-escaped actions/attest
+on: workflow_dispatch
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/attest\\u0040${OWNER_SHA}"
+YAML
+run_case unicode-escaped-action-is-refused "$case_root" 1
+
+case_root="$scratch/case-variant-action"
+seed "$case_root"
+cat >"$case_root/.github/workflows/case-variant-attest.yml" <<YAML
+name: Mutated case-variant actions/attest
+on: workflow_dispatch
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions/attest@${OWNER_SHA}
+YAML
+run_case case-variant-action-is-refused "$case_root" 1
+
+case_root="$scratch/unicode-escaped-identity"
+seed "$case_root"
+cat >"$case_root/.github/workflows/unicode-identity-attest.yml" <<YAML
+name: Mutated Unicode-escaped actions/attest identity
+on: workflow_dispatch
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "\\u0061ctions/attest@${OWNER_SHA}"
+YAML
+run_case unicode-escaped-identity-is-refused "$case_root" 1
+
+case_root="$scratch/escaped-line-break-action"
+seed "$case_root"
+python3 - "$case_root/.github/workflows/escaped-break-attest.yml" "$OWNER_SHA" <<'PY'
+from pathlib import Path
+import sys
+
+sha = sys.argv[2]
+Path(sys.argv[1]).write_text(
+    "name: Mutated escaped-line-break actions/attest\n"
+    "on: workflow_dispatch\n"
+    "jobs:\n"
+    "  attest:\n"
+    "    runs-on: ubuntu-latest\n"
+    "    steps:\n"
+    f'      - uses: "actions/att\\\n          est@{sha}"\n',
+    encoding="utf-8",
+)
+PY
+run_case escaped-line-break-action-is-refused "$case_root" 1
+
+printf 'PASS: actions/attest lockstep battery\n'

--- a/scripts/ci/test-actions-attest-lockstep.sh
+++ b/scripts/ci/test-actions-attest-lockstep.sh
@@ -11,6 +11,8 @@ WORKFLOWS=(
 )
 OWNER_SHA="1e69f48acb82d1966a394da916b4c1698aa569d6"
 DRIFT_SHA="d1ba80a13dd99fba24a470575428917156a28b43"
+HOOK_ENTRY="bash scripts/ci/test-actions-attest-lockstep.sh"
+HOOK_FILES='^(\.github/workflows/.*\.ya?ml|scripts/ci/(assay_runner_delegated_proof_pack\.py|check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$'
 
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
@@ -27,22 +29,37 @@ seed() {
 
 check_hook_scope() {
   local root="$1"
-  python3 - "$root/$PRECOMMIT" <<'PY'
+  python3 - "$root/$PRECOMMIT" "$HOOK_ENTRY" "$HOOK_FILES" <<'PY'
 import re
 import sys
 from pathlib import Path
 
 text = Path(sys.argv[1]).read_text(encoding="utf-8")
+expected_entry = sys.argv[2]
+expected_files = sys.argv[3]
 if "- id: actions-attest-lockstep" not in text:
     raise SystemExit("actions/attest lockstep hook is missing")
 block = text.split("- id: actions-attest-lockstep", 1)[1].split("\n      - id:", 1)[0]
+entry_match = re.search(r"^[ \t]*entry:[ \t]*(.+)$", block, re.MULTILINE)
+if entry_match is None:
+    raise SystemExit("actions/attest lockstep hook has no entry")
+entry = entry_match.group(1).strip()
+if entry != expected_entry:
+    raise SystemExit(
+        f"actions/attest lockstep hook entry {entry!r}, want {expected_entry!r}"
+    )
 match = re.search(r"^[ \t]*files:[ \t]*(.+)$", block, re.MULTILINE)
 if match is None:
     raise SystemExit("actions/attest lockstep hook has no files selector")
 pattern = match.group(1).strip()
+if pattern != expected_files:
+    raise SystemExit(
+        f"actions/attest lockstep hook files {pattern!r}, want {expected_files!r}"
+    )
 required = (
     ".github/workflows/third-attest.yml",
     ".github/workflows/third-attest.yaml",
+    "scripts/ci/assay_runner_delegated_proof_pack.py",
     "scripts/ci/check-actions-attest-lockstep.py",
     "scripts/ci/test-actions-attest-lockstep.sh",
     ".pre-commit-config.yaml",
@@ -95,12 +112,20 @@ seed "$case_root"
 run_case control-is-green "$case_root" 0
 run_hook_scope_case hook-scope-covers-all-workflows "$case_root" 0
 
+case_root="$scratch/hook-entry-true"
+seed "$case_root"
+mutate_once \
+  "$case_root/$PRECOMMIT" \
+  "        entry: ${HOOK_ENTRY}" \
+  "        entry: true"
+run_hook_scope_case hook-entry-true-is-refused "$case_root" 1
+
 case_root="$scratch/narrow-hook-scope"
 seed "$case_root"
 mutate_once \
   "$case_root/$PRECOMMIT" \
-  'files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$' \
-  'files: ^(\.github/workflows/(runner-spike-delegated|privileged-mcp-action-pack-release)\.yml|scripts/ci/(check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$'
+  "files: ${HOOK_FILES}" \
+  'files: ^(\.github/workflows/(runner-spike-delegated|privileged-mcp-action-pack-release)\.yml|scripts/ci/(assay_runner_delegated_proof_pack\.py|check-actions-attest-lockstep\.py|test-actions-attest-lockstep\.sh)|\.pre-commit-config\.yaml)$'
 run_hook_scope_case narrow-hook-scope-is-refused "$case_root" 1
 
 case_root="$scratch/missing-hook"
@@ -378,5 +403,177 @@ Path(sys.argv[1]).write_text(
 )
 PY
 run_case escaped-line-break-action-is-refused "$case_root" 1
+
+case_root="$scratch/retarget-pack-sha256sum"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS" \
+  "            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > OTHERSUMS"
+run_case retarget-pack-sha256sum-is-refused "$case_root" 1
+
+case_root="$scratch/delete-pack-sha256sum"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS
+" \
+  ""
+run_case delete-pack-sha256sum-is-refused "$case_root" 1
+
+case_root="$scratch/retarget-delegated-proof-pack"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "          python3 scripts/ci/assay_runner_delegated_proof_pack.py \\" \
+  "          python3 scripts/ci/other_delegated_proof_pack.py \\"
+run_case retarget-delegated-proof-pack-is-refused "$case_root" 1
+
+case_root="$scratch/delete-delegated-proof-pack"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "          python3 scripts/ci/assay_runner_delegated_proof_pack.py \\" \
+  "          true \\"
+run_case delete-delegated-proof-pack-is-refused "$case_root" 1
+
+case_root="$scratch/pack-consumer-comment"
+seed "$case_root"
+python3 - "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = """      - name: Retain attestation bundle
+        env:
+          ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+          test -n "$ATTESTATION_BUNDLE"
+          cp "$ATTESTATION_BUNDLE" release/attestation-bundle.json
+"""
+new = """      # Retain attestation bundle via steps.attest.outputs.bundle-path
+"""
+if text.count(old) != 1:
+    raise SystemExit("pack-consumer-comment subject missing")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+run_case pack-consumer-comment-is-refused "$case_root" 1
+
+case_root="$scratch/delegated-consumer-scalar"
+seed "$case_root"
+python3 - "$case_root/.github/workflows/runner-spike-delegated.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = """      - name: Retain delegated proof attestation bundle
+        if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp "${{ steps.attest-proof-pack.outputs.bundle-path }}" \\
+            "$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD/attestation-bundle.json"
+          {
+            echo "- attestation-bundle: assay-runner-proof-upload/attestation-bundle.json"
+            echo "- attestation-url: ${{ steps.attest-proof-pack.outputs.attestation-url }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+"""
+new = """      - name: Retain delegated proof attestation bundle
+        NOTE: steps.attest-proof-pack.outputs.bundle-path
+"""
+if text.count(old) != 1:
+    raise SystemExit("delegated-consumer-scalar subject missing")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+run_case delegated-consumer-scalar-is-refused "$case_root" 1
+
+case_root="$scratch/pack-attest-if-false"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "        id: attest
+        uses: actions/attest@${OWNER_SHA} # v4.2.2" \
+  "        id: attest
+        if: false
+        uses: actions/attest@${OWNER_SHA} # v4.2.2"
+run_case pack-attest-if-false-is-refused "$case_root" 1
+
+case_root="$scratch/delegated-consumer-if-false"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "        if: always() && steps.attest-proof-pack.outputs.bundle-path != ''" \
+  "        if: false"
+run_case delegated-consumer-if-false-is-refused "$case_root" 1
+
+case_root="$scratch/pack-consumer-other-job"
+seed "$case_root"
+python3 - "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+consumer = """      - name: Retain attestation bundle
+        env:
+          ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+          test -n "$ATTESTATION_BUNDLE"
+          cp "$ATTESTATION_BUNDLE" release/attestation-bundle.json
+
+"""
+if text.count(consumer) != 1:
+    raise SystemExit("pack-consumer-other-job subject missing")
+text = text.replace(consumer, "", 1)
+text += """
+  retain-elsewhere:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Retain attestation bundle
+        env:
+          ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+          test -n "$ATTESTATION_BUNDLE"
+          cp "$ATTESTATION_BUNDLE" release/attestation-bundle.json
+"""
+path.write_text(text, encoding="utf-8")
+PY
+run_case pack-consumer-other-job-is-refused "$case_root" 1
+
+case_root="$scratch/inert-note-census"
+seed "$case_root"
+cat >>"$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<YAML
+
+NOTE: "actions/attest@${OWNER_SHA}"
+YAML
+run_case inert-note-attest-is-not-a-callsite "$case_root" 0
+
+case_root="$scratch/missing-ruby"
+seed "$case_root"
+norb="$scratch/norb/bin"
+mkdir -p "$norb"
+ln -sfn "$(command -v python3)" "$norb/python3"
+if PATH="$norb" command -v ruby >/dev/null 2>&1; then
+  echo "FAIL: ruby-free PATH still locates ruby" >&2
+  exit 1
+fi
+status=0
+(cd "$case_root" && PATH="$norb" python3 "$CHECKER") >"$scratch/missing-ruby.log" 2>&1 || status=$?
+if [[ "$status" -ne 1 ]]; then
+  cat "$scratch/missing-ruby.log" >&2
+  echo "FAIL: missing-ruby exited $status, wanted 1" >&2
+  exit 1
+fi
+if ! grep -q "yaml parser unavailable" "$scratch/missing-ruby.log"; then
+  cat "$scratch/missing-ruby.log" >&2
+  echo "FAIL: missing-ruby did not fail-closed on parser unavailability" >&2
+  exit 1
+fi
+echo "ok    missing-ruby-is-refused (exit $status)"
 
 printf 'PASS: actions/attest lockstep battery\n'

--- a/scripts/ci/test-actions-attest-lockstep.sh
+++ b/scripts/ci/test-actions-attest-lockstep.sh
@@ -800,6 +800,36 @@ path.write_text(text.replace(old, new, 1), encoding="utf-8")
 PY
 run_case pack-attest-if-unsupported-is-refused "$case_root" 1
 
+case_root="$scratch/pack-attest-id-shadow"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "      - name: Retain attestation bundle
+        id: retain-release-attestation" \
+  '      - name: Shadow release attestation output
+        id: attest
+        shell: bash
+        run: echo "bundle-path=/tmp/fake-bundle.json" >> "$GITHUB_OUTPUT"
+
+      - name: Retain attestation bundle
+        id: retain-release-attestation'
+run_case pack-attest-id-shadow-is-refused "$case_root" 1
+
+case_root="$scratch/delegated-attest-id-shadow"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/runner-spike-delegated.yml" \
+  "      - name: Retain delegated proof attestation bundle
+        id: retain-proof-attestation" \
+  '      - name: Shadow delegated attestation output
+        id: attest-proof-pack
+        shell: bash
+        run: echo "bundle-path=/tmp/fake-bundle.json" >> "$GITHUB_OUTPUT"
+
+      - name: Retain delegated proof attestation bundle
+        id: retain-proof-attestation'
+run_case delegated-attest-id-shadow-is-refused "$case_root" 1
+
 case_root="$scratch/delegated-consumer-if-false"
 seed "$case_root"
 mutate_once \
@@ -881,6 +911,21 @@ cat >>"$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" <<'Y
 # Retention commands remain explicitly workspace-bound.
 YAML
 run_case cwd-comment-only-control-is-green "$case_root" 0
+
+case_root="$scratch/unrelated-unique-step-id-control"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/privileged-mcp-action-pack-release.yml" \
+  "      - name: Retain attestation bundle
+        id: retain-release-attestation" \
+  '      - name: Emit unrelated output
+        id: unrelated-output
+        shell: bash
+        run: echo "value=irrelevant" >> "$GITHUB_OUTPUT"
+
+      - name: Retain attestation bundle
+        id: retain-release-attestation'
+run_case unrelated-unique-step-id-control-is-green "$case_root" 0
 
 case_root="$scratch/missing-ruby"
 seed "$case_root"


### PR DESCRIPTION
## Summary

This is the bounded successor to draft #2742. It preserves Cursor's five-file implementation, integrates current `main` (including #2746), and closes independently reproduced false-greens before any new delegated proof is dispatched.

- enforces one exact SHA/tag pair across the two owned direct `actions/attest` producers;
- binds each subject to an earlier same-job, reachable producer with exact shell, environment, working directory, and command sequence;
- binds each returned bundle to a later same-job, reachable retention step with exact shell, environment, working directory, condition, and command sequence;
- pins the delegated job environment values that route proof input and retained output;
- rejects every additional direct `actions/attest@REF` callsite, including aliases and tag refs;
- fails closed on malformed workflow YAML and statically false or unsupported condition grammar.

Closes #2474.

## Provenance

- Cursor source head: `e4eb6e9dbc334348747479ed8a4530c7a2f3dd9d`
- current base merged before repair: `48976ba8d3c3e2288b31229a073d7380b9c1eb6c`
- final candidate head: `eb0143662fbc28de74a0529310b4db8a552a9d7d`
- three-dot scope remains exactly the five files from #2742.

## RED -> GREEN

All listed mutations were measured false-green before their corresponding repair and are refused on the final head:

1. third workflow with a tag-pinned or aliased `actions/attest` callsite;
2. malformed non-producer workflow;
3. attest step guarded by `${{ false && always() }}`;
4. producer step guarded by `if: false`;
5. producer command moved into an uncalled function or changed to `--help`;
6. retention command guarded by `if false` or moved into an uncalled function;
7. producer or retention step changed to a no-op custom shell (`true {0}`);
8. delegated proof ROOT or UPLOAD job environment retargeted;
9. delegated retention step environment retargeted to `/tmp`;
10. unexpected producer/consumer step environment added;
11. either retention consumer working directory retargeted to `/tmp`;
12. a second same-job step reusing either attestation step ID and shadowing output ownership.

Comment-only and unrelated unique-step controls remain green. Unsupported condition grammar, missing Ruby/YAML parser, extra callsites, malformed YAML, and duplicate attestation step IDs fail closed. Actionlint independently rejects duplicate step IDs; the lockstep guard does not depend on that additional lint layer.

## Verification

At `eb0143662fbc28de74a0529310b4db8a552a9d7d`:

- official actions/attest mutation battery: pass;
- direct checker: exactly two correct SHA-pinned callsites;
- both changed workflows: actionlint pass;
- Python compile, Bash 3.2 syntax, repo shellcheck hook (`-x -S warning`), `cargo fmt --check`, and `git diff --check`: pass;
- full pre-push hook catalogue: pass;
- workspace clippy with warnings denied: pass;
- Linux cross-target compile gate: pass.

A bounded-stdin 50 ms timing case flaked once during local iteration; its immediate rerun and both later pre-push runs passed. It is not used as evidence for this lockstep contract.

## Proof plan

Do not carry prior run `33560985521`; it is bound to a stale head. After this exact head is independently reviewed and frozen, dispatch `Runner Spike Delegated` on this branch/head with `gates=all`, `build_ebpf=true`. Require all five Gate steps and the attested proof pack to bind to this SHA before `lane-check/proof` can pass.

## Non-claims

- no proof or review from a prior head is carried;
- no general GitHub-expression, YAML, shell, or environment evaluator is claimed;
- no protection against arbitrary PATH/tool shadowing is claimed;
- no upstream `actions/attest` runtime or publication claim;
- no merge, release, or product-security-effectiveness claim.
