### PR TITLE
fix(docs): pin Claude Code plugin install recipe to published CLI/MCP version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1091,14 +1091,6 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Editor-release hook pre-commit consumer
-        shell: bash
-        run: |
-          set -euo pipefail
-          python -m pip install --user pre-commit==4.4.0
-          export PATH="$HOME/.local/bin:$PATH"
-          bash scripts/ci/test-editor-release-hook-precommit-consumer.sh
-
       - name: Verify CI hardening contracts
         shell: bash
         env:
@@ -1121,6 +1113,14 @@ jobs:
           set -euo pipefail
           python3 scripts/ci/check-ci-gate-coverage.py
           python3 scripts/ci/check-conformance-inventory-callsite.py
+
+      - name: Editor-release hook pre-commit consumer
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --user pre-commit==4.4.0
+          export PATH="$HOME/.local/bin:$PATH"
+          bash scripts/ci/test-editor-release-hook-precommit-consumer.sh
 
       - name: Verify review-record workflow contract
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1091,6 +1091,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Editor-release hook pre-commit consumer
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --user pre-commit==4.4.0
+          export PATH="$HOME/.local/bin:$PATH"
+          bash scripts/ci/test-editor-release-hook-precommit-consumer.sh
+
       - name: Verify CI hardening contracts
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1114,6 +1114,12 @@ jobs:
           python3 scripts/ci/check-ci-gate-coverage.py
           python3 scripts/ci/check-conformance-inventory-callsite.py
 
+      - name: Verify review-record workflow contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check-review-record-workflow.py
+
       - name: Editor-release hook pre-commit consumer
         shell: bash
         run: |
@@ -1121,12 +1127,6 @@ jobs:
           python -m pip install --user pre-commit==4.4.0
           export PATH="$HOME/.local/bin:$PATH"
           bash scripts/ci/test-editor-release-hook-precommit-consumer.sh
-
-      - name: Verify review-record workflow contract
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 scripts/ci/check-review-record-workflow.py
 
       - name: Evaluate required job results
         env:

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -135,12 +135,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install pre-commit==4.4.0
 
-      - name: Editor-release hook pre-commit consumer
-        shell: bash
-        run: |
-          set -euo pipefail
-          bash scripts/ci/test-editor-release-hook-precommit-consumer.sh
-
       - name: Install cargo-deny (for pre-commit hook)
         run: ./scripts/ci/install-cargo-deny.sh
 

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -135,6 +135,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install pre-commit==4.4.0
 
+      - name: Editor-release hook pre-commit consumer
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/test-editor-release-hook-precommit-consumer.sh
+
       - name: Install cargo-deny (for pre-commit hook)
         run: ./scripts/ci/install-cargo-deny.sh
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -509,15 +509,26 @@ repos:
         files: ^(scripts/ci/((check|test-check)-editor-mcp-recipe-truth|lib/editor-plugin-install-commands|test-editor-plugin-install-commands|test-editor-release-hook-precommit-consumer)\.sh|docs/guides/editor-mcp-recipe\.md|\.pre-commit-config\.yaml)$
 
 
+      - id: editor-release-hook-precommit-producer
+        name: Editor and release-surface pre-commit producer
+        entry: bash scripts/ci/test-editor-release-hook-precommit-consumer.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        # Independent runner for the consumer contract. A last-key-wins
+        # entry: 'true' on editor-release-hook-precommit-consumer cannot
+        # skip this invocation.
+
       - id: editor-release-hook-precommit-consumer
         name: Editor and release-surface pre-commit consumer contract
         entry: bash scripts/ci/test-editor-release-hook-precommit-consumer.sh
         language: system
         pass_filenames: false
         always_run: true
-        # Independently owns hook wiring for editor-mcp-recipe-truth and
-        # release-surface. A last-key-wins files: ^$ skip or entry: 'true'
-        # bypass on those hooks cannot hide this contract.
+        # Owns hook wiring for editor-mcp-recipe-truth and release-surface.
+        # IDs are counted from semantic YAML (flow mapping, reordered keys,
+        # duplicate keys). The producer hook invokes this same contract
+        # independently so this hook's own entry cannot be no-op'd unnoticed.
 
       - id: ci-gate-expectations-self-test
         name: CI gate expectation contract

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -509,26 +509,17 @@ repos:
         files: ^(scripts/ci/((check|test-check)-editor-mcp-recipe-truth|lib/editor-plugin-install-commands|test-editor-plugin-install-commands|test-editor-release-hook-precommit-consumer)\.sh|docs/guides/editor-mcp-recipe\.md|\.pre-commit-config\.yaml)$
 
 
-      - id: editor-release-hook-precommit-producer
-        name: Editor and release-surface pre-commit producer
-        entry: bash scripts/ci/test-editor-release-hook-precommit-consumer.sh
-        language: system
-        pass_filenames: false
-        always_run: true
-        # Independent runner for the consumer contract. A last-key-wins
-        # entry: 'true' on editor-release-hook-precommit-consumer cannot
-        # skip this invocation.
-
       - id: editor-release-hook-precommit-consumer
         name: Editor and release-surface pre-commit consumer contract
         entry: bash scripts/ci/test-editor-release-hook-precommit-consumer.sh
         language: system
         pass_filenames: false
         always_run: true
-        # Owns hook wiring for editor-mcp-recipe-truth and release-surface.
-        # IDs are counted from semantic YAML (flow mapping, reordered keys,
-        # duplicate keys). The producer hook invokes this same contract
-        # independently so this hook's own entry cannot be no-op'd unnoticed.
+        stages: [pre-push]
+        # Local feedback only. Required CI (ci.yml job named CI) invokes this
+        # script directly; a last-key-wins entry: 'true' here cannot skip that.
+        # stages: [pre-push] keeps default `pre-commit run --all-files` from
+        # duplicating the heavy check.
 
       - id: ci-gate-expectations-self-test
         name: CI gate expectation contract

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -405,7 +405,7 @@ repos:
         pass_filenames: false
         # Triggers on the files it can be wrong about, plus itself. It does not need a binary: with
         # no `target/` build it still verifies source and published-release truth independently.
-        files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag|lib/editor-plugin-install-commands)\.sh|scripts/ci/(release_readme|test_release_quickstart)\.py|\.github/assay-release-tag|Cargo\.toml|README\.md|SECURITY\.md|llms\.txt|mkdocs\.yml|examples/mcp-quickstart/README\.md|docs/(COMMUNITY\.md|index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.devcontainer/welcome\.sh|demo/CODESPACES-PLAYBOOK\.md|\.pre-commit-config\.yaml)$
+        files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag|lib/editor-plugin-install-commands|test-editor-release-hook-precommit-consumer)\.sh|scripts/ci/(release_readme|test_release_quickstart)\.py|\.github/assay-release-tag|Cargo\.toml|README\.md|SECURITY\.md|llms\.txt|mkdocs\.yml|examples/mcp-quickstart/README\.md|docs/(COMMUNITY\.md|index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.devcontainer/welcome\.sh|demo/CODESPACES-PLAYBOOK\.md|\.pre-commit-config\.yaml)$
 
 
 
@@ -506,7 +506,18 @@ repos:
         # Triggers on the recipe it judges, the guard and its self-test, the shared extractor,
         # and itself. The self-test runs first so a guard whose rules match nothing fails here
         # rather than passing quietly.
-        files: ^(scripts/ci/((check|test-check)-editor-mcp-recipe-truth|lib/editor-plugin-install-commands|test-editor-plugin-install-commands)\.sh|docs/guides/editor-mcp-recipe\.md|\.pre-commit-config\.yaml)$
+        files: ^(scripts/ci/((check|test-check)-editor-mcp-recipe-truth|lib/editor-plugin-install-commands|test-editor-plugin-install-commands|test-editor-release-hook-precommit-consumer)\.sh|docs/guides/editor-mcp-recipe\.md|\.pre-commit-config\.yaml)$
+
+
+      - id: editor-release-hook-precommit-consumer
+        name: Editor and release-surface pre-commit consumer contract
+        entry: bash scripts/ci/test-editor-release-hook-precommit-consumer.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        # Independently owns hook wiring for editor-mcp-recipe-truth and
+        # release-surface. A last-key-wins files: ^$ skip or entry: 'true'
+        # bypass on those hooks cannot hide this contract.
 
       - id: ci-gate-expectations-self-test
         name: CI gate expectation contract

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -405,7 +405,7 @@ repos:
         pass_filenames: false
         # Triggers on the files it can be wrong about, plus itself. It does not need a binary: with
         # no `target/` build it still verifies source and published-release truth independently.
-        files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag)\.sh|scripts/ci/(release_readme|test_release_quickstart)\.py|\.github/assay-release-tag|Cargo\.toml|README\.md|SECURITY\.md|llms\.txt|mkdocs\.yml|examples/mcp-quickstart/README\.md|docs/(COMMUNITY\.md|index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.devcontainer/welcome\.sh|demo/CODESPACES-PLAYBOOK\.md|\.pre-commit-config\.yaml)$
+        files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag|lib/editor-plugin-install-commands)\.sh|scripts/ci/(release_readme|test_release_quickstart)\.py|\.github/assay-release-tag|Cargo\.toml|README\.md|SECURITY\.md|llms\.txt|mkdocs\.yml|examples/mcp-quickstart/README\.md|docs/(COMMUNITY\.md|index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.devcontainer/welcome\.sh|demo/CODESPACES-PLAYBOOK\.md|\.pre-commit-config\.yaml)$
 
 
 
@@ -500,12 +500,13 @@ repos:
 
       - id: editor-mcp-recipe-truth
         name: Editor MCP recipe describes only the shipped transport
-        entry: bash -c 'bash scripts/ci/test-check-editor-mcp-recipe-truth.sh && bash scripts/ci/check-editor-mcp-recipe-truth.sh'
+        entry: bash -c 'bash scripts/ci/test-editor-plugin-install-commands.sh && bash scripts/ci/test-check-editor-mcp-recipe-truth.sh && bash scripts/ci/check-editor-mcp-recipe-truth.sh'
         language: system
         pass_filenames: false
-        # Triggers on the recipe it judges, the guard and its self-test, and itself. The self-test
-        # runs first so a guard whose rules match nothing fails here rather than passing quietly.
-        files: ^(scripts/ci/(check|test-check)-editor-mcp-recipe-truth\.sh|docs/guides/editor-mcp-recipe\.md|\.pre-commit-config\.yaml)$
+        # Triggers on the recipe it judges, the guard and its self-test, the shared extractor,
+        # and itself. The self-test runs first so a guard whose rules match nothing fails here
+        # rather than passing quietly.
+        files: ^(scripts/ci/((check|test-check)-editor-mcp-recipe-truth|lib/editor-plugin-install-commands|test-editor-plugin-install-commands)\.sh|docs/guides/editor-mcp-recipe\.md|\.pre-commit-config\.yaml)$
 
       - id: ci-gate-expectations-self-test
         name: CI gate expectation contract

--- a/docs/guides/editor-mcp-recipe.md
+++ b/docs/guides/editor-mcp-recipe.md
@@ -27,6 +27,7 @@ claude plugin install assay@assay --scope local
 
 # 3. Verify that the installed plugin can start the server.
 claude mcp list
+# assay-editor-plugin-install-commands:end
 ```
 
 Restart Claude Code after installation, then ask it to use

--- a/docs/guides/editor-mcp-recipe.md
+++ b/docs/guides/editor-mcp-recipe.md
@@ -16,8 +16,8 @@ From the project where Claude Code should use Assay:
 
 ```bash
 # 1. Install both prerequisites and confirm they are on PATH.
-cargo install assay-cli --locked
-cargo install assay-mcp-server --locked
+cargo install assay-cli --version 5.5.2 --locked
+cargo install assay-mcp-server --version 5.5.2 --locked
 assay version
 assay-mcp-server --version
 

--- a/docs/guides/editor-mcp-recipe.md
+++ b/docs/guides/editor-mcp-recipe.md
@@ -44,7 +44,7 @@ the installed plugin cache.
 
 Plugin updates require a restart to take effect:
 
-```bash
+```sh
 claude plugin marketplace update assay
 claude plugin update assay@assay --scope local
 claude plugin list --json
@@ -70,7 +70,7 @@ but installing it does not prove provider execution or external side effects.
 Maintainers can exercise the bounded, disposable installation contract without
 touching their normal Claude configuration:
 
-```bash
+```sh
 bash scripts/ci/test-claude-plugin-install.sh --self-test
 ```
 

--- a/docs/guides/editor-mcp-recipe.md
+++ b/docs/guides/editor-mcp-recipe.md
@@ -43,7 +43,7 @@ the installed plugin cache.
 
 ### Update and inspect stale state
 
-Plugin updates require a restart to take effect:
+Plugin updates may activate immediately. If the current session still shows stale plugin state, run `/reload-plugins` in Claude Code or restart the session before inspecting.
 
 ```sh
 claude plugin marketplace update assay

--- a/scripts/ci/check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/check-editor-mcp-recipe-truth.sh
@@ -124,6 +124,10 @@ fi
 # recipe's real content.
 require 'local stdio wrap claim retained' '(assay mcp wrap|`assay mcp wrap`)'
 require 'proxy-enforce claim retained' 'proxy-enforce'
+# Plugin updates can take effect without a restart (`/reload-plugins`, some
+# installs). An unconditional restart claim is too strong for this recipe.
+forbid 'unconditional plugin-update restart claim' \
+  'plugin updates require a restart'
 
 # Keep these as standalone commands in this recipe, not a general shell/Markdown grammar.
 # Comments, prose, and commands in a different H2 section cannot satisfy plugin prerequisites.

--- a/scripts/ci/check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/check-editor-mcp-recipe-truth.sh
@@ -128,14 +128,17 @@ require 'proxy-enforce claim retained' 'proxy-enforce'
 # Keep these as standalone commands in this recipe, not a general shell/Markdown grammar.
 # Comments, prose, and commands in a different H2 section cannot satisfy plugin prerequisites.
 # Version pinning of cargo install is owned by check-release-surface.sh, not this guard.
-plugin_commands="$(editor_plugin_install_commands "$RECIPE")"
-for command in 'assay version' 'assay-mcp-server --version'; do
-  if printf '%s\n' "$plugin_commands" | grep -Fxq -- "$command"; then
-    ok "plugin prerequisite command present: $command"
-  else
-    fail "$RECIPE: plugin prerequisite command missing: $command"
-  fi
-done
+if ! plugin_commands="$(editor_plugin_install_commands "$RECIPE" 2>&1)"; then
+  fail "$RECIPE: plugin install command extraction failed: $plugin_commands"
+else
+  for command in 'assay version' 'assay-mcp-server --version'; do
+    if printf '%s\n' "$plugin_commands" | grep -Fxq -- "$command"; then
+      ok "plugin prerequisite command present: $command"
+    else
+      fail "$RECIPE: plugin prerequisite command missing: $command"
+    fi
+  done
+fi
 
 printf '\n'
 if [ "$failures" -gt 0 ]; then

--- a/scripts/ci/check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/check-editor-mcp-recipe-truth.sh
@@ -36,6 +36,9 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 
+# shellcheck source=scripts/ci/lib/editor-plugin-install-commands.sh
+source scripts/ci/lib/editor-plugin-install-commands.sh
+
 RECIPE="${ASSAY_EDITOR_RECIPE:-docs/guides/editor-mcp-recipe.md}"
 MAX_RECIPE_BYTES=65536
 MODERN_REVISION='2026-07-28'
@@ -124,40 +127,9 @@ require 'proxy-enforce claim retained' 'proxy-enforce'
 
 # Keep these as standalone commands in this recipe, not a general shell/Markdown grammar.
 # Comments, prose, and commands in a different H2 section cannot satisfy plugin prerequisites.
-plugin_commands="$(awk '
-  {
-    fence_line = $0
-    sub(/^ ? ? ?/, "", fence_line)
-  }
-  match(fence_line, /^(```+|~~~+)/) {
-    width = RLENGTH
-    mark = substr(fence_line, 1, 1)
-    rest = substr(fence_line, width + 1)
-    if (fence) {
-      if (mark == fence_mark && width >= fence_width && rest ~ /^[ \t]*$/) {
-        fence = 0
-        bash_fence = 0
-      }
-    } else {
-      fence = 1
-      fence_mark = mark
-      fence_width = width
-      bash_fence = (fence_line == "```bash")
-    }
-    next
-  }
-  !fence && /^## / {
-    section = ($0 == "## Install the Claude Code plugin")
-    next
-  }
-  section && fence && bash_fence {
-    sub(/^[ \t]+/, "")
-    sub(/[ \t]+$/, "")
-    print
-  }
-' "$RECIPE")"
-for command in 'cargo install assay-cli --locked' 'cargo install assay-mcp-server --locked' \
-  'assay version' 'assay-mcp-server --version'; do
+# Version pinning of cargo install is owned by check-release-surface.sh, not this guard.
+plugin_commands="$(editor_plugin_install_commands "$RECIPE")"
+for command in 'assay version' 'assay-mcp-server --version'; do
   if printf '%s\n' "$plugin_commands" | grep -Fxq -- "$command"; then
     ok "plugin prerequisite command present: $command"
   else

--- a/scripts/ci/check-release-surface.sh
+++ b/scripts/ci/check-release-surface.sh
@@ -345,7 +345,7 @@ check_editor_plugin_published_installs() {
       "$PINNED_ASSAY_CLI"|"$PINNED_ASSAY_MCP") continue ;;
     esac
     case "$line" in
-      cargo\ install*|cargo\ install) ;;
+      cargo\ install*) ;;
       *) continue ;;
     esac
     if [[ "$line" == *\\ ]]; then

--- a/scripts/ci/check-release-surface.sh
+++ b/scripts/ci/check-release-surface.sh
@@ -325,8 +325,8 @@ check_editor_plugin_published_installs() {
     fail "$recipe: checked outward document is missing"
     return
   fi
-  if ! commands="$(editor_plugin_install_commands "$recipe")"; then
-    fail "$recipe: plugin install command extraction failed"
+  if ! commands="$(editor_plugin_install_commands "$recipe" 2>&1)"; then
+    fail "$recipe: plugin install command extraction failed: $commands"
     return
   fi
 

--- a/scripts/ci/check-release-surface.sh
+++ b/scripts/ci/check-release-surface.sh
@@ -41,6 +41,9 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 
+# shellcheck source=scripts/ci/lib/editor-plugin-install-commands.sh
+source scripts/ci/lib/editor-plugin-install-commands.sh
+
 failures=0
 fail() {
   failures=$((failures + 1))
@@ -72,6 +75,12 @@ note "workspace version: $WORKSPACE_VERSION"
 PUBLISHED_TAG="$(bash scripts/ci/read-assay-release-tag.sh)"
 PUBLISHED_VERSION="${PUBLISHED_TAG#v}"
 note "published release pin: $PUBLISHED_TAG"
+
+# One owner of the published pin strings and the floating-ban strings.
+PINNED_ASSAY_CLI="cargo install assay-cli --version $PUBLISHED_VERSION --locked"
+PINNED_ASSAY_MCP="cargo install assay-mcp-server --version $PUBLISHED_VERSION --locked"
+FLOATING_ASSAY_CLI="cargo install assay-cli --locked"
+FLOATING_ASSAY_MCP="cargo install assay-mcp-server --locked"
 
 # ---------------------------------------------------------------------------
 # 1. Internal dependency declarations, enumerated from the manifest.
@@ -279,12 +288,22 @@ check_action_refs_pinned() {
   fi
 }
 
+check_absent_fixed() {
+  local file="$1" needle="$2" label="$3"
+  if [ ! -f "$file" ]; then
+    fail "$file: checked outward document is missing"
+    return
+  fi
+  if grep -Fq -- "$needle" "$file"; then
+    fail "$file: $label"
+  fi
+}
+
 check_install_command_count() {
   local file="$1" expected_count="$2"
-  local expected="cargo install assay-cli --version $PUBLISHED_VERSION --locked"
   local all_count current_count
   all_count="$(grep -Ec 'cargo install assay-cli --version [^[:space:]]+ --locked' "$file" || true)"
-  current_count="$(grep -Fc "$expected" "$file" || true)"
+  current_count="$(grep -Fc "$PINNED_ASSAY_CLI" "$file" || true)"
   if [ "$all_count" -ne "$expected_count" ] || [ "$current_count" -ne "$expected_count" ]; then
     fail "$file: expected $expected_count current release-pinned install command(s)"
   fi
@@ -293,8 +312,63 @@ check_install_command_count() {
 check_rust_cli_installs() {
   local file="$1" expected_count="$2"
   check_install_command_count "$file" "$expected_count"
+  check_absent_fixed "$file" "$FLOATING_ASSAY_CLI" 'floating unpinned assay-cli install'
   check_absent_regex "$file" 'cargo install assay([^[:alnum:]_-]|$)' \
     'unsupported Rust CLI package; use assay-cli'
+}
+
+check_editor_plugin_published_installs() {
+  local recipe="docs/guides/editor-mcp-recipe.md"
+  local commands line cli_exact mcp_exact
+
+  if [ ! -f "$recipe" ]; then
+    fail "$recipe: checked outward document is missing"
+    return
+  fi
+  if ! commands="$(editor_plugin_install_commands "$recipe")"; then
+    fail "$recipe: plugin install command extraction failed"
+    return
+  fi
+
+  cli_exact="$(printf '%s\n' "$commands" | grep -Fxc -- "$PINNED_ASSAY_CLI" || true)"
+  mcp_exact="$(printf '%s\n' "$commands" | grep -Fxc -- "$PINNED_ASSAY_MCP" || true)"
+  if [ "$cli_exact" -ne 1 ]; then
+    fail "$recipe: expected exactly one current release-pinned assay-cli plugin install"
+  fi
+  if [ "$mcp_exact" -ne 1 ]; then
+    fail "$recipe: expected exactly one current release-pinned assay-mcp-server plugin install"
+  fi
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] || continue
+    case "$line" in
+      "$PINNED_ASSAY_CLI"|"$PINNED_ASSAY_MCP") continue ;;
+    esac
+    case "$line" in
+      cargo\ install*|cargo\ install) ;;
+      *) continue ;;
+    esac
+    if [[ "$line" == *\\ ]]; then
+      fail "$recipe: plugin section: continued cargo install is not a published pin"
+      continue
+    fi
+    if [[ "$line" == *\"* ]] || [[ "$line" == *"'"* ]]; then
+      fail "$recipe: plugin section: quoted cargo install is not a published pin"
+      continue
+    fi
+    if [[ "$line" == *--path* ]]; then
+      fail "$recipe: plugin section: source-path cargo install is not allowed"
+      continue
+    fi
+    if [[ "$line" =~ ^cargo\ install\ assay([^[:alnum:]_-]|$) ]]; then
+      fail "$recipe: plugin section: unsupported Rust CLI package; use assay-cli"
+      continue
+    fi
+    fail "$recipe: plugin section: unexpected cargo install"
+  done <<< "$commands"
+
+  check_absent_fixed "$recipe" "$FLOATING_ASSAY_CLI" 'floating unpinned assay-cli install'
+  check_absent_fixed "$recipe" "$FLOATING_ASSAY_MCP" 'floating unpinned assay-mcp-server install'
 }
 
 is_digest_scoped_rge_bench_claim() {
@@ -449,6 +523,7 @@ for file in README.md docs/guides/editor-mcp-recipe.md; do
   check_absent_regex "$file" 'assay mcp config-path (codex|<editor>)' \
     'config-path does not support Codex'
 done
+check_editor_plugin_published_installs
 for file in .devcontainer/welcome.sh demo/CODESPACES-PLAYBOOK.md; do
   check_absent_regex "$file" 'https://assay\.dev/' \
     'unrelated assay.dev onboarding URL'

--- a/scripts/ci/check-release-surface.sh
+++ b/scripts/ci/check-release-surface.sh
@@ -346,6 +346,10 @@ check_editor_plugin_published_installs() {
     esac
     case "$line" in
       cargo\ install*) ;;
+      cargo\ *|cargo)
+        fail "$recipe: plugin section: unexpected cargo command"
+        continue
+        ;;
       *) continue ;;
     esac
     if [[ "$line" == *\\ ]]; then

--- a/scripts/ci/lib/editor-plugin-install-commands.sh
+++ b/scripts/ci/lib/editor-plugin-install-commands.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Extract standalone command lines from the Claude Code plugin install section.
+#
+# One parser, sourced by the editor-transport guard and the release-surface guard.
+# This file does not judge cargo vs claude, quotes, or continuations. Missing or
+# wrong H2 / fence emit nothing; consumers own cardinality and semantic reject.
+
+editor_plugin_install_commands() {
+  local recipe="${1:-}"
+  local max_recipe_bytes=65536
+
+  if [ -z "$recipe" ]; then
+    printf 'usage: editor_plugin_install_commands <recipe-path>\n' >&2
+    return 2
+  fi
+  if [ ! -f "$recipe" ]; then
+    printf 'recipe not found: %s\n' "$recipe" >&2
+    return 1
+  fi
+  if [ "$(wc -c < "$recipe")" -gt "$max_recipe_bytes" ]; then
+    printf 'recipe exceeds %s-byte limit: %s\n' "$max_recipe_bytes" "$recipe" >&2
+    return 1
+  fi
+
+  awk '
+    {
+      fence_line = $0
+      sub(/^ ? ? ?/, "", fence_line)
+    }
+    match(fence_line, /^(```+|~~~+)/) {
+      width = RLENGTH
+      mark = substr(fence_line, 1, 1)
+      rest = substr(fence_line, width + 1)
+      if (fence) {
+        if (mark == fence_mark && width >= fence_width && rest ~ /^[ \t]*$/) {
+          fence = 0
+          bash_fence = 0
+        }
+      } else {
+        fence = 1
+        fence_mark = mark
+        fence_width = width
+        bash_fence = (fence_line == "```bash")
+      }
+      next
+    }
+    !fence && /^## / {
+      section = ($0 == "## Install the Claude Code plugin")
+      next
+    }
+    section && fence && bash_fence {
+      sub(/^[ \t]+/, "")
+      sub(/[ \t]+$/, "")
+      if ($0 != "" && $0 !~ /^#/) print
+    }
+  ' "$recipe"
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  set -euo pipefail
+  editor_plugin_install_commands "$@"
+fi

--- a/scripts/ci/lib/editor-plugin-install-commands.sh
+++ b/scripts/ci/lib/editor-plugin-install-commands.sh
@@ -2,8 +2,10 @@
 # Extract standalone command lines from the Claude Code plugin install section.
 #
 # One parser, sourced by the editor-transport guard and the release-surface guard.
-# This file does not judge cargo vs claude, quotes, or continuations. Missing or
-# wrong H2 / fence emit nothing; consumers own cardinality and semantic reject.
+# This file does not judge cargo vs claude, quotes, or continuations. Cardinality
+# of matching H2s and ```bash fences in that section is this parser's job: not
+# exactly one of each fails closed and emits nothing. Semantic reject stays with
+# consumers.
 
 editor_plugin_install_commands() {
   local recipe="${1:-}"
@@ -41,17 +43,34 @@ editor_plugin_install_commands() {
         fence_mark = mark
         fence_width = width
         bash_fence = (fence_line == "```bash")
+        if (section && bash_fence) bash_fence_count++
       }
       next
     }
     !fence && /^## / {
       section = ($0 == "## Install the Claude Code plugin")
+      if (section) h2_count++
       next
     }
     section && fence && bash_fence {
       sub(/^[ \t]+/, "")
       sub(/[ \t]+$/, "")
-      if ($0 != "" && $0 !~ /^#/) print
+      if ($0 != "" && $0 !~ /^#/) {
+        if (ncmds) cmds = cmds "\n" $0
+        else cmds = $0
+        ncmds++
+      }
+    }
+    END {
+      if (h2_count != 1) {
+        print "expected exactly one plugin install heading" > "/dev/stderr"
+        exit 1
+      }
+      if (bash_fence_count != 1) {
+        print "expected exactly one bash fence in the plugin section" > "/dev/stderr"
+        exit 1
+      }
+      if (ncmds) print cmds
     }
   ' "$recipe"
 }

--- a/scripts/ci/lib/editor-plugin-install-commands.sh
+++ b/scripts/ci/lib/editor-plugin-install-commands.sh
@@ -35,8 +35,11 @@ editor_plugin_install_commands() {
       rest = substr(fence_line, width + 1)
       if (fence) {
         if (mark == fence_mark && width >= fence_width && rest ~ /^[ \t]*$/) {
+          if (section && bash_fence) bash_fence_close_count++
           fence = 0
           bash_fence = 0
+        } else if (section && bash_fence) {
+          nested_fence_before_close = 1
         }
       } else {
         fence = 1
@@ -68,6 +71,10 @@ editor_plugin_install_commands() {
       }
       if (bash_fence_count != 1) {
         print "expected exactly one bash fence in the plugin section" > "/dev/stderr"
+        exit 1
+      }
+      if (bash_fence_close_count != 1 || nested_fence_before_close) {
+        print "plugin bash fence is not closed at its own boundary" > "/dev/stderr"
         exit 1
       }
       if (ncmds) print cmds

--- a/scripts/ci/lib/editor-plugin-install-commands.sh
+++ b/scripts/ci/lib/editor-plugin-install-commands.sh
@@ -3,9 +3,9 @@
 #
 # One parser, sourced by the editor-transport guard and the release-surface guard.
 # This file does not judge cargo vs claude, quotes, or continuations. Cardinality
-# of matching H2s and ```bash fences in that section is this parser's job: not
-# exactly one of each fails closed and emits nothing. Semantic reject stays with
-# consumers.
+# of matching H2s, ```bash fences, and the explicit end marker in that section is
+# this parser's job: invalid structure fails closed and emits nothing. Semantic
+# reject stays with consumers.
 
 editor_plugin_install_commands() {
   local recipe="${1:-}"
@@ -35,11 +35,15 @@ editor_plugin_install_commands() {
       rest = substr(fence_line, width + 1)
       if (fence) {
         if (mark == fence_mark && width >= fence_width && rest ~ /^[ \t]*$/) {
-          if (section && bash_fence) bash_fence_close_count++
+          if (section && bash_fence) {
+            bash_fence_close_count++
+            if (marker_before_close) marker_close_count++
+          }
           fence = 0
           bash_fence = 0
         } else if (section && bash_fence) {
           nested_fence_before_close = 1
+          marker_before_close = 0
         }
       } else {
         fence = 1
@@ -48,8 +52,7 @@ editor_plugin_install_commands() {
         bash_fence = (fence_line == "```bash")
         if (section && bash_fence) {
           bash_fence_count++
-          previous_blank = 0
-          possible_next_h2 = 0
+          marker_before_close = 0
         }
       }
       next
@@ -60,12 +63,12 @@ editor_plugin_install_commands() {
       next
     }
     section && fence && bash_fence {
-      if (possible_next_h2) {
-        if ($0 ~ /^[ \t]*$/) next_h2_before_close = 1
-        possible_next_h2 = 0
+      marker_before_close = 0
+      if ($0 == "# assay-editor-plugin-install-commands:end") {
+        marker_count++
+        marker_before_close = 1
+        next
       }
-      if (previous_blank && $0 ~ /^## /) possible_next_h2 = 1
-      previous_blank = ($0 ~ /^[ \t]*$/)
       sub(/^[ \t]+/, "")
       sub(/[ \t]+$/, "")
       if ($0 != "" && $0 !~ /^#/) {
@@ -91,8 +94,12 @@ editor_plugin_install_commands() {
         print "plugin bash fence is not closed at its own boundary" > "/dev/stderr"
         exit 1
       }
-      if (next_h2_before_close) {
-        print "plugin bash fence absorbs a later H2" > "/dev/stderr"
+      if (marker_count != 1) {
+        print "expected exactly one plugin bash fence end marker" > "/dev/stderr"
+        exit 1
+      }
+      if (bash_fence_close_count == 1 && !nested_fence_before_close && marker_close_count != 1) {
+        print "plugin bash fence end marker must immediately precede its close" > "/dev/stderr"
         exit 1
       }
       if (ncmds) print cmds

--- a/scripts/ci/lib/editor-plugin-install-commands.sh
+++ b/scripts/ci/lib/editor-plugin-install-commands.sh
@@ -46,7 +46,11 @@ editor_plugin_install_commands() {
         fence_mark = mark
         fence_width = width
         bash_fence = (fence_line == "```bash")
-        if (section && bash_fence) bash_fence_count++
+        if (section && bash_fence) {
+          bash_fence_count++
+          previous_blank = 0
+          possible_next_h2 = 0
+        }
       }
       next
     }
@@ -56,6 +60,12 @@ editor_plugin_install_commands() {
       next
     }
     section && fence && bash_fence {
+      if (possible_next_h2) {
+        if ($0 ~ /^[ \t]*$/) next_h2_before_close = 1
+        possible_next_h2 = 0
+      }
+      if (previous_blank && $0 ~ /^## /) possible_next_h2 = 1
+      previous_blank = ($0 ~ /^[ \t]*$/)
       sub(/^[ \t]+/, "")
       sub(/[ \t]+$/, "")
       if ($0 != "" && $0 !~ /^#/) {
@@ -73,8 +83,16 @@ editor_plugin_install_commands() {
         print "expected exactly one bash fence in the plugin section" > "/dev/stderr"
         exit 1
       }
-      if (bash_fence_close_count != 1 || nested_fence_before_close) {
+      if (bash_fence_close_count != 1) {
         print "plugin bash fence is not closed at its own boundary" > "/dev/stderr"
+        exit 1
+      }
+      if (nested_fence_before_close) {
+        print "plugin bash fence is not closed at its own boundary" > "/dev/stderr"
+        exit 1
+      }
+      if (next_h2_before_close) {
+        print "plugin bash fence absorbs a later H2" > "/dev/stderr"
         exit 1
       }
       if (ncmds) print cmds

--- a/scripts/ci/test-check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/test-check-editor-mcp-recipe-truth.sh
@@ -314,14 +314,15 @@ echo '== CI wiring: recipe, extractor, and extractor self-test must reach this g
 EXTRACTOR_LIB='scripts/ci/lib/editor-plugin-install-commands.sh'
 EXTRACTOR_SELFTEST='scripts/ci/test-editor-plugin-install-commands.sh'
 RECIPE_PATH='docs/guides/editor-mcp-recipe.md'
+CONSUMER_CONTRACT='scripts/ci/test-editor-release-hook-precommit-consumer.sh'
 
 check_editor_hook_wiring() {
-  python3 - "$1" "$RECIPE_PATH" "$EXTRACTOR_LIB" "$EXTRACTOR_SELFTEST" <<'PY'
+  python3 - "$1" "$RECIPE_PATH" "$EXTRACTOR_LIB" "$EXTRACTOR_SELFTEST" "$CONSUMER_CONTRACT" <<'PY'
 from pathlib import Path
 import re
 import sys
 
-cfg_path, recipe, extractor, selftest = sys.argv[1:5]
+cfg_path, recipe, extractor, selftest, contract = sys.argv[1:6]
 problems = []
 cfg = Path(cfg_path).read_text(encoding="utf-8")
 hook = re.search(
@@ -336,7 +337,7 @@ else:
         problems.append("editor-mcp-recipe-truth: no files: selector")
     else:
         pattern = re.compile(files.group(1))
-        for path in (recipe, extractor, selftest):
+        for path in (recipe, extractor, selftest, contract):
             if not pattern.search(path):
                 problems.append(
                     f"editor-mcp-recipe-truth: files: selector does not match {path}"

--- a/scripts/ci/test-check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/test-check-editor-mcp-recipe-truth.sh
@@ -35,6 +35,7 @@ cargo install assay-cli --locked
 cargo install assay-mcp-server --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## The wrap command
@@ -123,6 +124,7 @@ assay version
 ```bash
 cargo install assay-mcp-server --locked
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## The wrap command
@@ -146,6 +148,7 @@ assay version
 ```bash
 cargo install assay-mcp-server --locked
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## The wrap command
@@ -166,6 +169,7 @@ cargo install assay-cli --locked
 cargo install assay-mcp-server --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 
 ### Update stale state
 
@@ -191,11 +195,11 @@ cargo install assay-cli --locked
 cargo install assay-mcp-server --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 
 Continue with the verification notes below.
 
 ## Verify the installation
-
 Run both version probes before continuing.
 ```
 
@@ -205,7 +209,7 @@ Run `assay mcp wrap` to enforce policy at the protocol boundary.
 Use `assay-mcp-server proxy-enforce` for the enforcing path.
 MD
 expect_fail 'later bare fence cannot close across an apparent next H2' \
-  'plugin bash fence absorbs a later H2'
+  'plugin bash fence end marker must immediately precede its close'
 
 
 echo '== fenced examples cannot impersonate the plugin section =='

--- a/scripts/ci/test-check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/test-check-editor-mcp-recipe-truth.sh
@@ -85,8 +85,7 @@ write_clean
 expect_pass 'clean fixture passes'
 
 echo '== plugin prerequisites must be commands in the plugin installation section =='
-for command in 'cargo install assay-cli --locked' 'cargo install assay-mcp-server --locked' \
-  'assay version' 'assay-mcp-server --version'; do
+for command in 'assay version' 'assay-mcp-server --version'; do
   for mode in delete comment prose elsewhere; do
     write_clean
     awk -v command="$command" -v mode="$mode" '
@@ -118,7 +117,7 @@ for fence in '```' '````' '~~~' '   ~~~'; do
   ' "$TMP/recipe.md" > "$TMP/edited.md"
   mv "$TMP/edited.md" "$TMP/recipe.md"
   expect_fail "plugin section inside $fence example" \
-    'plugin prerequisite command missing: cargo install assay-cli --locked'
+    'plugin prerequisite command missing: assay version'
 done
 for heading in '## shell comment' '### subheading-shaped shell comment'; do
   write_clean

--- a/scripts/ci/test-check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/test-check-editor-mcp-recipe-truth.sh
@@ -250,6 +250,12 @@ write_clean
 printf 'It will be finalised once the spec is final.\n' >> "$TMP/recipe.md"
 expect_fail 'future-tense promise rejected' 'future-tense specification promise'
 
+echo '== plugin updates must not require an unconditional restart =='
+write_clean
+printf 'Plugin updates require a restart to take effect:\n' >> "$TMP/recipe.md"
+expect_fail 'unconditional restart wording rejected' \
+  'unconditional plugin-update restart claim'
+
 echo '== drift 3a: remote OAuth/OIDC instruction =='
 write_clean
 printf 'Align the wrapped server to that OAuth 2.1 / OIDC flow with PKCE.\n' >> "$TMP/recipe.md"

--- a/scripts/ci/test-check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/test-check-editor-mcp-recipe-truth.sh
@@ -156,6 +156,31 @@ MD
 expect_fail 'split version probes across two bash fences' \
   'expected exactly one bash fence in the plugin section'
 
+cat > "$TMP/recipe.md" <<'MD'
+# Editor MCP Recipe
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --locked
+cargo install assay-mcp-server --locked
+assay version
+assay-mcp-server --version
+
+### Update stale state
+
+```sh
+claude plugin update assay@assay --scope local
+```
+
+## The wrap command
+
+Run `assay mcp wrap` to enforce policy at the protocol boundary.
+Use `assay-mcp-server proxy-enforce` for the enforcing path.
+MD
+expect_fail 'later fenced block cannot close the plugin bash fence' \
+  'plugin bash fence is not closed at its own boundary'
+
 
 echo '== fenced examples cannot impersonate the plugin section =='
 for fence in '```' '````' '~~~' '   ~~~'; do

--- a/scripts/ci/test-check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/test-check-editor-mcp-recipe-truth.sh
@@ -107,6 +107,56 @@ write_clean
 printf '\n<!-- unchanged executable recipe -->\n' >> "$TMP/recipe.md"
 expect_pass 'comment-only no-op preserves prerequisites'
 
+echo '== split version probes across duplicate H2 / fences must fail closed =='
+cat > "$TMP/recipe.md" <<'MD'
+# Editor MCP Recipe
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --locked
+assay version
+```
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-mcp-server --locked
+assay-mcp-server --version
+```
+
+## The wrap command
+
+Run `assay mcp wrap` to enforce policy at the protocol boundary.
+Use `assay-mcp-server proxy-enforce` for the enforcing path.
+MD
+expect_fail 'split version probes across two plugin H2s' \
+  'expected exactly one plugin install heading'
+
+cat > "$TMP/recipe.md" <<'MD'
+# Editor MCP Recipe
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --locked
+assay version
+```
+
+```bash
+cargo install assay-mcp-server --locked
+assay-mcp-server --version
+```
+
+## The wrap command
+
+Run `assay mcp wrap` to enforce policy at the protocol boundary.
+Use `assay-mcp-server proxy-enforce` for the enforcing path.
+MD
+expect_fail 'split version probes across two bash fences' \
+  'expected exactly one bash fence in the plugin section'
+
+
 echo '== fenced examples cannot impersonate the plugin section =='
 for fence in '```' '````' '~~~' '   ~~~'; do
   write_clean
@@ -117,7 +167,7 @@ for fence in '```' '````' '~~~' '   ~~~'; do
   ' "$TMP/recipe.md" > "$TMP/edited.md"
   mv "$TMP/edited.md" "$TMP/recipe.md"
   expect_fail "plugin section inside $fence example" \
-    'plugin prerequisite command missing: assay version'
+    'expected exactly one plugin install heading'
 done
 for heading in '## shell comment' '### subheading-shaped shell comment'; do
   write_clean
@@ -196,14 +246,63 @@ write_clean
 printf 'Rendered in a sandboxed-iframe host.\n' >> "$TMP/recipe.md"
 expect_fail 'hyphenated sandboxed-iframe rejected' 'MCP UI / sandboxed-iframe instruction'
 
-echo '== CI wiring: a recipe-only change must execute this guard =='
+echo '== CI wiring: recipe, extractor, and extractor self-test must reach this guard =='
 # The guard is only worth its rules if a drift actually reaches it. The pre-commit hook covers
 # the local path; CI coverage depends on the one workflow that runs `pre-commit run --all-files`
 # selecting the recipe, and `scripts/**` does not help because a recipe-only drift touches no
 # script. Asserted here rather than in a workflow-wide contract so the rule that judges this
 # file also owns the wiring that reaches it.
+#
+# files: and entry are mutation-pinned: a live-only assert already passes on this tree and
+# would not catch deleting the extractor path or dropping the extractor self-test from entry.
+
+EXTRACTOR_LIB='scripts/ci/lib/editor-plugin-install-commands.sh'
+EXTRACTOR_SELFTEST='scripts/ci/test-editor-plugin-install-commands.sh'
+RECIPE_PATH='docs/guides/editor-mcp-recipe.md'
+
+check_editor_hook_wiring() {
+  python3 - "$1" "$RECIPE_PATH" "$EXTRACTOR_LIB" "$EXTRACTOR_SELFTEST" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+cfg_path, recipe, extractor, selftest = sys.argv[1:5]
+problems = []
+cfg = Path(cfg_path).read_text(encoding="utf-8")
+hook = re.search(
+    r"(?ms)^      - id: editor-mcp-recipe-truth\n(.*?)(?=^      - id: |\Z)",
+    cfg,
+)
+if not hook:
+    problems.append(".pre-commit-config.yaml: hook editor-mcp-recipe-truth not found")
+else:
+    files = re.search(r"^\s*files:\s*(\S+)\s*$", hook.group(1), re.M)
+    if not files:
+        problems.append("editor-mcp-recipe-truth: no files: selector")
+    else:
+        pattern = re.compile(files.group(1))
+        for path in (recipe, extractor, selftest):
+            if not pattern.search(path):
+                problems.append(
+                    f"editor-mcp-recipe-truth: files: selector does not match {path}"
+                )
+    entry = re.search(r"^\s*entry:\s*(.+?)\s*$", hook.group(1), re.M)
+    if not entry:
+        problems.append("editor-mcp-recipe-truth: no entry:")
+    elif selftest not in entry.group(1):
+        problems.append(
+            f"editor-mcp-recipe-truth: entry does not invoke {selftest}"
+        )
+
+if problems:
+    print("\n".join(problems), file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
 cases=$((cases + 1))
-if RECIPE_PATH='docs/guides/editor-mcp-recipe.md' python3 - "$ROOT" <<'PY'
+wf_ok=0
+if RECIPE_PATH="$RECIPE_PATH" python3 - "$ROOT" <<'PY'
 import os, re, sys
 
 root = sys.argv[1]
@@ -237,31 +336,100 @@ for name in runners:
             "a recipe-only drift would not execute the guard in CI"
         )
 
-# 3. The pre-commit hook that runs the guard must also select the recipe locally.
-cfg = open(os.path.join(root, ".pre-commit-config.yaml"), encoding="utf-8").read()
-hook = re.search(
-    r"(?ms)^      - id: editor-mcp-recipe-truth\n(.*?)(?=^      - id: |\Z)", cfg
-)
-if not hook:
-    problems.append(".pre-commit-config.yaml: hook editor-mcp-recipe-truth not found")
-else:
-    files = re.search(r"^\s*files:\s*(\S+)\s*$", hook.group(1), re.M)
-    if not files:
-        problems.append("editor-mcp-recipe-truth: no files: selector")
-    elif not re.search(files.group(1), recipe):
-        problems.append(
-            f"editor-mcp-recipe-truth: files: selector does not match {recipe}"
-        )
-
 if problems:
     print("\n".join(problems), file=sys.stderr)
     sys.exit(1)
 PY
 then
+  wf_ok=1
+fi
+if [ "$wf_ok" -eq 1 ] && check_editor_hook_wiring "$ROOT/.pre-commit-config.yaml"; then
   printf 'ok   a recipe-only change reaches the guard locally and in CI\n'
 else
   failures=$((failures + 1))
   printf 'FAIL: recipe-only change would not execute the guard\n'
+fi
+
+cases=$((cases + 1))
+cp "$ROOT/.pre-commit-config.yaml" "$TMP/pre-commit-drop-extractor.yaml"
+if python3 - "$TMP/pre-commit-drop-extractor.yaml" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+hook = re.search(
+    r"(?ms)^      - id: editor-mcp-recipe-truth\n(.*?)(?=^      - id: |\Z)",
+    text,
+)
+if not hook:
+    raise SystemExit("editor-mcp-recipe-truth hook not found")
+block = hook.group(0)
+needle = "lib/editor-plugin-install-commands|"
+if needle not in block:
+    raise SystemExit("extractor files: token not found in hook")
+new_block = block.replace(needle, "", 1)
+path.write_text(text[:hook.start()] + new_block + text[hook.end():], encoding="utf-8")
+PY
+then
+  if check_editor_hook_wiring "$TMP/pre-commit-drop-extractor.yaml" \
+    >"$TMP/drop-extractor.out" 2>&1
+  then
+    failures=$((failures + 1))
+    printf 'FAIL: dropping extractor from files: was not observed\n'
+  elif grep -Fq "files: selector does not match $EXTRACTOR_LIB" "$TMP/drop-extractor.out"
+  then
+    printf 'ok   files: mutation dropping extractor is observed\n'
+  else
+    failures=$((failures + 1))
+    printf 'FAIL: extractor files: mutation missed diagnostic\n%s\n' \
+      "$(cat "$TMP/drop-extractor.out")"
+  fi
+else
+  failures=$((failures + 1))
+  printf 'FAIL: could not drop extractor from files: selector\n'
+fi
+
+cases=$((cases + 1))
+cp "$ROOT/.pre-commit-config.yaml" "$TMP/pre-commit-drop-selftest.yaml"
+if python3 - "$TMP/pre-commit-drop-selftest.yaml" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+hook = re.search(
+    r"(?ms)^      - id: editor-mcp-recipe-truth\n(.*?)(?=^      - id: |\Z)",
+    text,
+)
+if not hook:
+    raise SystemExit("editor-mcp-recipe-truth hook not found")
+block = hook.group(0)
+needle = "bash scripts/ci/test-editor-plugin-install-commands.sh && "
+if needle not in block:
+    raise SystemExit("extractor self-test entry token not found in hook")
+new_block = block.replace(needle, "", 1)
+path.write_text(text[:hook.start()] + new_block + text[hook.end():], encoding="utf-8")
+PY
+then
+  if check_editor_hook_wiring "$TMP/pre-commit-drop-selftest.yaml" \
+    >"$TMP/drop-selftest.out" 2>&1
+  then
+    failures=$((failures + 1))
+    printf 'FAIL: dropping extractor self-test from entry was not observed\n'
+  elif grep -Fq "entry does not invoke $EXTRACTOR_SELFTEST" "$TMP/drop-selftest.out"
+  then
+    printf 'ok   entry mutation dropping extractor self-test is observed\n'
+  else
+    failures=$((failures + 1))
+    printf 'FAIL: extractor self-test entry mutation missed diagnostic\n%s\n' \
+      "$(cat "$TMP/drop-selftest.out")"
+  fi
+else
+  failures=$((failures + 1))
+  printf 'FAIL: could not drop extractor self-test from entry\n'
 fi
 
 echo '== a missing recipe fails closed =='

--- a/scripts/ci/test-check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/test-check-editor-mcp-recipe-truth.sh
@@ -181,6 +181,32 @@ MD
 expect_fail 'later fenced block cannot close the plugin bash fence' \
   'plugin bash fence is not closed at its own boundary'
 
+cat > "$TMP/recipe.md" <<'MD'
+# Editor MCP Recipe
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --locked
+cargo install assay-mcp-server --locked
+assay version
+assay-mcp-server --version
+
+Continue with the verification notes below.
+
+## Verify the installation
+
+Run both version probes before continuing.
+```
+
+## The wrap command
+
+Run `assay mcp wrap` to enforce policy at the protocol boundary.
+Use `assay-mcp-server proxy-enforce` for the enforcing path.
+MD
+expect_fail 'later bare fence cannot close across an apparent next H2' \
+  'plugin bash fence absorbs a later H2'
+
 
 echo '== fenced examples cannot impersonate the plugin section =='
 for fence in '```' '````' '~~~' '   ~~~'; do

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -537,6 +537,9 @@ PINNED_MCP_DIAG='expected exactly one current release-pinned assay-mcp-server pl
 mutate_and_expect_failure plugin-stale-version "$RECIPE_FILE" \
   's/assay-cli --version 5.1.0/assay-cli --version 5.0.0/' \
   "$PINNED_CLI_DIAG"
+mutate_and_expect_failure plugin-stale-mcp-version "$RECIPE_FILE" \
+  's/assay-mcp-server --version 5.1.0/assay-mcp-server --version 5.0.0/' \
+  "$PINNED_MCP_DIAG"
 mutate_and_expect_failure plugin-missing-version "$RECIPE_FILE" \
   's/cargo install assay-cli --version 5.1.0 --locked/cargo install assay-cli --locked/' \
   "$PINNED_CLI_DIAG"
@@ -754,8 +757,8 @@ cargo install --path crates/assay-mcp-server --locked
 ```
 MD
 
-if [ "$mutation_count" -ne 88 ]; then
-  echo "FAIL: expected 88 release-surface mutations, observed $mutation_count" >&2
+if [ "$mutation_count" -ne 89 ]; then
+  echo "FAIL: expected 89 release-surface mutations, observed $mutation_count" >&2
   exit 1
 fi
 echo "release-surface mutations: $mutation_count observed"

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -597,12 +597,12 @@ cargo install --path crates/assay-mcp-server --locked
 MD
 mutate_and_expect_failure plugin-missing-h2 "$RECIPE_FILE" \
   '/^## Install the Claude Code plugin$/d' \
-  "$PINNED_CLI_DIAG"
+  'expected exactly one plugin install heading'
 mutate_and_expect_failure plugin-wrong-h2 "$RECIPE_FILE" \
   's/^## Install the Claude Code plugin$/## Install the Claude Code Plugin/' \
-  "$PINNED_CLI_DIAG"
+  'expected exactly one plugin install heading'
 rewrite_and_expect_failure plugin-missing-fence "$RECIPE_FILE" \
-  "$PINNED_CLI_DIAG" <<'MD'
+  'expected exactly one bash fence in the plugin section' <<'MD'
 Codex uses .codex/config.toml.
 
 ## Install the Claude Code plugin
@@ -621,7 +621,7 @@ cargo install --path crates/assay-mcp-server --locked
 ```
 MD
 rewrite_and_expect_failure plugin-wrong-fence "$RECIPE_FILE" \
-  "$PINNED_CLI_DIAG" <<'MD'
+  'expected exactly one bash fence in the plugin section' <<'MD'
 Codex uses .codex/config.toml.
 
 ## Install the Claude Code plugin
@@ -724,7 +724,7 @@ cargo install --path crates/assay-mcp-server --locked
 MD
 
 rewrite_and_expect_failure plugin-duplicate-h2 "$RECIPE_FILE" \
-  "$PINNED_CLI_DIAG" <<'MD'
+  'expected exactly one plugin install heading' <<'MD'
 Codex uses .codex/config.toml.
 
 ## Install the Claude Code plugin
@@ -753,7 +753,7 @@ cargo install --path crates/assay-mcp-server --locked
 MD
 
 rewrite_and_expect_failure plugin-second-bash-fence "$RECIPE_FILE" \
-  "$PINNED_CLI_DIAG" <<'MD'
+  'expected exactly one bash fence in the plugin section' <<'MD'
 Codex uses .codex/config.toml.
 
 ## Install the Claude Code plugin
@@ -767,6 +767,54 @@ assay-mcp-server --version
 
 ```bash
 cargo install assay-cli --version 5.1.0 --locked
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
+
+rewrite_and_expect_failure plugin-split-h2-commands "$RECIPE_FILE" \
+  'expected exactly one plugin install heading' <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+assay version
+```
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay-mcp-server --version
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
+
+rewrite_and_expect_failure plugin-split-bash-fence-commands "$RECIPE_FILE" \
+  'expected exactly one bash fence in the plugin section' <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+assay version
+```
+
+```bash
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay-mcp-server --version
 ```
 
 ## Install Assay's review tools
@@ -797,8 +845,8 @@ cargo install --path crates/assay-mcp-server --locked
 ```
 MD
 
-if [ "$mutation_count" -ne 91 ]; then
-  echo "FAIL: expected 91 release-surface mutations, observed $mutation_count" >&2
+if [ "$mutation_count" -ne 93 ]; then
+  echo "FAIL: expected 93 release-surface mutations, observed $mutation_count" >&2
   exit 1
 fi
 echo "release-surface mutations: $mutation_count observed"

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -8,13 +8,14 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-mkdir -p "$TMP/scripts/ci" "$TMP/.github" "$TMP/docs/getting-started" "$TMP/docs/reference/cli" \
+mkdir -p "$TMP/scripts/ci/lib" "$TMP/.github" "$TMP/docs/getting-started" "$TMP/docs/reference/cli" \
   "$TMP/docs/python-sdk" "$TMP/docs/use-cases" "$TMP/docs/AIcontext" "$TMP/docs/guides" \
   "$TMP/examples/mcp-quickstart" "$TMP/crates/assay-x" "$TMP/bin" "$TMP/.devcontainer" \
   "$TMP/demo"
 cp "$ROOT/scripts/ci/check-release-surface.sh" "$TMP/scripts/ci/"
 cp "$ROOT/scripts/ci/release_readme.py" "$TMP/scripts/ci/"
 cp "$ROOT/scripts/ci/read-assay-release-tag.sh" "$TMP/scripts/ci/"
+cp "$ROOT/scripts/ci/lib/editor-plugin-install-commands.sh" "$TMP/scripts/ci/lib/"
 cp "$ROOT/.pre-commit-config.yaml" "$TMP/"
 printf '%s\n' 'v5.1.0' > "$TMP/.github/assay-release-tag"
 cat > "$TMP/SECURITY.md" <<'DOC'
@@ -124,7 +125,24 @@ Assay CLI via the release installer.
 For v5.5.2, run this from a source checkout or an extracted published CLI archive. The installer is binary-only and does not carry this bounded quickstart.
 DOC
 printf '%s\n' 'Current release: [`v5.1.0`](https://github.com/Rul1an/assay/releases/tag/v5.1.0)' > "$TMP/docs/index.md"
-printf '%s\n' 'Codex uses .codex/config.toml.' > "$TMP/docs/guides/editor-mcp-recipe.md"
+cat > "$TMP/docs/guides/editor-mcp-recipe.md" <<'DOC'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay version
+assay-mcp-server --version
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+DOC
 printf '%s\n' 'Docs: https://docs.getassay.dev' > "$TMP/.devcontainer/welcome.sh"
 cat > "$TMP/demo/CODESPACES-PLAYBOOK.md" <<'DOC'
 Docs: https://docs.getassay.dev
@@ -169,6 +187,8 @@ for path in (
     "SECURITY.md",
     "docs/COMMUNITY.md",
     "mkdocs.yml",
+    "scripts/ci/lib/editor-plugin-install-commands.sh",
+    "docs/guides/editor-mcp-recipe.md",
 ):
     if not pattern.search(path):
         raise SystemExit(f"release-surface hook omits {path}")
@@ -215,6 +235,25 @@ append_and_expect_failure() {
   local original="$TMP/$file" backup="$TMP/$file.$name"
   cp "$original" "$backup"
   printf '\n%s\n' "$line" >> "$original"
+  if run_check >"$TMP/$name.out" 2>&1; then
+    echo "FAIL: mutation $name was not observed" >&2
+    exit 1
+  fi
+  grep -Fq "$diagnostic" "$TMP/$name.out" || {
+    echo "FAIL: mutation $name missed diagnostic: $diagnostic" >&2
+    cat "$TMP/$name.out" >&2
+    exit 1
+  }
+  mv "$backup" "$original"
+  mutation_count=$((mutation_count + 1))
+  echo "PASS: $name"
+}
+
+rewrite_and_expect_failure() {
+  local name="$1" file="$2" diagnostic="$3"
+  local original="$TMP/$file" backup="$TMP/$file.$name"
+  cp "$original" "$backup"
+  cat > "$original"
   if run_check >"$TMP/$name.out" 2>&1; then
     echo "FAIL: mutation $name was not observed" >&2
     exit 1
@@ -491,8 +530,132 @@ mutate_and_expect_failure stale-codespaces-host demo/CODESPACES-PLAYBOOK.md \
   's#https://getassay.dev/install.sh#https://assay.dev/install.sh#' \
   'unrelated assay.dev onboarding URL'
 
-if [ "$mutation_count" -ne 70 ]; then
-  echo "FAIL: expected 70 release-surface mutations, observed $mutation_count" >&2
+RECIPE_FILE=docs/guides/editor-mcp-recipe.md
+PINNED_CLI_DIAG='expected exactly one current release-pinned assay-cli plugin install'
+PINNED_MCP_DIAG='expected exactly one current release-pinned assay-mcp-server plugin install'
+
+mutate_and_expect_failure plugin-stale-version "$RECIPE_FILE" \
+  's/assay-cli --version 5.1.0/assay-cli --version 5.0.0/' \
+  "$PINNED_CLI_DIAG"
+mutate_and_expect_failure plugin-missing-version "$RECIPE_FILE" \
+  's/cargo install assay-cli --version 5.1.0 --locked/cargo install assay-cli --locked/' \
+  "$PINNED_CLI_DIAG"
+mutate_and_expect_failure plugin-duplicate-pinned "$RECIPE_FILE" \
+  '/cargo install assay-cli --version 5.1.0 --locked/p' \
+  "$PINNED_CLI_DIAG"
+mutate_and_expect_failure plugin-no-locked "$RECIPE_FILE" \
+  's/cargo install assay-cli --version 5.1.0 --locked/cargo install assay-cli --version 5.1.0/' \
+  "$PINNED_CLI_DIAG"
+mutate_and_expect_failure plugin-comment "$RECIPE_FILE" \
+  's/^cargo install assay-cli --version 5.1.0 --locked/# cargo install assay-cli --version 5.1.0 --locked/' \
+  "$PINNED_CLI_DIAG"
+mutate_and_expect_failure plugin-prose "$RECIPE_FILE" \
+  's/^cargo install assay-cli --version 5.1.0 --locked$/Run cargo install assay-cli --version 5.1.0 --locked before continuing./' \
+  "$PINNED_CLI_DIAG"
+mutate_and_expect_failure plugin-path-in-plugin "$RECIPE_FILE" \
+  '/^assay version$/i cargo install --path crates/assay-mcp-server --locked' \
+  'source-path cargo install is not allowed'
+mutate_and_expect_failure plugin-wrong-package "$RECIPE_FILE" \
+  '/^assay version$/i cargo install assay --locked' \
+  'unsupported Rust CLI package; use assay-cli'
+mutate_and_expect_failure plugin-missing-h2 "$RECIPE_FILE" \
+  '/^## Install the Claude Code plugin$/d' \
+  "$PINNED_CLI_DIAG"
+mutate_and_expect_failure plugin-wrong-h2 "$RECIPE_FILE" \
+  's/^## Install the Claude Code plugin$/## Install the Claude Code Plugin/' \
+  "$PINNED_CLI_DIAG"
+mutate_and_expect_failure plugin-missing-fence "$RECIPE_FILE" \
+  '0,/^```bash$/s/^```bash$/```/' \
+  "$PINNED_CLI_DIAG"
+mutate_and_expect_failure plugin-wrong-fence "$RECIPE_FILE" \
+  '0,/^```bash$/s/^```bash$/```sh/' \
+  "$PINNED_CLI_DIAG"
+mutate_and_expect_failure plugin-extra-cargo-install "$RECIPE_FILE" \
+  '/^assay version$/i cargo install extra-crate --locked' \
+  'unexpected cargo install'
+mutate_and_expect_failure plugin-quoted-cargo-install "$RECIPE_FILE" \
+  's/cargo install assay-cli --version 5.1.0 --locked/cargo install "assay-cli" --version 5.1.0 --locked/' \
+  'quoted cargo install is not a published pin'
+mutate_and_expect_failure floating-outside-plugin "$RECIPE_FILE" \
+  's/cargo install --path crates\/assay-mcp-server --locked/cargo install --path crates\/assay-mcp-server --locked\ncargo install assay-cli --locked/' \
+  'floating unpinned assay-cli install'
+
+rewrite_and_expect_failure plugin-duplicate-h2 "$RECIPE_FILE" \
+  "$PINNED_CLI_DIAG" <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay version
+assay-mcp-server --version
+```
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay version
+assay-mcp-server --version
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
+
+rewrite_and_expect_failure plugin-second-bash-fence "$RECIPE_FILE" \
+  "$PINNED_CLI_DIAG" <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay version
+assay-mcp-server --version
+```
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
+
+rewrite_and_expect_failure plugin-continued-cargo-install "$RECIPE_FILE" \
+  'continued cargo install is not a published pin' <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli \
+  --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay version
+assay-mcp-server --version
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
+
+if [ "$mutation_count" -ne 88 ]; then
+  echo "FAIL: expected 88 release-surface mutations, observed $mutation_count" >&2
   exit 1
 fi
 echo "release-surface mutations: $mutation_count observed"

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -552,33 +552,133 @@ mutate_and_expect_failure plugin-comment "$RECIPE_FILE" \
 mutate_and_expect_failure plugin-prose "$RECIPE_FILE" \
   's/^cargo install assay-cli --version 5.1.0 --locked$/Run cargo install assay-cli --version 5.1.0 --locked before continuing./' \
   "$PINNED_CLI_DIAG"
-mutate_and_expect_failure plugin-path-in-plugin "$RECIPE_FILE" \
-  '/^assay version$/i cargo install --path crates/assay-mcp-server --locked' \
-  'source-path cargo install is not allowed'
-mutate_and_expect_failure plugin-wrong-package "$RECIPE_FILE" \
-  '/^assay version$/i cargo install assay --locked' \
-  'unsupported Rust CLI package; use assay-cli'
+rewrite_and_expect_failure plugin-path-in-plugin "$RECIPE_FILE" \
+  'source-path cargo install is not allowed' <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+cargo install --path crates/assay-mcp-server --locked
+assay version
+assay-mcp-server --version
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
+rewrite_and_expect_failure plugin-wrong-package "$RECIPE_FILE" \
+  'unsupported Rust CLI package; use assay-cli' <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+cargo install assay --locked
+assay version
+assay-mcp-server --version
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
 mutate_and_expect_failure plugin-missing-h2 "$RECIPE_FILE" \
   '/^## Install the Claude Code plugin$/d' \
   "$PINNED_CLI_DIAG"
 mutate_and_expect_failure plugin-wrong-h2 "$RECIPE_FILE" \
   's/^## Install the Claude Code plugin$/## Install the Claude Code Plugin/' \
   "$PINNED_CLI_DIAG"
-mutate_and_expect_failure plugin-missing-fence "$RECIPE_FILE" \
-  '0,/^```bash$/s/^```bash$/```/' \
-  "$PINNED_CLI_DIAG"
-mutate_and_expect_failure plugin-wrong-fence "$RECIPE_FILE" \
-  '0,/^```bash$/s/^```bash$/```sh/' \
-  "$PINNED_CLI_DIAG"
-mutate_and_expect_failure plugin-extra-cargo-install "$RECIPE_FILE" \
-  '/^assay version$/i cargo install extra-crate --locked' \
-  'unexpected cargo install'
+rewrite_and_expect_failure plugin-missing-fence "$RECIPE_FILE" \
+  "$PINNED_CLI_DIAG" <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay version
+assay-mcp-server --version
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
+rewrite_and_expect_failure plugin-wrong-fence "$RECIPE_FILE" \
+  "$PINNED_CLI_DIAG" <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```sh
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay version
+assay-mcp-server --version
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
+rewrite_and_expect_failure plugin-extra-cargo-install "$RECIPE_FILE" \
+  'unexpected cargo install' <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+cargo install extra-crate --locked
+assay version
+assay-mcp-server --version
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
 mutate_and_expect_failure plugin-quoted-cargo-install "$RECIPE_FILE" \
   's/cargo install assay-cli --version 5.1.0 --locked/cargo install "assay-cli" --version 5.1.0 --locked/' \
   'quoted cargo install is not a published pin'
-mutate_and_expect_failure floating-outside-plugin "$RECIPE_FILE" \
-  's/cargo install --path crates\/assay-mcp-server --locked/cargo install --path crates\/assay-mcp-server --locked\ncargo install assay-cli --locked/' \
-  'floating unpinned assay-cli install'
+rewrite_and_expect_failure floating-outside-plugin "$RECIPE_FILE" \
+  'floating unpinned assay-cli install' <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay version
+assay-mcp-server --version
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+cargo install assay-cli --locked
+```
+MD
 
 rewrite_and_expect_failure plugin-duplicate-h2 "$RECIPE_FILE" \
   "$PINNED_CLI_DIAG" <<'MD'

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -190,6 +190,7 @@ for path in (
     "mkdocs.yml",
     "scripts/ci/lib/editor-plugin-install-commands.sh",
     "docs/guides/editor-mcp-recipe.md",
+    "scripts/ci/test-editor-release-hook-precommit-consumer.sh",
 ):
     if not pattern.search(path):
         raise SystemExit(f"release-surface hook omits {path}")

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -682,6 +682,46 @@ cargo install --path crates/assay-mcp-server --locked
 cargo install assay-cli --locked
 ```
 MD
+rewrite_and_expect_failure floating-mcp-outside-plugin "$RECIPE_FILE" \
+  'floating unpinned assay-mcp-server install' <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay version
+assay-mcp-server --version
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+cargo install assay-mcp-server --locked
+```
+MD
+rewrite_and_expect_failure plugin-cargo-offline-install "$RECIPE_FILE" \
+  'unexpected cargo command' <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+cargo --offline install extra-crate --locked
+assay version
+assay-mcp-server --version
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
 
 rewrite_and_expect_failure plugin-duplicate-h2 "$RECIPE_FILE" \
   "$PINNED_CLI_DIAG" <<'MD'
@@ -757,8 +797,8 @@ cargo install --path crates/assay-mcp-server --locked
 ```
 MD
 
-if [ "$mutation_count" -ne 89 ]; then
-  echo "FAIL: expected 89 release-surface mutations, observed $mutation_count" >&2
+if [ "$mutation_count" -ne 91 ]; then
+  echo "FAIL: expected 91 release-surface mutations, observed $mutation_count" >&2
   exit 1
 fi
 echo "release-surface mutations: $mutation_count observed"

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -849,6 +849,32 @@ cargo install --path crates/assay-mcp-server --locked
 ```
 MD
 
+rewrite_and_expect_failure plugin-absorbed-next-h2 "$RECIPE_FILE" \
+  'plugin bash fence absorbs a later H2' <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay version
+assay-mcp-server --version
+
+Continue with the verification notes below.
+
+## Verify the installation
+
+Run both version probes before continuing.
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
+
 rewrite_and_expect_failure plugin-continued-cargo-install "$RECIPE_FILE" \
   'continued cargo install is not a published pin' <<'MD'
 Codex uses .codex/config.toml.
@@ -870,8 +896,8 @@ cargo install --path crates/assay-mcp-server --locked
 ```
 MD
 
-if [ "$mutation_count" -ne 94 ]; then
-  echo "FAIL: expected 94 release-surface mutations, observed $mutation_count" >&2
+if [ "$mutation_count" -ne 95 ]; then
+  echo "FAIL: expected 95 release-surface mutations, observed $mutation_count" >&2
   exit 1
 fi
 echo "release-surface mutations: $mutation_count observed"

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -824,6 +824,31 @@ cargo install --path crates/assay-mcp-server --locked
 ```
 MD
 
+rewrite_and_expect_failure plugin-unclosed-bash-fence "$RECIPE_FILE" \
+  'plugin bash fence is not closed at its own boundary' <<'MD'
+Codex uses .codex/config.toml.
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay version
+assay-mcp-server --version
+
+### Update stale state
+
+```sh
+claude plugin update assay@assay --scope local
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
+
 rewrite_and_expect_failure plugin-continued-cargo-install "$RECIPE_FILE" \
   'continued cargo install is not a published pin' <<'MD'
 Codex uses .codex/config.toml.
@@ -845,8 +870,8 @@ cargo install --path crates/assay-mcp-server --locked
 ```
 MD
 
-if [ "$mutation_count" -ne 93 ]; then
-  echo "FAIL: expected 93 release-surface mutations, observed $mutation_count" >&2
+if [ "$mutation_count" -ne 94 ]; then
+  echo "FAIL: expected 94 release-surface mutations, observed $mutation_count" >&2
   exit 1
 fi
 echo "release-surface mutations: $mutation_count observed"

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -135,6 +135,7 @@ cargo install assay-cli --version 5.1.0 --locked
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools
@@ -567,6 +568,7 @@ cargo install assay-mcp-server --version 5.1.0 --locked
 cargo install --path crates/assay-mcp-server --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools
@@ -587,6 +589,7 @@ cargo install assay-mcp-server --version 5.1.0 --locked
 cargo install assay --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools
@@ -612,6 +615,7 @@ cargo install assay-cli --version 5.1.0 --locked
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools
@@ -631,6 +635,7 @@ cargo install assay-cli --version 5.1.0 --locked
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools
@@ -651,6 +656,7 @@ cargo install assay-mcp-server --version 5.1.0 --locked
 cargo install extra-crate --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools
@@ -673,6 +679,7 @@ cargo install assay-cli --version 5.1.0 --locked
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools
@@ -693,6 +700,7 @@ cargo install assay-cli --version 5.1.0 --locked
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools
@@ -714,6 +722,7 @@ cargo install assay-mcp-server --version 5.1.0 --locked
 cargo --offline install extra-crate --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools
@@ -734,6 +743,7 @@ cargo install assay-cli --version 5.1.0 --locked
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install the Claude Code plugin
@@ -743,6 +753,7 @@ cargo install assay-cli --version 5.1.0 --locked
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools
@@ -763,6 +774,7 @@ cargo install assay-cli --version 5.1.0 --locked
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ```bash
@@ -792,6 +804,7 @@ assay version
 ```bash
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools
@@ -815,6 +828,7 @@ assay version
 ```bash
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools
@@ -835,6 +849,7 @@ cargo install assay-cli --version 5.1.0 --locked
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 
 ### Update stale state
 
@@ -850,7 +865,7 @@ cargo install --path crates/assay-mcp-server --locked
 MD
 
 rewrite_and_expect_failure plugin-absorbed-next-h2 "$RECIPE_FILE" \
-  'plugin bash fence absorbs a later H2' <<'MD'
+  'plugin bash fence end marker must immediately precede its close' <<'MD'
 Codex uses .codex/config.toml.
 
 ## Install the Claude Code plugin
@@ -860,11 +875,11 @@ cargo install assay-cli --version 5.1.0 --locked
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 
 Continue with the verification notes below.
 
 ## Verify the installation
-
 Run both version probes before continuing.
 ```
 
@@ -887,6 +902,7 @@ cargo install assay-cli \
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools

--- a/scripts/ci/test-editor-plugin-install-commands.sh
+++ b/scripts/ci/test-editor-plugin-install-commands.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ci/lib/editor-plugin-install-commands.sh.
+#
+# The extractor owns parsing of the Claude Code plugin install fence. Guards must
+# not reimplement that awk. This battery drives the sourceable function and the
+# executable entry against fixtures, so a later semantic change cannot hide behind
+# a guard that still happens to pass.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIB="$ROOT/scripts/ci/lib/editor-plugin-install-commands.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cases=0
+failures=0
+
+if [ ! -f "$LIB" ]; then
+  printf 'FAIL: extractor missing: %s\n' "$LIB"
+  exit 1
+fi
+
+# shellcheck source=scripts/ci/lib/editor-plugin-install-commands.sh
+source "$LIB"
+
+write_recipe() {
+  cat > "$TMP/recipe.md"
+}
+
+run_exe() {
+  bash "$LIB" "$TMP/recipe.md" 2>"$TMP/err"
+}
+
+run_fn() {
+  editor_plugin_install_commands "$TMP/recipe.md" 2>"$TMP/err"
+}
+
+expect_stdout() {
+  local label="$1" expected="$2"
+  local got
+  cases=$((cases + 1))
+  if ! got="$(run_exe)"; then
+    failures=$((failures + 1))
+    printf 'FAIL: %s — executable extractor exited non-zero\n%s\n' "$label" "$(cat "$TMP/err")"
+    return
+  fi
+  if [ "$got" != "$expected" ]; then
+    failures=$((failures + 1))
+    printf 'FAIL: %s — executable stdout mismatch\nexpected:\n%s\ngot:\n%s\n' \
+      "$label" "$expected" "$got"
+    return
+  fi
+  cases=$((cases + 1))
+  if ! got="$(run_fn)"; then
+    failures=$((failures + 1))
+    printf 'FAIL: %s — sourced function exited non-zero\n%s\n' "$label" "$(cat "$TMP/err")"
+    return
+  fi
+  if [ "$got" != "$expected" ]; then
+    failures=$((failures + 1))
+    printf 'FAIL: %s — sourced stdout mismatch\nexpected:\n%s\ngot:\n%s\n' \
+      "$label" "$expected" "$got"
+    return
+  fi
+  printf 'ok   %s\n' "$label"
+}
+
+expect_empty() {
+  local label="$1"
+  expect_stdout "$label" ""
+}
+
+expect_fail() {
+  local label="$1" expected="$2"
+  cases=$((cases + 1))
+  if got="$(run_exe)"; then
+    failures=$((failures + 1))
+    printf 'FAIL: %s — executable extractor accepted input it should reject\n%s\n' \
+      "$label" "$got"
+    return
+  fi
+  if ! grep -Fq -- "$expected" "$TMP/err"; then
+    failures=$((failures + 1))
+    printf 'FAIL: %s — rejected, but not for the stated reason (wanted %s)\n%s\n' \
+      "$label" "$expected" "$(cat "$TMP/err")"
+    return
+  fi
+  printf 'ok   %s\n' "$label"
+}
+
+echo '== baseline: plugin bash fence commands are emitted =='
+write_recipe <<'MD'
+# Title
+
+## Install the Claude Code plugin
+
+```bash
+# comment should be skipped
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+
+assay version
+assay-mcp-server --version
+```
+
+## Install Assay's review tools
+
+```bash
+cargo install --path crates/assay-mcp-server --locked
+```
+MD
+expect_stdout 'plugin fence commands; path-elsewhere omitted' \
+  $'cargo install assay-cli --version 5.1.0 --locked\ncargo install assay-mcp-server --version 5.1.0 --locked\nassay version\nassay-mcp-server --version'
+
+echo '== comments and blank lines in the fence are not commands =='
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+# cargo install assay-cli --version 5.1.0 --locked
+   # indented comment
+
+cargo install assay-mcp-server --version 5.1.0 --locked
+```
+MD
+expect_stdout 'comment skip keeps only non-comment lines' \
+  'cargo install assay-mcp-server --version 5.1.0 --locked'
+
+echo '== H2 scoping: only the exact plugin heading =='
+write_recipe <<'MD'
+## Install the Claude Code Plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+```
+
+## Install the Claude Code plugin extra
+
+```bash
+cargo install assay-mcp-server --version 5.1.0 --locked
+```
+MD
+expect_empty 'wrong H2 text emits nothing'
+
+write_recipe <<'MD'
+## Something else
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+assay version
+```
+MD
+expect_empty 'other H2 does not emit plugin commands'
+
+echo '== fence scoping: only the exact ```bash opener =='
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```sh
+cargo install assay-cli --version 5.1.0 --locked
+```
+
+```
+assay version
+```
+
+~~~bash
+assay-mcp-server --version
+~~~
+MD
+expect_empty 'non-bash fences emit nothing'
+
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+assay version
+```
+MD
+expect_stdout 'exact ```bash fence is extracted' 'assay version'
+
+echo '== duplicate matching H2: both sections emit =='
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+assay version
+```
+
+## Other
+
+```bash
+ignored
+```
+
+## Install the Claude Code plugin
+
+```bash
+assay-mcp-server --version
+```
+MD
+expect_stdout 'duplicate plugin H2 concatenates both fences' \
+  $'assay version\nassay-mcp-server --version'
+
+echo '== quoted and continued lines are emitted as standalone text =='
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+cargo install "assay-cli" --version 5.1.0 --locked
+cargo install assay-cli \
+  --version 5.1.0 --locked
+```
+MD
+expect_stdout 'extractor does not join or unquote cargo lines' \
+  $'cargo install "assay-cli" --version 5.1.0 --locked\ncargo install assay-cli \\\n--version 5.1.0 --locked'
+
+echo '== missing H2 or fence emits nothing; consumers fail =='
+write_recipe <<'MD'
+# no plugin heading
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+```
+MD
+expect_empty 'missing plugin H2 emits nothing'
+
+echo '== recipe byte ceiling =='
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+assay version
+```
+MD
+bytes="$(wc -c < "$TMP/recipe.md")"
+printf '%*s' "$((65536 - bytes))" '' >> "$TMP/recipe.md"
+cases=$((cases + 1))
+if ! run_exe >/dev/null; then
+  failures=$((failures + 1))
+  printf 'FAIL: recipe at 65536 bytes rejected\n%s\n' "$(cat "$TMP/err")"
+else
+  printf 'ok   recipe at 65536 bytes accepted\n'
+fi
+printf ' ' >> "$TMP/recipe.md"
+expect_fail 'recipe over 65536 bytes rejected' 'recipe exceeds 65536-byte limit'
+
+printf '\n'
+if [ "$failures" -gt 0 ]; then
+  printf 'editor plugin install extractor self-test: %s of %s case(s) failed\n' \
+    "$failures" "$cases"
+  exit 1
+fi
+printf 'editor plugin install extractor self-test: %s case(s) PASS\n' "$cases"

--- a/scripts/ci/test-editor-plugin-install-commands.sh
+++ b/scripts/ci/test-editor-plugin-install-commands.sh
@@ -73,20 +73,44 @@ expect_empty() {
 
 expect_fail() {
   local label="$1" expected="$2"
+  local got case_failed=0
   cases=$((cases + 1))
   if got="$(run_exe)"; then
     failures=$((failures + 1))
+    case_failed=1
     printf 'FAIL: %s — executable extractor accepted input it should reject\n%s\n' \
       "$label" "$got"
-    return
-  fi
-  if ! grep -Fq -- "$expected" "$TMP/err"; then
+  elif [ -n "$got" ]; then
     failures=$((failures + 1))
-    printf 'FAIL: %s — rejected, but not for the stated reason (wanted %s)\n%s\n' \
+    case_failed=1
+    printf 'FAIL: %s — executable extractor emitted stdout before rejecting\n%s\n' \
+      "$label" "$got"
+  elif ! grep -Fq -- "$expected" "$TMP/err"; then
+    failures=$((failures + 1))
+    case_failed=1
+    printf 'FAIL: %s — executable rejected, but not for the stated reason (wanted %s)\n%s\n' \
       "$label" "$expected" "$(cat "$TMP/err")"
-    return
   fi
-  printf 'ok   %s\n' "$label"
+
+  if got="$(run_fn)"; then
+    failures=$((failures + 1))
+    case_failed=1
+    printf 'FAIL: %s — sourced extractor accepted input it should reject\n%s\n' \
+      "$label" "$got"
+  elif [ -n "$got" ]; then
+    failures=$((failures + 1))
+    case_failed=1
+    printf 'FAIL: %s — sourced extractor emitted stdout before rejecting\n%s\n' \
+      "$label" "$got"
+  elif ! grep -Fq -- "$expected" "$TMP/err"; then
+    failures=$((failures + 1))
+    case_failed=1
+    printf 'FAIL: %s — sourced function rejected, but not for the stated reason (wanted %s)\n%s\n' \
+      "$label" "$expected" "$(cat "$TMP/err")"
+  fi
+  if [ "$case_failed" -eq 0 ]; then
+    printf 'ok   %s\n' "$label"
+  fi
 }
 
 echo '== baseline: plugin bash fence commands are emitted =='
@@ -269,6 +293,36 @@ assay version
 MD
 expect_fail 'plugin bash fence left open at end of file' \
   'plugin bash fence is not closed at its own boundary'
+
+echo '== a blank-line-delimited next H2 cannot be absorbed by the bash fence =='
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+assay version
+
+Continue with the verification notes below.
+
+## Verify the installation
+
+Run both version probes before continuing.
+```
+MD
+expect_fail 'later bare fence cannot close across an apparent next H2' \
+  'plugin bash fence absorbs a later H2'
+
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+assay version
+
+## shell comment
+assay-mcp-server --version
+```
+MD
+expect_stdout 'in-fence H2-shaped shell comment remains supported' \
+  $'assay version\nassay-mcp-server --version'
 
 echo '== quoted and continued lines are emitted as standalone text =='
 write_recipe <<'MD'

--- a/scripts/ci/test-editor-plugin-install-commands.sh
+++ b/scripts/ci/test-editor-plugin-install-commands.sh
@@ -242,6 +242,34 @@ MD
 expect_fail 'split CLI/MCP commands across two bash fences' \
   'expected exactly one bash fence in the plugin section'
 
+echo '== the plugin bash fence must close before a later fenced block =='
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay version
+assay-mcp-server --version
+
+### Update stale state
+
+```sh
+claude plugin update assay@assay --scope local
+```
+MD
+expect_fail 'later fenced block cannot close the plugin bash fence' \
+  'plugin bash fence is not closed at its own boundary'
+
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+assay version
+MD
+expect_fail 'plugin bash fence left open at end of file' \
+  'plugin bash fence is not closed at its own boundary'
+
 echo '== quoted and continued lines are emitted as standalone text =='
 write_recipe <<'MD'
 ## Install the Claude Code plugin

--- a/scripts/ci/test-editor-plugin-install-commands.sh
+++ b/scripts/ci/test-editor-plugin-install-commands.sh
@@ -141,7 +141,8 @@ cargo install assay-cli --version 5.1.0 --locked
 cargo install assay-mcp-server --version 5.1.0 --locked
 ```
 MD
-expect_empty 'wrong H2 text emits nothing'
+expect_fail 'wrong H2 text is not exactly one plugin heading' \
+  'expected exactly one plugin install heading'
 
 write_recipe <<'MD'
 ## Something else
@@ -151,7 +152,8 @@ cargo install assay-cli --version 5.1.0 --locked
 assay version
 ```
 MD
-expect_empty 'other H2 does not emit plugin commands'
+expect_fail 'other H2 is not exactly one plugin heading' \
+  'expected exactly one plugin install heading'
 
 echo '== fence scoping: only the exact ```bash opener =='
 write_recipe <<'MD'
@@ -169,7 +171,8 @@ assay version
 assay-mcp-server --version
 ~~~
 MD
-expect_empty 'non-bash fences emit nothing'
+expect_fail 'non-bash fences are not exactly one bash fence' \
+  'expected exactly one bash fence in the plugin section'
 
 write_recipe <<'MD'
 ## Install the Claude Code plugin
@@ -180,7 +183,7 @@ assay version
 MD
 expect_stdout 'exact ```bash fence is extracted' 'assay version'
 
-echo '== duplicate matching H2: both sections emit =='
+echo '== duplicate matching H2 is not exactly one heading =='
 write_recipe <<'MD'
 ## Install the Claude Code plugin
 
@@ -200,8 +203,44 @@ ignored
 assay-mcp-server --version
 ```
 MD
-expect_stdout 'duplicate plugin H2 concatenates both fences' \
-  $'assay version\nassay-mcp-server --version'
+expect_fail 'duplicate plugin H2 concatenates both fences' \
+  'expected exactly one plugin install heading'
+
+echo '== split commands across two plugin H2s is a heading failure =='
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+assay version
+```
+
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay-mcp-server --version
+```
+MD
+expect_fail 'split CLI/MCP commands across two plugin H2s' \
+  'expected exactly one plugin install heading'
+
+echo '== split commands across two bash fences is a fence failure =='
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+cargo install assay-cli --version 5.1.0 --locked
+assay version
+```
+
+```bash
+cargo install assay-mcp-server --version 5.1.0 --locked
+assay-mcp-server --version
+```
+MD
+expect_fail 'split CLI/MCP commands across two bash fences' \
+  'expected exactly one bash fence in the plugin section'
 
 echo '== quoted and continued lines are emitted as standalone text =='
 write_recipe <<'MD'
@@ -216,7 +255,7 @@ MD
 expect_stdout 'extractor does not join or unquote cargo lines' \
   $'cargo install "assay-cli" --version 5.1.0 --locked\ncargo install assay-cli \\\n--version 5.1.0 --locked'
 
-echo '== missing H2 or fence emits nothing; consumers fail =='
+echo '== missing plugin H2 is not exactly one heading =='
 write_recipe <<'MD'
 # no plugin heading
 
@@ -224,7 +263,8 @@ write_recipe <<'MD'
 cargo install assay-cli --version 5.1.0 --locked
 ```
 MD
-expect_empty 'missing plugin H2 emits nothing'
+expect_fail 'missing plugin H2 is not exactly one heading' \
+  'expected exactly one plugin install heading'
 
 echo '== recipe byte ceiling =='
 write_recipe <<'MD'

--- a/scripts/ci/test-editor-plugin-install-commands.sh
+++ b/scripts/ci/test-editor-plugin-install-commands.sh
@@ -126,6 +126,7 @@ cargo install assay-mcp-server --version 5.1.0 --locked
 
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 
 ## Install Assay's review tools
@@ -146,6 +147,7 @@ write_recipe <<'MD'
    # indented comment
 
 cargo install assay-mcp-server --version 5.1.0 --locked
+# assay-editor-plugin-install-commands:end
 ```
 MD
 expect_stdout 'comment skip keeps only non-comment lines' \
@@ -203,6 +205,7 @@ write_recipe <<'MD'
 
 ```bash
 assay version
+# assay-editor-plugin-install-commands:end
 ```
 MD
 expect_stdout 'exact ```bash fence is extracted' 'assay version'
@@ -225,6 +228,7 @@ ignored
 
 ```bash
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 MD
 expect_fail 'duplicate plugin H2 concatenates both fences' \
@@ -244,6 +248,7 @@ assay version
 ```bash
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 MD
 expect_fail 'split CLI/MCP commands across two plugin H2s' \
@@ -261,6 +266,7 @@ assay version
 ```bash
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 MD
 expect_fail 'split CLI/MCP commands across two bash fences' \
@@ -275,6 +281,7 @@ cargo install assay-cli --version 5.1.0 --locked
 cargo install assay-mcp-server --version 5.1.0 --locked
 assay version
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 
 ### Update stale state
 
@@ -290,26 +297,60 @@ write_recipe <<'MD'
 
 ```bash
 assay version
+# assay-editor-plugin-install-commands:end
 MD
 expect_fail 'plugin bash fence left open at end of file' \
   'plugin bash fence is not closed at its own boundary'
 
-echo '== a blank-line-delimited next H2 cannot be absorbed by the bash fence =='
+echo '== only the explicit marker can establish the plugin bash fence boundary =='
 write_recipe <<'MD'
 ## Install the Claude Code plugin
 
 ```bash
 assay version
+# assay-editor-plugin-install-commands:end
 
 Continue with the verification notes below.
 
 ## Verify the installation
-
 Run both version probes before continuing.
 ```
 MD
 expect_fail 'later bare fence cannot close across an apparent next H2' \
-  'plugin bash fence absorbs a later H2'
+  'plugin bash fence end marker must immediately precede its close'
+
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+assay version
+```
+MD
+expect_fail 'plugin bash fence end marker is required' \
+  'expected exactly one plugin bash fence end marker'
+
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+assay version
+# assay-editor-plugin-install-commands:end
+# assay-editor-plugin-install-commands:end
+```
+MD
+expect_fail 'plugin bash fence end marker must be unique' \
+  'expected exactly one plugin bash fence end marker'
+
+write_recipe <<'MD'
+## Install the Claude Code plugin
+
+```bash
+# assay-editor-plugin-install-commands:end
+assay version
+```
+MD
+expect_fail 'plugin bash fence end marker cannot move away from close' \
+  'plugin bash fence end marker must immediately precede its close'
 
 write_recipe <<'MD'
 ## Install the Claude Code plugin
@@ -319,6 +360,7 @@ assay version
 
 ## shell comment
 assay-mcp-server --version
+# assay-editor-plugin-install-commands:end
 ```
 MD
 expect_stdout 'in-fence H2-shaped shell comment remains supported' \
@@ -332,6 +374,7 @@ write_recipe <<'MD'
 cargo install "assay-cli" --version 5.1.0 --locked
 cargo install assay-cli \
   --version 5.1.0 --locked
+# assay-editor-plugin-install-commands:end
 ```
 MD
 expect_stdout 'extractor does not join or unquote cargo lines' \
@@ -354,6 +397,7 @@ write_recipe <<'MD'
 
 ```bash
 assay version
+# assay-editor-plugin-install-commands:end
 ```
 MD
 bytes="$(wc -c < "$TMP/recipe.md")"

--- a/scripts/ci/test-editor-release-hook-precommit-consumer.sh
+++ b/scripts/ci/test-editor-release-hook-precommit-consumer.sh
@@ -7,7 +7,10 @@
 # duplicate-key-rejecting PyYAML SafeLoader and counts both protected IDs from
 # repos[*].hooks[*] (flow mapping and reordered keys included). A producer hook
 # independently invokes this script so last-key-wins `entry: 'true'` on the
-# consumer hook cannot skip the contract.
+# consumer hook cannot skip the contract. Both producer and consumer live in the
+# yaml being validated, so last-key-wins `entry: 'true'` on BOTH is still a
+# paired no-op for pre-commit. Kernel Matrix lint invokes this script directly
+# outside that yaml so the contract still runs.
 set -euo pipefail
 
 # shellcheck source=scripts/ci/lib/clear-git-repository-env.sh
@@ -15,6 +18,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/clear-git-repository-e
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CONFIG="$ROOT/.pre-commit-config.yaml"
+KERNEL_MATRIX="$ROOT/.github/workflows/kernel-matrix.yml"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -304,6 +308,91 @@ def problems_for(
     return problems
 
 
+CI_CONSUMER_STEP = (
+    "      - name: Editor-release hook pre-commit consumer\n"
+    "        shell: bash\n"
+    "        run: |\n"
+    "          set -euo pipefail\n"
+    "          bash scripts/ci/test-editor-release-hook-precommit-consumer.sh\n"
+)
+CI_CONSUMER_STEP_HEAD = (
+    "      - name: Editor-release hook pre-commit consumer\n"
+    "        shell: bash\n"
+)
+CI_CONSUMER_RUN_LINE = (
+    "          bash scripts/ci/test-editor-release-hook-precommit-consumer.sh\n"
+)
+
+
+def problems_for_ci(src: str, *, contract_rel: str) -> list[str]:
+    problems: list[str] = []
+    try:
+        data = load_unique(src)
+    except yaml.YAMLError as exc:
+        problems.append(f"kernel-matrix.yml YAML rejected: {exc}")
+        return problems
+    if not isinstance(data, dict):
+        problems.append("kernel-matrix.yml: root is not a mapping")
+        return problems
+    jobs = data.get("jobs")
+    if not isinstance(jobs, dict):
+        problems.append("kernel-matrix.yml: jobs missing")
+        return problems
+    lint = jobs.get("lint")
+    if not isinstance(lint, dict):
+        problems.append("kernel-matrix.yml: lint job missing")
+        return problems
+    if lint.get("name") != "Lint (pre-commit)":
+        problems.append("kernel-matrix.yml: lint job name is not Lint (pre-commit)")
+    steps = lint.get("steps")
+    if not isinstance(steps, list):
+        problems.append("kernel-matrix.yml: lint job has no steps")
+        return problems
+
+    wanted = f"bash {contract_rel}"
+    install_idx = None
+    active: list[int] = []
+    for index, step in enumerate(steps):
+        if not isinstance(step, dict):
+            continue
+        if step.get("name") == "Install pre-commit (pinned)":
+            install_idx = index
+        run = step.get("run")
+        if not isinstance(run, str):
+            continue
+        body = tuple(
+            line.strip()
+            for line in run.splitlines()
+            if line.strip()
+            and not line.strip().startswith("#")
+            and line.strip() != "set -euo pipefail"
+        )
+        if body != (wanted,):
+            continue
+        if step.get("continue-on-error") is True:
+            continue
+        if "if" in step:
+            continue
+        active.append(index)
+
+    if len(active) != 1:
+        problems.append(
+            f"kernel-matrix lint job: expected exactly one active direct "
+            f"invocation of {contract_rel}, found {len(active)}"
+        )
+        return problems
+    if install_idx is None:
+        problems.append(
+            "kernel-matrix lint job missing Install pre-commit (pinned)"
+        )
+    elif active[0] <= install_idx:
+        problems.append(
+            f"kernel-matrix lint job: direct invocation of {contract_rel} "
+            "must run after Install pre-commit (pinned)"
+        )
+    return problems
+
+
 def main() -> None:
     (
         editor_id,
@@ -337,6 +426,58 @@ def main() -> None:
             sys.stderr.write("\n".join(problems) + "\n")
             raise SystemExit(1)
         return
+
+    if action == "check-ci":
+        problems = problems_for_ci(src, contract_rel=contract_rel)
+        if problems:
+            sys.stderr.write("\n".join(problems) + "\n")
+            raise SystemExit(1)
+        return
+
+    if action == "mutate-ci":
+        kind = rest[0]
+        if src.count(CI_CONSUMER_STEP) != 1:
+            raise SystemExit("canonical CI consumer step is not unique")
+        if kind == "delete-step":
+            Path(dest).write_text(src.replace(CI_CONSUMER_STEP, "", 1), encoding="utf-8")
+            return
+        if kind == "comment-step":
+            if src.count(CI_CONSUMER_RUN_LINE) != 1:
+                raise SystemExit("canonical CI consumer run line is not unique")
+            Path(dest).write_text(
+                src.replace(
+                    CI_CONSUMER_RUN_LINE,
+                    "          # bash scripts/ci/test-editor-release-hook-precommit-consumer.sh\n",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            return
+        if kind == "if-false":
+            if src.count(CI_CONSUMER_STEP_HEAD) != 1:
+                raise SystemExit("canonical CI consumer step head is not unique")
+            Path(dest).write_text(
+                src.replace(
+                    CI_CONSUMER_STEP_HEAD,
+                    CI_CONSUMER_STEP_HEAD + "        if: false\n",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            return
+        if kind == "continue-on-error":
+            if src.count(CI_CONSUMER_STEP_HEAD) != 1:
+                raise SystemExit("canonical CI consumer step head is not unique")
+            Path(dest).write_text(
+                src.replace(
+                    CI_CONSUMER_STEP_HEAD,
+                    CI_CONSUMER_STEP_HEAD + "        continue-on-error: true\n",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            return
+        raise SystemExit(f"unknown ci mutation {kind}")
 
     if action == "extract-minimal":
         hook_id = rest[0]
@@ -524,6 +665,20 @@ expect_wiring_red() {
   fi
 }
 
+check_ci_producer() {
+  local path="$1"
+  cfg check-ci "$path" "$path"
+}
+
+expect_ci_red() {
+  local label="$1" config="$2"
+  if check_ci_producer "$config" >"$TMP/$label.ci" 2>&1; then
+    fail "$label — CI producer stayed green"
+  else
+    ok "RED $label"
+  fi
+}
+
 expect_consumer() {
   local label="$1" dest="$2" hook_id="$3" want="$4"
   local got
@@ -541,6 +696,13 @@ if check_wiring "$CONFIG"; then
   ok 'live unmutated tree wiring'
 else
   fail 'live unmutated tree wiring'
+fi
+
+echo '== live CI producer =='
+if check_ci_producer "$KERNEL_MATRIX"; then
+  ok 'live kernel-matrix lint job direct consumer invocation'
+else
+  fail 'live kernel-matrix lint job direct consumer invocation'
 fi
 
 echo '== pin behavior: unmutated consumer must fail closed =='
@@ -583,6 +745,24 @@ expect_wiring_red 'remove test-check-release-surface.sh from release-surface cha
 cfg mutate "$CONFIG" "$TMP/entry-true-consumer.yaml" entry-true "$CONSUMER_ID"
 expect_wiring_red "last-key-wins entry: 'true' on consumer hook" \
   "$TMP/entry-true-consumer.yaml"
+
+cfg mutate "$TMP/entry-true-consumer.yaml" "$TMP/entry-true-both.yaml" \
+  entry-true "$PRODUCER_ID"
+expect_wiring_red "paired last-key-wins entry: 'true' on producer and consumer" \
+  "$TMP/entry-true-both.yaml"
+
+cfg mutate-ci "$KERNEL_MATRIX" "$TMP/km-delete.yml" delete-step
+expect_ci_red 'deleting kernel-matrix lint consumer step' "$TMP/km-delete.yml"
+
+cfg mutate-ci "$KERNEL_MATRIX" "$TMP/km-comment.yml" comment-step
+expect_ci_red 'commenting kernel-matrix lint consumer step' "$TMP/km-comment.yml"
+
+cfg mutate-ci "$KERNEL_MATRIX" "$TMP/km-if-false.yml" if-false
+expect_ci_red 'if: false on kernel-matrix lint consumer step' "$TMP/km-if-false.yml"
+
+cfg mutate-ci "$KERNEL_MATRIX" "$TMP/km-continue.yml" continue-on-error
+expect_ci_red 'continue-on-error on kernel-matrix lint consumer step' \
+  "$TMP/km-continue.yml"
 
 cfg mutate "$CONFIG" "$TMP/flow-dup-editor.yaml" flow-duplicate "$EDITOR_ID"
 expect_wiring_red 'flow-mapping duplicate of editor-mcp-recipe-truth' \

--- a/scripts/ci/test-editor-release-hook-precommit-consumer.sh
+++ b/scripts/ci/test-editor-release-hook-precommit-consumer.sh
@@ -1,0 +1,507 @@
+#!/usr/bin/env bash
+# Pin editor-mcp-recipe-truth and release-surface through the pre-commit consumer.
+#
+# The 38/95 suites parse hook YAML themselves and miss last-key-wins duplicates
+# (`files: ^$`, `entry: 'true'`). pre-commit/PyYAML keeps the last key, so the
+# effective consumer Skips or runs `/usr/bin/true` while those suites stay green.
+# This contract owns both hook IDs independently and drives real `pre-commit run`.
+set -euo pipefail
+
+# shellcheck source=scripts/ci/lib/clear-git-repository-env.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/clear-git-repository-env.sh"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONFIG="$ROOT/.pre-commit-config.yaml"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+EDITOR_ID="editor-mcp-recipe-truth"
+RELEASE_ID="release-surface"
+CONSUMER_ID="editor-release-hook-precommit-consumer"
+CONTRACT_REL="scripts/ci/test-editor-release-hook-precommit-consumer.sh"
+
+EDITOR_ENTRY="bash -c 'bash scripts/ci/test-editor-plugin-install-commands.sh && bash scripts/ci/test-check-editor-mcp-recipe-truth.sh && bash scripts/ci/check-editor-mcp-recipe-truth.sh'"
+RELEASE_ENTRY="bash -c 'bash scripts/ci/test-check-release-surface.sh && bash scripts/ci/check-release-surface.sh'"
+CONSUMER_ENTRY="bash $CONTRACT_REL"
+
+EDITOR_DROP="bash scripts/ci/test-editor-plugin-install-commands.sh && "
+RELEASE_DROP="bash scripts/ci/test-check-release-surface.sh && "
+
+failures=0
+
+fail() {
+  failures=$((failures + 1))
+  printf 'FAIL: %s\n' "$*"
+}
+
+ok() { printf 'ok   %s\n' "$*"; }
+
+if ! command -v pre-commit >/dev/null 2>&1; then
+  fail "pre-commit not on PATH (CI pin is pre-commit==4.4.0)"
+  exit 1
+fi
+CFG_PY="$TMP/editor_release_hook_precommit_consumer.py"
+cat > "$CFG_PY" << 'ENDPY'
+# Helper for test-editor-release-hook-precommit-consumer.sh (invoked via python3).
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def uncommented_items(src: str) -> list[tuple[str, str]]:
+    items: list[tuple[str, str]] = []
+    for line in src.splitlines():
+        code = line.split("#", 1)[0].rstrip()
+        if ":" not in code:
+            continue
+        key, val = code.strip().split(":", 1)
+        items.append((key, val.strip()))
+    return items
+
+
+def hook_starts(src: str, hook_id: str) -> list[int]:
+    marker = f"      - id: {hook_id}\n"
+    starts: list[int] = []
+    i = 0
+    while True:
+        j = src.find(marker, i)
+        if j < 0:
+            return starts
+        starts.append(j)
+        i = j + 1
+
+
+def hook_span(src: str, hook_id: str) -> tuple[int, int]:
+    starts = hook_starts(src, hook_id)
+    if len(starts) != 1:
+        raise SystemExit(
+            f"expected exactly one hook block for {hook_id}, found {len(starts)}"
+        )
+    start = starts[0]
+    rest = src[start + 1 :]
+    cuts = []
+    for token in ("\n      - id:", "\n  - repo:"):
+        k = rest.find(token)
+        if k >= 0:
+            cuts.append(k)
+    end = start + 1 + min(cuts) if cuts else len(src)
+    return start, end
+
+
+def hook_block(src: str, hook_id: str) -> str:
+    start, end = hook_span(src, hook_id)
+    return src[start:end]
+
+
+def replace_block(src: str, hook_id: str, new_block: str) -> str:
+    start, end = hook_span(src, hook_id)
+    return src[:start] + new_block.rstrip("\n") + "\n" + src[end:]
+
+
+def insert_after_key(block: str, key: str, new_line: str) -> str:
+    lines = block.splitlines(keepends=True)
+    out: list[str] = []
+    inserted = False
+    for line in lines:
+        out.append(line)
+        code = line.split("#", 1)[0]
+        if not inserted and code.strip().startswith(f"{key}:"):
+            indent = line[: len(line) - len(line.lstrip(" "))]
+            out.append(f"{indent}{new_line}\n")
+            inserted = True
+    if not inserted:
+        raise SystemExit(f"no uncommented {key}: in hook block")
+    return "".join(out)
+
+
+def problems_for(
+    src: str,
+    *,
+    editor_id: str,
+    release_id: str,
+    consumer_id: str,
+    editor_entry: str,
+    release_entry: str,
+    consumer_entry: str,
+    contract_rel: str,
+) -> list[str]:
+    problems: list[str] = []
+    required = {
+        editor_id: {
+            "entry": editor_entry,
+            "paths": (
+                "scripts/ci/test-editor-plugin-install-commands.sh",
+                "scripts/ci/test-check-editor-mcp-recipe-truth.sh",
+                "scripts/ci/check-editor-mcp-recipe-truth.sh",
+                "scripts/ci/lib/editor-plugin-install-commands.sh",
+                "docs/guides/editor-mcp-recipe.md",
+                contract_rel,
+            ),
+        },
+        release_id: {
+            "entry": release_entry,
+            "paths": (
+                ".github/assay-release-tag",
+                "scripts/ci/check-release-surface.sh",
+                "scripts/ci/test-check-release-surface.sh",
+                "docs/guides/editor-mcp-recipe.md",
+                contract_rel,
+            ),
+        },
+    }
+    for hook_id, spec in required.items():
+        starts = hook_starts(src, hook_id)
+        if len(starts) != 1:
+            problems.append(
+                f"{hook_id}: expected exactly one hook block, found {len(starts)}"
+            )
+            continue
+        block = hook_block(src, hook_id)
+        items = uncommented_items(block)
+        files_vals = [val for key, val in items if key == "files"]
+        entry_vals = [val for key, val in items if key == "entry"]
+        if len(files_vals) != 1:
+            problems.append(
+                f"{hook_id}: expected exactly one uncommented files: selector, found {len(files_vals)}"
+            )
+        else:
+            if files_vals[0] == "^$":
+                problems.append(f"{hook_id}: files: selector is ^$")
+            else:
+                pattern = re.compile(files_vals[0])
+                for path in spec["paths"]:
+                    if not pattern.search(path):
+                        problems.append(
+                            f"{hook_id}: files: selector does not match {path}"
+                        )
+        if len(entry_vals) != 1:
+            problems.append(
+                f"{hook_id}: expected exactly one uncommented entry:, found {len(entry_vals)}"
+            )
+        elif entry_vals[0] != spec["entry"]:
+            problems.append(f"{hook_id}: entry is not the exact command chain")
+
+    starts = hook_starts(src, consumer_id)
+    if len(starts) != 1:
+        problems.append(
+            f"{consumer_id}: expected exactly one hook block, found {len(starts)}"
+        )
+        return problems
+    block = hook_block(src, consumer_id)
+    items = uncommented_items(block)
+    keys = [key for key, _ in items]
+    entry_vals = [val for key, val in items if key == "entry"]
+    files_vals = [val for key, val in items if key == "files"]
+    if "always_run" not in keys or "always_run: true" not in block:
+        problems.append(f"{consumer_id}: must set always_run: true")
+    if "pass_filenames" not in keys or "pass_filenames: false" not in block:
+        problems.append(f"{consumer_id}: must set pass_filenames: false")
+    if "language" not in keys or "language: system" not in block:
+        problems.append(f"{consumer_id}: must set language: system")
+    if files_vals:
+        problems.append(
+            f"{consumer_id}: must not have a files: start-condition regex"
+        )
+    if len(entry_vals) != 1 or entry_vals[0] != consumer_entry:
+        problems.append(f"{consumer_id}: entry must invoke only {contract_rel}")
+    return problems
+
+
+def main() -> None:
+    (
+        editor_id,
+        release_id,
+        consumer_id,
+        editor_entry,
+        release_entry,
+        consumer_entry,
+        contract_rel,
+        action,
+        config_path,
+        dest,
+        *rest
+    ) = sys.argv[1:]
+    src = Path(config_path).read_text(encoding="utf-8")
+
+    if action == "check":
+        problems = problems_for(
+            src,
+            editor_id=editor_id,
+            release_id=release_id,
+            consumer_id=consumer_id,
+            editor_entry=editor_entry,
+            release_entry=release_entry,
+            consumer_entry=consumer_entry,
+            contract_rel=contract_rel,
+        )
+        if problems:
+            sys.stderr.write("\n".join(problems) + "\n")
+            raise SystemExit(1)
+        return
+
+    if action == "extract-minimal":
+        hook_id = rest[0]
+        block = hook_block(src, hook_id)
+        Path(dest).write_text(
+            'minimum_pre_commit_version: "4.4.0"\n'
+            "repos:\n"
+            "  - repo: local\n"
+            "    hooks:\n" + block.rstrip("\n") + "\n",
+            encoding="utf-8",
+        )
+        return
+
+    if action == "mutate":
+        kind, hook_id = rest[0], rest[1]
+        block = hook_block(src, hook_id)
+        if kind == "second-files":
+            block = insert_after_key(block, "files", "files: ^$")
+        elif kind == "entry-true":
+            block = insert_after_key(block, "entry", "entry: 'true'")
+        elif kind == "drop-command":
+            token = rest[2]
+            if token not in block:
+                raise SystemExit(f"drop token not found in {hook_id}: {token!r}")
+            block = block.replace(token, "", 1)
+        else:
+            raise SystemExit(f"unknown mutation {kind}")
+        Path(dest).write_text(replace_block(src, hook_id, block), encoding="utf-8")
+        return
+
+    raise SystemExit(f"unknown action {action}")
+
+
+if __name__ == "__main__":
+    main()
+ENDPY
+
+cfg() {
+  python3 "$CFG_PY" \
+    "$EDITOR_ID" "$RELEASE_ID" "$CONSUMER_ID" \
+    "$EDITOR_ENTRY" "$RELEASE_ENTRY" "$CONSUMER_ENTRY" \
+    "$CONTRACT_REL" "$@"
+}
+
+check_wiring() {
+  local path="$1"
+  cfg check "$path" "$path"
+}
+
+unclose_plugin_fence() {
+  python3 - "$1" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+needle = "# assay-editor-plugin-install-commands:end\n```\n"
+if needle not in text:
+    raise SystemExit("plugin bash-fence close not found")
+path.write_text(
+    text.replace(needle, "# assay-editor-plugin-install-commands:end\n", 1),
+    encoding="utf-8",
+)
+PY
+}
+
+git_seed() {
+  local dest="$1"
+  git -C "$dest" init -q
+  git -C "$dest" config user.email "ci@example.com"
+  git -C "$dest" config user.name "CI"
+  git -C "$dest" config commit.gpgsign false
+  git -C "$dest" add -A
+  git -C "$dest" commit -q -m seed
+}
+
+archive_into() {
+  local dest="$1"
+  shift
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD -- "$@" | tar -x -C "$dest"
+}
+
+prepare_editor_tree() {
+  local dest="$1"
+  archive_into "$dest" \
+    scripts/ci/test-editor-plugin-install-commands.sh \
+    scripts/ci/test-check-editor-mcp-recipe-truth.sh \
+    scripts/ci/check-editor-mcp-recipe-truth.sh \
+    scripts/ci/lib/editor-plugin-install-commands.sh \
+    scripts/ci/lib/clear-git-repository-env.sh \
+    docs/guides/editor-mcp-recipe.md \
+    .github/workflows/kernel-matrix.yml
+}
+
+prepare_release_tree() {
+  local dest="$1"
+  local paths=""
+  paths="$(
+    git -C "$ROOT" ls-files \
+      Cargo.toml Cargo.lock \
+      'crates/*/Cargo.toml' assay-python-sdk/Cargo.toml \
+      README.md SECURITY.md llms.txt mkdocs.yml \
+      docs/getting-started/installation.md \
+      docs/getting-started/index.md \
+      docs/getting-started/quickstart.md \
+      docs/getting-started/ci-integration.md \
+      docs/reference/cli/index.md \
+      docs/AIcontext/user-flows.md \
+      docs/use-cases/ci-gate.md \
+      docs/use-cases/air-gapped.md \
+      docs/index.md docs/COMMUNITY.md \
+      docs/python-sdk/index.md docs/migration-v1.2.md \
+      docs/guides/editor-mcp-recipe.md \
+      examples/mcp-quickstart/README.md \
+      .devcontainer/welcome.sh demo/CODESPACES-PLAYBOOK.md \
+      .github/assay-release-tag \
+      scripts/ci/check-release-surface.sh \
+      scripts/ci/test-check-release-surface.sh \
+      scripts/ci/read-assay-release-tag.sh \
+      scripts/ci/release_readme.py \
+      scripts/ci/lib/editor-plugin-install-commands.sh \
+      scripts/ci/lib/clear-git-repository-env.sh
+  )"
+  # Paths are repo-relative and space-free; keep this split for bash 3.2.
+  # shellcheck disable=SC2086
+  archive_into "$dest" $paths
+}
+
+install_hook_config() {
+  local src_config="$1" hook_id="$2" dest="$3"
+  cfg extract-minimal "$src_config" "$dest/.pre-commit-config.yaml" "$hook_id"
+}
+
+consumer_status() {
+  local dest="$1"
+  local hook_id="$2"
+  local out="$dest/precommit.out"
+  set +e
+  (
+    cd "$dest"
+    export PRE_COMMIT_HOME="$dest/pc-home"
+    pre-commit run "$hook_id" --color never --all-files
+  ) >"$out" 2>&1
+  local rc=$?
+  set -e
+  if grep -Fq 'Skipped' "$out"; then
+    printf 'skipped'
+    return 0
+  fi
+  if grep -Fq 'Passed' "$out" && [ "$rc" -eq 0 ]; then
+    printf 'passed'
+    return 0
+  fi
+  if [ "$rc" -ne 0 ]; then
+    printf 'failed'
+    return 0
+  fi
+  printf 'unknown'
+}
+
+expect_wiring_red() {
+  local label="$1" config="$2"
+  if check_wiring "$config" >"$TMP/$label.wiring" 2>&1; then
+    fail "$label — wiring stayed green"
+  else
+    ok "RED $label"
+  fi
+}
+
+expect_consumer() {
+  local label="$1" dest="$2" hook_id="$3" want="$4"
+  local got
+  got="$(consumer_status "$dest" "$hook_id")"
+  if [ "$got" = "$want" ]; then
+    ok "$label (consumer $got)"
+  else
+    fail "$label — consumer $got, wanted $want"
+    sed 's/^/      /' "$dest/precommit.out" || true
+  fi
+}
+
+echo '== live wiring =='
+if check_wiring "$CONFIG"; then
+  ok 'live unmutated tree wiring'
+else
+  fail 'live unmutated tree wiring'
+fi
+
+echo '== pin behavior: unmutated consumer must fail closed =='
+teeth_editor="$TMP/teeth-editor"
+prepare_editor_tree "$teeth_editor"
+unclose_plugin_fence "$teeth_editor/docs/guides/editor-mcp-recipe.md"
+install_hook_config "$CONFIG" "$EDITOR_ID" "$teeth_editor"
+git_seed "$teeth_editor"
+expect_consumer 'malformed recipe (missing plugin bash-fence close)' \
+  "$teeth_editor" "$EDITOR_ID" failed
+
+teeth_release="$TMP/teeth-release"
+prepare_release_tree "$teeth_release"
+printf '%s\n' '0.0.0' > "$teeth_release/.github/assay-release-tag"
+install_hook_config "$CONFIG" "$RELEASE_ID" "$teeth_release"
+git_seed "$teeth_release"
+expect_consumer 'stale pin 0.0.0' "$teeth_release" "$RELEASE_ID" failed
+
+echo '== named wiring mutations =='
+cfg mutate "$CONFIG" "$TMP/second-files-editor.yaml" second-files "$EDITOR_ID"
+expect_wiring_red 'second files: ^$ on editor hook' "$TMP/second-files-editor.yaml"
+
+cfg mutate "$CONFIG" "$TMP/second-files-release.yaml" second-files "$RELEASE_ID"
+expect_wiring_red 'second files: ^$ on release-surface hook' "$TMP/second-files-release.yaml"
+
+cfg mutate "$CONFIG" "$TMP/entry-true-editor.yaml" entry-true "$EDITOR_ID"
+expect_wiring_red 'entry: true on editor hook' "$TMP/entry-true-editor.yaml"
+
+cfg mutate "$CONFIG" "$TMP/entry-true-release.yaml" entry-true "$RELEASE_ID"
+expect_wiring_red 'entry: true on release-surface hook' "$TMP/entry-true-release.yaml"
+
+cfg mutate "$CONFIG" "$TMP/drop-editor.yaml" drop-command "$EDITOR_ID" "$EDITOR_DROP"
+expect_wiring_red 'remove test-editor-plugin-install-commands.sh from editor chain' \
+  "$TMP/drop-editor.yaml"
+
+cfg mutate "$CONFIG" "$TMP/drop-release.yaml" drop-command "$RELEASE_ID" "$RELEASE_DROP"
+expect_wiring_red 'remove test-check-release-surface.sh from release-surface chain' \
+  "$TMP/drop-release.yaml"
+
+echo '== malformed recipe paired with editor bypasses =='
+pair="$TMP/pair-editor-second-files"
+prepare_editor_tree "$pair"
+unclose_plugin_fence "$pair/docs/guides/editor-mcp-recipe.md"
+install_hook_config "$TMP/second-files-editor.yaml" "$EDITOR_ID" "$pair"
+git_seed "$pair"
+expect_consumer 'malformed recipe + second files: ^$ on editor hook' \
+  "$pair" "$EDITOR_ID" skipped
+
+pair="$TMP/pair-editor-entry-true"
+prepare_editor_tree "$pair"
+unclose_plugin_fence "$pair/docs/guides/editor-mcp-recipe.md"
+install_hook_config "$TMP/entry-true-editor.yaml" "$EDITOR_ID" "$pair"
+git_seed "$pair"
+expect_consumer 'malformed recipe + entry: true on editor hook' \
+  "$pair" "$EDITOR_ID" passed
+
+echo '== stale pin paired with release-surface bypasses =='
+pair="$TMP/pair-release-second-files"
+prepare_release_tree "$pair"
+printf '%s\n' '0.0.0' > "$pair/.github/assay-release-tag"
+install_hook_config "$TMP/second-files-release.yaml" "$RELEASE_ID" "$pair"
+git_seed "$pair"
+expect_consumer 'stale pin 0.0.0 + second files: ^$ on release-surface hook' \
+  "$pair" "$RELEASE_ID" skipped
+
+pair="$TMP/pair-release-entry-true"
+prepare_release_tree "$pair"
+printf '%s\n' '0.0.0' > "$pair/.github/assay-release-tag"
+install_hook_config "$TMP/entry-true-release.yaml" "$RELEASE_ID" "$pair"
+git_seed "$pair"
+expect_consumer 'stale pin 0.0.0 + entry: true on release-surface hook' \
+  "$pair" "$RELEASE_ID" passed
+
+printf '\n'
+if [ "$failures" -gt 0 ]; then
+  printf 'editor/release-surface pre-commit consumer: %s failure(s)\n' "$failures"
+  exit 1
+fi
+printf 'editor/release-surface pre-commit consumer: PASS\n'

--- a/scripts/ci/test-editor-release-hook-precommit-consumer.sh
+++ b/scripts/ci/test-editor-release-hook-precommit-consumer.sh
@@ -5,12 +5,11 @@
 # (`files: ^$`, `entry: 'true'`) and miss a second hook whose `id` is not written
 # as `      - id: <name>`. This contract loads `.pre-commit-config.yaml` with a
 # duplicate-key-rejecting PyYAML SafeLoader and counts both protected IDs from
-# repos[*].hooks[*] (flow mapping and reordered keys included). A producer hook
-# independently invokes this script so last-key-wins `entry: 'true'` on the
-# consumer hook cannot skip the contract. Both producer and consumer live in the
-# yaml being validated, so last-key-wins `entry: 'true'` on BOTH is still a
-# paired no-op for pre-commit. Kernel Matrix lint invokes this script directly
-# outside that yaml so the contract still runs.
+# repos[*].hooks[*] (flow mapping and reordered keys included). Required context
+# `CI` (the ci.yml aggregator) invokes this script directly; Kernel Matrix is
+# not a required context, so a lint-job invocation cannot close the merge gate.
+# One local consumer hook remains for pre-push feedback (`stages: [pre-push]`)
+# so default `pre-commit run --all-files` does not duplicate the heavy check.
 set -euo pipefail
 
 # shellcheck source=scripts/ci/lib/clear-git-repository-env.sh
@@ -18,14 +17,15 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/clear-git-repository-e
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CONFIG="$ROOT/.pre-commit-config.yaml"
-KERNEL_MATRIX="$ROOT/.github/workflows/kernel-matrix.yml"
+CI_WORKFLOW="$ROOT/.github/workflows/ci.yml"
+RULESET="$ROOT/.github/rulesets/main-required-ci-contexts.json"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 EDITOR_ID="editor-mcp-recipe-truth"
 RELEASE_ID="release-surface"
 CONSUMER_ID="editor-release-hook-precommit-consumer"
-PRODUCER_ID="editor-release-hook-precommit-producer"
+ABSENT_PRODUCER_ID="editor-release-hook-precommit-producer"
 CONTRACT_REL="scripts/ci/test-editor-release-hook-precommit-consumer.sh"
 
 EDITOR_ENTRY="bash -c 'bash scripts/ci/test-editor-plugin-install-commands.sh && bash scripts/ci/test-check-editor-mcp-recipe-truth.sh && bash scripts/ci/check-editor-mcp-recipe-truth.sh'"
@@ -212,7 +212,7 @@ def problems_for(
     editor_id: str,
     release_id: str,
     consumer_id: str,
-    producer_id: str,
+    absent_producer_id: str,
     editor_entry: str,
     release_entry: str,
     consumer_entry: str,
@@ -226,10 +226,15 @@ def problems_for(
         return problems
 
     counts = hook_id_counts(data)
-    for hook_id in (editor_id, release_id, consumer_id, producer_id):
+    for hook_id in (editor_id, release_id, consumer_id):
         n = counts.get(hook_id, 0)
         if n != 1:
             problems.append(f"{hook_id}: expected exactly one hook, found {n}")
+    n_prod = counts.get(absent_producer_id, 0)
+    if n_prod != 0:
+        problems.append(
+            f"{absent_producer_id}: expected no in-config producer, found {n_prod}"
+        )
 
     required = {
         editor_id: {
@@ -284,27 +289,31 @@ def problems_for(
         elif hook.get("entry") != spec["entry"]:
             problems.append(f"{hook_id}: entry is not the exact command chain")
 
-    for hook_id in (consumer_id, producer_id):
-        if counts.get(hook_id, 0) != 1:
-            continue
-        hook = hook_by_id(data, hook_id)
-        if hook is None:
-            continue
-        if hook.get("always_run") is not True:
-            problems.append(f"{hook_id}: must set always_run: true")
-        if hook.get("pass_filenames") is not False:
-            problems.append(f"{hook_id}: must set pass_filenames: false")
-        if hook.get("language") != "system":
-            problems.append(f"{hook_id}: must set language: system")
-        if "files" in hook:
-            problems.append(
-                f"{hook_id}: must not have a files: start-condition regex"
-            )
-        if hook.get("entry") != consumer_entry:
-            problems.append(f"{hook_id}: entry must invoke only {contract_rel}")
-        effective = hook.get("entry")
-        if effective in ("true", True) or effective == "/usr/bin/true":
-            problems.append(f"{hook_id}: effective entry is a no-op ({effective!r})")
+    if counts.get(consumer_id, 0) == 1:
+        hook = hook_by_id(data, consumer_id)
+        if hook is not None:
+            if hook.get("always_run") is not True:
+                problems.append(f"{consumer_id}: must set always_run: true")
+            if hook.get("pass_filenames") is not False:
+                problems.append(f"{consumer_id}: must set pass_filenames: false")
+            if hook.get("language") != "system":
+                problems.append(f"{consumer_id}: must set language: system")
+            if "files" in hook:
+                problems.append(
+                    f"{consumer_id}: must not have a files: start-condition regex"
+                )
+            stages = hook.get("stages")
+            if stages != ["pre-push"]:
+                problems.append(
+                    f"{consumer_id}: stages must be exactly [pre-push], found {stages!r}"
+                )
+            if hook.get("entry") != consumer_entry:
+                problems.append(f"{consumer_id}: entry must invoke only {contract_rel}")
+            effective = hook.get("entry")
+            if effective in ("true", True) or effective == "/usr/bin/true":
+                problems.append(
+                    f"{consumer_id}: effective entry is a no-op ({effective!r})"
+                )
     return problems
 
 
@@ -313,6 +322,8 @@ CI_CONSUMER_STEP = (
     "        shell: bash\n"
     "        run: |\n"
     "          set -euo pipefail\n"
+    "          python -m pip install --user pre-commit==4.4.0\n"
+    "          export PATH=\"$HOME/.local/bin:$PATH\"\n"
     "          bash scripts/ci/test-editor-release-hook-precommit-consumer.sh\n"
 )
 CI_CONSUMER_STEP_HEAD = (
@@ -323,72 +334,102 @@ CI_CONSUMER_RUN_LINE = (
     "          bash scripts/ci/test-editor-release-hook-precommit-consumer.sh\n"
 )
 
+ALLOWED_PRELUDE = (
+    "python -m pip install --user pre-commit==4.4.0",
+    'export PATH="$HOME/.local/bin:$PATH"',
+)
 
-def problems_for_ci(src: str, *, contract_rel: str) -> list[str]:
+
+def ruleset_contexts(ruleset_src: str) -> set[str]:
+    doc = yaml.safe_load(ruleset_src)
+    found: set[str] = set()
+    if not isinstance(doc, dict):
+        return found
+    for rule in doc.get("rules") or []:
+        if not isinstance(rule, dict) or rule.get("type") != "required_status_checks":
+            continue
+        params = rule.get("parameters")
+        if not isinstance(params, dict):
+            continue
+        for check in params.get("required_status_checks") or []:
+            if isinstance(check, dict) and isinstance(check.get("context"), str):
+                found.add(check["context"])
+    return found
+
+
+def step_uncommented_commands(run: str) -> tuple[str, ...]:
+    return tuple(
+        line.strip()
+        for line in run.splitlines()
+        if line.strip()
+        and not line.strip().startswith("#")
+        and line.strip() != "set -euo pipefail"
+    )
+
+
+def problems_for_ci(src: str, *, contract_rel: str, ruleset_src: str) -> list[str]:
     problems: list[str] = []
     try:
         data = load_unique(src)
     except yaml.YAMLError as exc:
-        problems.append(f"kernel-matrix.yml YAML rejected: {exc}")
+        problems.append(f"ci.yml YAML rejected: {exc}")
         return problems
     if not isinstance(data, dict):
-        problems.append("kernel-matrix.yml: root is not a mapping")
+        problems.append("ci.yml: root is not a mapping")
         return problems
     jobs = data.get("jobs")
     if not isinstance(jobs, dict):
-        problems.append("kernel-matrix.yml: jobs missing")
+        problems.append("ci.yml: jobs missing")
         return problems
-    lint = jobs.get("lint")
-    if not isinstance(lint, dict):
-        problems.append("kernel-matrix.yml: lint job missing")
-        return problems
-    if lint.get("name") != "Lint (pre-commit)":
-        problems.append("kernel-matrix.yml: lint job name is not Lint (pre-commit)")
-    steps = lint.get("steps")
-    if not isinstance(steps, list):
-        problems.append("kernel-matrix.yml: lint job has no steps")
+    contexts = ruleset_contexts(ruleset_src)
+    if "CI" not in contexts:
+        problems.append("ruleset missing required context CI")
         return problems
 
     wanted = f"bash {contract_rel}"
-    install_idx = None
-    active: list[int] = []
-    for index, step in enumerate(steps):
-        if not isinstance(step, dict):
+    active: list[tuple[str, str, bool]] = []
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict):
             continue
-        if step.get("name") == "Install pre-commit (pinned)":
-            install_idx = index
-        run = step.get("run")
-        if not isinstance(run, str):
+        job_name = job.get("name") if isinstance(job.get("name"), str) else job_id
+        job_coe = job.get("continue-on-error") is True
+        steps = job.get("steps")
+        if not isinstance(steps, list):
             continue
-        body = tuple(
-            line.strip()
-            for line in run.splitlines()
-            if line.strip()
-            and not line.strip().startswith("#")
-            and line.strip() != "set -euo pipefail"
-        )
-        if body != (wanted,):
-            continue
-        if step.get("continue-on-error") is True:
-            continue
-        if "if" in step:
-            continue
-        active.append(index)
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            run = step.get("run")
+            if not isinstance(run, str):
+                continue
+            body = step_uncommented_commands(run)
+            if wanted not in body:
+                continue
+            extra = tuple(cmd for cmd in body if cmd != wanted)
+            if any(cmd not in ALLOWED_PRELUDE for cmd in extra):
+                continue
+            if step.get("continue-on-error") is True:
+                continue
+            if "if" in step:
+                continue
+            active.append((job_id, job_name, job_coe))
 
     if len(active) != 1:
         problems.append(
-            f"kernel-matrix lint job: expected exactly one active direct "
-            f"invocation of {contract_rel}, found {len(active)}"
+            f"ci.yml: expected exactly one active direct invocation of "
+            f"{contract_rel} in a required-context job, found {len(active)}"
         )
         return problems
-    if install_idx is None:
+    job_id, job_name, job_coe = active[0]
+    if job_name not in contexts:
         problems.append(
-            "kernel-matrix lint job missing Install pre-commit (pinned)"
+            f"ci.yml: invocation is in job {job_id!r} named {job_name!r}, "
+            f"which is not a required context {sorted(contexts)}"
         )
-    elif active[0] <= install_idx:
+    if job_coe:
         problems.append(
-            f"kernel-matrix lint job: direct invocation of {contract_rel} "
-            "must run after Install pre-commit (pinned)"
+            f"ci.yml: job {job_id!r} sets continue-on-error, so a consumer "
+            "failure would not redden the required context"
         )
     return problems
 
@@ -398,7 +439,7 @@ def main() -> None:
         editor_id,
         release_id,
         consumer_id,
-        producer_id,
+        absent_producer_id,
         editor_entry,
         release_entry,
         consumer_entry,
@@ -416,7 +457,7 @@ def main() -> None:
             editor_id=editor_id,
             release_id=release_id,
             consumer_id=consumer_id,
-            producer_id=producer_id,
+            absent_producer_id=absent_producer_id,
             editor_entry=editor_entry,
             release_entry=release_entry,
             consumer_entry=consumer_entry,
@@ -428,7 +469,11 @@ def main() -> None:
         return
 
     if action == "check-ci":
-        problems = problems_for_ci(src, contract_rel=contract_rel)
+        ruleset_path = rest[0] if rest else dest
+        ruleset_src = Path(ruleset_path).read_text(encoding="utf-8")
+        problems = problems_for_ci(
+            src, contract_rel=contract_rel, ruleset_src=ruleset_src
+        )
         if problems:
             sys.stderr.write("\n".join(problems) + "\n")
             raise SystemExit(1)
@@ -524,6 +569,35 @@ def main() -> None:
             )
             Path(dest).write_text(insert_after_span(src, hook_id, extra), encoding="utf-8")
             return
+        if kind == "drop-stages":
+            block = hook_block(src, hook_id)
+            lines = [
+                line
+                for line in block.splitlines(keepends=True)
+                if not line.split("#", 1)[0].strip().startswith("stages:")
+            ]
+            Path(dest).write_text(
+                replace_block(src, hook_id, "".join(lines)), encoding="utf-8"
+            )
+            return
+        if kind == "change-stages":
+            block = hook_block(src, hook_id)
+            replaced = 0
+            out = []
+            for line in block.splitlines(keepends=True):
+                code = line.split("#", 1)[0]
+                if code.strip().startswith("stages:"):
+                    indent = line[: len(line) - len(line.lstrip(" "))]
+                    out.append(f"{indent}stages: [commit]\n")
+                    replaced += 1
+                else:
+                    out.append(line)
+            if replaced != 1:
+                raise SystemExit(f"expected one stages: line in {hook_id}, found {replaced}")
+            Path(dest).write_text(
+                replace_block(src, hook_id, "".join(out)), encoding="utf-8"
+            )
+            return
         raise SystemExit(f"unknown mutation {kind}")
 
     raise SystemExit(f"unknown action {action}")
@@ -535,7 +609,7 @@ ENDPY
 
 cfg() {
   "$PYTHON_YAML" "$CFG_PY" \
-    "$EDITOR_ID" "$RELEASE_ID" "$CONSUMER_ID" "$PRODUCER_ID" \
+    "$EDITOR_ID" "$RELEASE_ID" "$CONSUMER_ID" "$ABSENT_PRODUCER_ID" \
     "$EDITOR_ENTRY" "$RELEASE_ENTRY" "$CONSUMER_ENTRY" \
     "$CONTRACT_REL" "$@"
 }
@@ -587,7 +661,7 @@ prepare_editor_tree() {
     scripts/ci/lib/editor-plugin-install-commands.sh \
     scripts/ci/lib/clear-git-repository-env.sh \
     docs/guides/editor-mcp-recipe.md \
-    .github/workflows/kernel-matrix.yml
+    .github/workflows/ci.yml
 }
 
 prepare_release_tree() {
@@ -637,7 +711,11 @@ consumer_status() {
   (
     cd "$dest"
     export PRE_COMMIT_HOME="$dest/pc-home"
-    pre-commit run "$hook_id" --color never --all-files
+    if [ "$hook_id" = "$CONSUMER_ID" ]; then
+      pre-commit run "$hook_id" --hook-stage pre-push --color never --all-files
+    else
+      pre-commit run "$hook_id" --color never --all-files
+    fi
   ) >"$out" 2>&1
   local rc=$?
   set -e
@@ -667,7 +745,7 @@ expect_wiring_red() {
 
 check_ci_producer() {
   local path="$1"
-  cfg check-ci "$path" "$path"
+  cfg check-ci "$path" "$path" "$RULESET"
 }
 
 expect_ci_red() {
@@ -698,11 +776,11 @@ else
   fail 'live unmutated tree wiring'
 fi
 
-echo '== live CI producer =='
-if check_ci_producer "$KERNEL_MATRIX"; then
-  ok 'live kernel-matrix lint job direct consumer invocation'
+echo '== live required-CI producer =='
+if check_ci_producer "$CI_WORKFLOW"; then
+  ok 'live CI job direct consumer invocation reaches required context'
 else
-  fail 'live kernel-matrix lint job direct consumer invocation'
+  fail 'live CI job direct consumer invocation reaches required context'
 fi
 
 echo '== pin behavior: unmutated consumer must fail closed =='
@@ -746,23 +824,32 @@ cfg mutate "$CONFIG" "$TMP/entry-true-consumer.yaml" entry-true "$CONSUMER_ID"
 expect_wiring_red "last-key-wins entry: 'true' on consumer hook" \
   "$TMP/entry-true-consumer.yaml"
 
-cfg mutate "$TMP/entry-true-consumer.yaml" "$TMP/entry-true-both.yaml" \
-  entry-true "$PRODUCER_ID"
-expect_wiring_red "paired last-key-wins entry: 'true' on producer and consumer" \
-  "$TMP/entry-true-both.yaml"
+cfg mutate "$TMP/entry-true-consumer.yaml" "$TMP/entry-true-editor-too.yaml" \
+  entry-true "$EDITOR_ID"
+cfg mutate "$TMP/entry-true-editor-too.yaml" "$TMP/entry-true-paired.yaml" \
+  entry-true "$RELEASE_ID"
+expect_wiring_red "paired last-key-wins entry: 'true' on consumer, editor, and release-surface" \
+  "$TMP/entry-true-paired.yaml"
 
-cfg mutate-ci "$KERNEL_MATRIX" "$TMP/km-delete.yml" delete-step
-expect_ci_red 'deleting kernel-matrix lint consumer step' "$TMP/km-delete.yml"
+cfg mutate "$CONFIG" "$TMP/drop-stages.yaml" drop-stages "$CONSUMER_ID"
+expect_wiring_red 'removing pre-push stage from consumer hook' "$TMP/drop-stages.yaml"
 
-cfg mutate-ci "$KERNEL_MATRIX" "$TMP/km-comment.yml" comment-step
-expect_ci_red 'commenting kernel-matrix lint consumer step' "$TMP/km-comment.yml"
+cfg mutate "$CONFIG" "$TMP/change-stages.yaml" change-stages "$CONSUMER_ID"
+expect_wiring_red 'changing consumer hook stage away from pre-push' \
+  "$TMP/change-stages.yaml"
 
-cfg mutate-ci "$KERNEL_MATRIX" "$TMP/km-if-false.yml" if-false
-expect_ci_red 'if: false on kernel-matrix lint consumer step' "$TMP/km-if-false.yml"
+cfg mutate-ci "$CI_WORKFLOW" "$TMP/ci-delete.yml" delete-step
+expect_ci_red 'deleting required-CI consumer step' "$TMP/ci-delete.yml"
 
-cfg mutate-ci "$KERNEL_MATRIX" "$TMP/km-continue.yml" continue-on-error
-expect_ci_red 'continue-on-error on kernel-matrix lint consumer step' \
-  "$TMP/km-continue.yml"
+cfg mutate-ci "$CI_WORKFLOW" "$TMP/ci-comment.yml" comment-step
+expect_ci_red 'commenting required-CI consumer step' "$TMP/ci-comment.yml"
+
+cfg mutate-ci "$CI_WORKFLOW" "$TMP/ci-if-false.yml" if-false
+expect_ci_red 'if: false on required-CI consumer step' "$TMP/ci-if-false.yml"
+
+cfg mutate-ci "$CI_WORKFLOW" "$TMP/ci-continue.yml" continue-on-error
+expect_ci_red 'continue-on-error on required-CI consumer step' \
+  "$TMP/ci-continue.yml"
 
 cfg mutate "$CONFIG" "$TMP/flow-dup-editor.yaml" flow-duplicate "$EDITOR_ID"
 expect_wiring_red 'flow-mapping duplicate of editor-mcp-recipe-truth' \
@@ -806,7 +893,30 @@ git_seed "$pair"
 expect_consumer 'stale pin 0.0.0 + entry: true on release-surface hook' \
   "$pair" "$RELEASE_ID" passed
 
-echo '== consumer last-key-wins entry: true cannot hide from the producer =='
+echo '== default pre-commit run --all-files skips the pre-push consumer =='
+skip="$TMP/all-files-skip"
+mkdir -p "$skip"
+install_hook_config "$CONFIG" "$CONSUMER_ID" "$skip"
+git_seed "$skip"
+set +e
+(
+  cd "$skip"
+  export PRE_COMMIT_HOME="$skip/pc-home"
+  pre-commit run --color never --all-files
+) >"$skip/precommit.out" 2>&1
+skip_rc=$?
+set -e
+if grep -Eq 'Passed|Failed' "$skip/precommit.out"; then
+  fail 'default pre-commit run --all-files ran the pre-push consumer'
+  sed 's/^/      /' "$skip/precommit.out" || true
+elif [ "$skip_rc" -eq 0 ]; then
+  ok 'default pre-commit run --all-files skips pre-push consumer'
+else
+  fail "default pre-commit run --all-files rc=$skip_rc"
+  sed 's/^/      /' "$skip/precommit.out" || true
+fi
+
+echo '== consumer last-key-wins entry: true is a local no-op =='
 pair="$TMP/pair-consumer-entry-true"
 mkdir -p "$pair"
 install_hook_config "$TMP/entry-true-consumer.yaml" "$CONSUMER_ID" "$pair"

--- a/scripts/ci/test-editor-release-hook-precommit-consumer.sh
+++ b/scripts/ci/test-editor-release-hook-precommit-consumer.sh
@@ -2,9 +2,12 @@
 # Pin editor-mcp-recipe-truth and release-surface through the pre-commit consumer.
 #
 # The 38/95 suites parse hook YAML themselves and miss last-key-wins duplicates
-# (`files: ^$`, `entry: 'true'`). pre-commit/PyYAML keeps the last key, so the
-# effective consumer Skips or runs `/usr/bin/true` while those suites stay green.
-# This contract owns both hook IDs independently and drives real `pre-commit run`.
+# (`files: ^$`, `entry: 'true'`) and miss a second hook whose `id` is not written
+# as `      - id: <name>`. This contract loads `.pre-commit-config.yaml` with a
+# duplicate-key-rejecting PyYAML SafeLoader and counts both protected IDs from
+# repos[*].hooks[*] (flow mapping and reordered keys included). A producer hook
+# independently invokes this script so last-key-wins `entry: 'true'` on the
+# consumer hook cannot skip the contract.
 set -euo pipefail
 
 # shellcheck source=scripts/ci/lib/clear-git-repository-env.sh
@@ -18,6 +21,7 @@ trap 'rm -rf "$TMP"' EXIT
 EDITOR_ID="editor-mcp-recipe-truth"
 RELEASE_ID="release-surface"
 CONSUMER_ID="editor-release-hook-precommit-consumer"
+PRODUCER_ID="editor-release-hook-precommit-producer"
 CONTRACT_REL="scripts/ci/test-editor-release-hook-precommit-consumer.sh"
 
 EDITOR_ENTRY="bash -c 'bash scripts/ci/test-editor-plugin-install-commands.sh && bash scripts/ci/test-check-editor-mcp-recipe-truth.sh && bash scripts/ci/check-editor-mcp-recipe-truth.sh'"
@@ -40,6 +44,17 @@ if ! command -v pre-commit >/dev/null 2>&1; then
   fail "pre-commit not on PATH (CI pin is pre-commit==4.4.0)"
   exit 1
 fi
+# Duplicate-key YAML load needs PyYAML. System python3 has it on Linux CI;
+# Darwin review machines may only expose it via the pre-commit interpreter.
+if python3 -c 'import yaml' >/dev/null 2>&1; then
+  PYTHON_YAML=python3
+else
+  PYTHON_YAML="$(sed -n '1s/^#!//p' "$(command -v pre-commit)")"
+  if ! "$PYTHON_YAML" -c 'import yaml' >/dev/null 2>&1; then
+    fail "PyYAML not importable from python3 or the pre-commit interpreter"
+    exit 1
+  fi
+fi
 CFG_PY="$TMP/editor_release_hook_precommit_consumer.py"
 cat > "$CFG_PY" << 'ENDPY'
 # Helper for test-editor-release-hook-precommit-consumer.sh (invoked via python3).
@@ -49,19 +64,49 @@ import re
 import sys
 from pathlib import Path
 
+import yaml
 
-def uncommented_items(src: str) -> list[tuple[str, str]]:
-    items: list[tuple[str, str]] = []
-    for line in src.splitlines():
-        code = line.split("#", 1)[0].rstrip()
-        if ":" not in code:
-            continue
-        key, val = code.strip().split(":", 1)
-        items.append((key, val.strip()))
-    return items
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    """SafeLoader that rejects repeated keys in the same mapping."""
+
+
+def _construct_unique_mapping(loader, node, deep=False):
+    if not isinstance(node, yaml.MappingNode):
+        raise yaml.constructor.ConstructorError(
+            None,
+            None,
+            f"expected a mapping node, but found {node.id}",
+            node.start_mark,
+        )
+    loader.flatten_mapping(node)
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def load_unique(src: str):
+    return yaml.load(src, Loader=UniqueKeyLoader)
 
 
 def hook_starts(src: str, hook_id: str) -> list[int]:
+    # Canonical live blocks are `      - id: <id>`. Mutations of those blocks
+    # still use this locator; counting protected IDs does not.
     marker = f"      - id: {hook_id}\n"
     starts: list[int] = []
     i = 0
@@ -100,6 +145,13 @@ def replace_block(src: str, hook_id: str, new_block: str) -> str:
     return src[:start] + new_block.rstrip("\n") + "\n" + src[end:]
 
 
+def insert_after_span(src: str, hook_id: str, extra: str) -> str:
+    _, end = hook_span(src, hook_id)
+    if not extra.endswith("\n"):
+        extra += "\n"
+    return src[:end] + extra + src[end:]
+
+
 def insert_after_key(block: str, key: str, new_line: str) -> str:
     lines = block.splitlines(keepends=True)
     out: list[str] = []
@@ -116,18 +168,65 @@ def insert_after_key(block: str, key: str, new_line: str) -> str:
     return "".join(out)
 
 
+def iter_hooks(data: object):
+    if not isinstance(data, dict):
+        return
+    repos = data.get("repos")
+    if not isinstance(repos, list):
+        return
+    for repo in repos:
+        if not isinstance(repo, dict):
+            continue
+        hooks = repo.get("hooks")
+        if not isinstance(hooks, list):
+            continue
+        for hook in hooks:
+            if isinstance(hook, dict):
+                yield hook
+
+
+def hook_id_counts(data: object) -> dict[object, int]:
+    counts: dict[object, int] = {}
+    for hook in iter_hooks(data):
+        hid = hook.get("id")
+        if hid is None:
+            continue
+        counts[hid] = counts.get(hid, 0) + 1
+    return counts
+
+
+def hook_by_id(data: object, hook_id: str):
+    found = [hook for hook in iter_hooks(data) if hook.get("id") == hook_id]
+    if len(found) != 1:
+        return None
+    return found[0]
+
+
 def problems_for(
     src: str,
     *,
     editor_id: str,
     release_id: str,
     consumer_id: str,
+    producer_id: str,
     editor_entry: str,
     release_entry: str,
     consumer_entry: str,
     contract_rel: str,
 ) -> list[str]:
     problems: list[str] = []
+    try:
+        data = load_unique(src)
+    except yaml.YAMLError as exc:
+        problems.append(f"pre-commit config YAML rejected: {exc}")
+        return problems
+
+    counts = hook_id_counts(data)
+    for hook_id in (editor_id, release_id, consumer_id, producer_id):
+        n = counts.get(hook_id, 0)
+        if n != 1:
+            problems.append(f"{hook_id}: expected exactly one hook, found {n}")
+
     required = {
         editor_id: {
             "entry": editor_entry,
@@ -152,60 +251,56 @@ def problems_for(
         },
     }
     for hook_id, spec in required.items():
-        starts = hook_starts(src, hook_id)
-        if len(starts) != 1:
-            problems.append(
-                f"{hook_id}: expected exactly one hook block, found {len(starts)}"
-            )
+        if counts.get(hook_id, 0) != 1:
             continue
-        block = hook_block(src, hook_id)
-        items = uncommented_items(block)
-        files_vals = [val for key, val in items if key == "files"]
-        entry_vals = [val for key, val in items if key == "entry"]
-        if len(files_vals) != 1:
+        hook = hook_by_id(data, hook_id)
+        if hook is None:
+            continue
+        if "files" not in hook:
             problems.append(
-                f"{hook_id}: expected exactly one uncommented files: selector, found {len(files_vals)}"
+                f"{hook_id}: expected exactly one uncommented files: selector, found 0"
             )
         else:
-            if files_vals[0] == "^$":
+            files_val = hook.get("files")
+            if files_val == "^$":
                 problems.append(f"{hook_id}: files: selector is ^$")
+            elif not isinstance(files_val, str):
+                problems.append(f"{hook_id}: files: selector is not a string")
             else:
-                pattern = re.compile(files_vals[0])
+                pattern = re.compile(files_val)
                 for path in spec["paths"]:
                     if not pattern.search(path):
                         problems.append(
                             f"{hook_id}: files: selector does not match {path}"
                         )
-        if len(entry_vals) != 1:
+        if "entry" not in hook:
             problems.append(
-                f"{hook_id}: expected exactly one uncommented entry:, found {len(entry_vals)}"
+                f"{hook_id}: expected exactly one uncommented entry:, found 0"
             )
-        elif entry_vals[0] != spec["entry"]:
+        elif hook.get("entry") != spec["entry"]:
             problems.append(f"{hook_id}: entry is not the exact command chain")
 
-    starts = hook_starts(src, consumer_id)
-    if len(starts) != 1:
-        problems.append(
-            f"{consumer_id}: expected exactly one hook block, found {len(starts)}"
-        )
-        return problems
-    block = hook_block(src, consumer_id)
-    items = uncommented_items(block)
-    keys = [key for key, _ in items]
-    entry_vals = [val for key, val in items if key == "entry"]
-    files_vals = [val for key, val in items if key == "files"]
-    if "always_run" not in keys or "always_run: true" not in block:
-        problems.append(f"{consumer_id}: must set always_run: true")
-    if "pass_filenames" not in keys or "pass_filenames: false" not in block:
-        problems.append(f"{consumer_id}: must set pass_filenames: false")
-    if "language" not in keys or "language: system" not in block:
-        problems.append(f"{consumer_id}: must set language: system")
-    if files_vals:
-        problems.append(
-            f"{consumer_id}: must not have a files: start-condition regex"
-        )
-    if len(entry_vals) != 1 or entry_vals[0] != consumer_entry:
-        problems.append(f"{consumer_id}: entry must invoke only {contract_rel}")
+    for hook_id in (consumer_id, producer_id):
+        if counts.get(hook_id, 0) != 1:
+            continue
+        hook = hook_by_id(data, hook_id)
+        if hook is None:
+            continue
+        if hook.get("always_run") is not True:
+            problems.append(f"{hook_id}: must set always_run: true")
+        if hook.get("pass_filenames") is not False:
+            problems.append(f"{hook_id}: must set pass_filenames: false")
+        if hook.get("language") != "system":
+            problems.append(f"{hook_id}: must set language: system")
+        if "files" in hook:
+            problems.append(
+                f"{hook_id}: must not have a files: start-condition regex"
+            )
+        if hook.get("entry") != consumer_entry:
+            problems.append(f"{hook_id}: entry must invoke only {contract_rel}")
+        effective = hook.get("entry")
+        if effective in ("true", True) or effective == "/usr/bin/true":
+            problems.append(f"{hook_id}: effective entry is a no-op ({effective!r})")
     return problems
 
 
@@ -214,6 +309,7 @@ def main() -> None:
         editor_id,
         release_id,
         consumer_id,
+        producer_id,
         editor_entry,
         release_entry,
         consumer_entry,
@@ -231,6 +327,7 @@ def main() -> None:
             editor_id=editor_id,
             release_id=release_id,
             consumer_id=consumer_id,
+            producer_id=producer_id,
             editor_entry=editor_entry,
             release_entry=release_entry,
             consumer_entry=consumer_entry,
@@ -255,20 +352,38 @@ def main() -> None:
 
     if action == "mutate":
         kind, hook_id = rest[0], rest[1]
-        block = hook_block(src, hook_id)
         if kind == "second-files":
-            block = insert_after_key(block, "files", "files: ^$")
-        elif kind == "entry-true":
-            block = insert_after_key(block, "entry", "entry: 'true'")
-        elif kind == "drop-command":
+            block = insert_after_key(hook_block(src, hook_id), "files", "files: ^$")
+            Path(dest).write_text(replace_block(src, hook_id, block), encoding="utf-8")
+            return
+        if kind == "entry-true":
+            block = insert_after_key(hook_block(src, hook_id), "entry", "entry: 'true'")
+            Path(dest).write_text(replace_block(src, hook_id, block), encoding="utf-8")
+            return
+        if kind == "drop-command":
             token = rest[2]
+            block = hook_block(src, hook_id)
             if token not in block:
                 raise SystemExit(f"drop token not found in {hook_id}: {token!r}")
             block = block.replace(token, "", 1)
-        else:
-            raise SystemExit(f"unknown mutation {kind}")
-        Path(dest).write_text(replace_block(src, hook_id, block), encoding="utf-8")
-        return
+            Path(dest).write_text(replace_block(src, hook_id, block), encoding="utf-8")
+            return
+        if kind == "flow-duplicate":
+            extra = (
+                "      - {id: %s, entry: 'true', language: system}\n" % hook_id
+            )
+            Path(dest).write_text(insert_after_span(src, hook_id, extra), encoding="utf-8")
+            return
+        if kind == "reordered-duplicate":
+            extra = (
+                f"      - name: decoy {hook_id}\n"
+                f"        entry: 'true'\n"
+                f"        language: system\n"
+                f"        id: {hook_id}\n"
+            )
+            Path(dest).write_text(insert_after_span(src, hook_id, extra), encoding="utf-8")
+            return
+        raise SystemExit(f"unknown mutation {kind}")
 
     raise SystemExit(f"unknown action {action}")
 
@@ -278,8 +393,8 @@ if __name__ == "__main__":
 ENDPY
 
 cfg() {
-  python3 "$CFG_PY" \
-    "$EDITOR_ID" "$RELEASE_ID" "$CONSUMER_ID" \
+  "$PYTHON_YAML" "$CFG_PY" \
+    "$EDITOR_ID" "$RELEASE_ID" "$CONSUMER_ID" "$PRODUCER_ID" \
     "$EDITOR_ENTRY" "$RELEASE_ENTRY" "$CONSUMER_ENTRY" \
     "$CONTRACT_REL" "$@"
 }
@@ -465,6 +580,18 @@ cfg mutate "$CONFIG" "$TMP/drop-release.yaml" drop-command "$RELEASE_ID" "$RELEA
 expect_wiring_red 'remove test-check-release-surface.sh from release-surface chain' \
   "$TMP/drop-release.yaml"
 
+cfg mutate "$CONFIG" "$TMP/entry-true-consumer.yaml" entry-true "$CONSUMER_ID"
+expect_wiring_red "last-key-wins entry: 'true' on consumer hook" \
+  "$TMP/entry-true-consumer.yaml"
+
+cfg mutate "$CONFIG" "$TMP/flow-dup-editor.yaml" flow-duplicate "$EDITOR_ID"
+expect_wiring_red 'flow-mapping duplicate of editor-mcp-recipe-truth' \
+  "$TMP/flow-dup-editor.yaml"
+
+cfg mutate "$CONFIG" "$TMP/reordered-dup-release.yaml" reordered-duplicate "$RELEASE_ID"
+expect_wiring_red 'reordered-key duplicate of release-surface' \
+  "$TMP/reordered-dup-release.yaml"
+
 echo '== malformed recipe paired with editor bypasses =='
 pair="$TMP/pair-editor-second-files"
 prepare_editor_tree "$pair"
@@ -498,6 +625,14 @@ install_hook_config "$TMP/entry-true-release.yaml" "$RELEASE_ID" "$pair"
 git_seed "$pair"
 expect_consumer 'stale pin 0.0.0 + entry: true on release-surface hook' \
   "$pair" "$RELEASE_ID" passed
+
+echo '== consumer last-key-wins entry: true cannot hide from the producer =='
+pair="$TMP/pair-consumer-entry-true"
+mkdir -p "$pair"
+install_hook_config "$TMP/entry-true-consumer.yaml" "$CONSUMER_ID" "$pair"
+git_seed "$pair"
+expect_consumer "consumer hook last-key-wins entry: 'true' is a no-op" \
+  "$pair" "$CONSUMER_ID" passed
 
 printf '\n'
 if [ "$failures" -gt 0 ]; then

--- a/scripts/ci/test-editor-release-hook-precommit-consumer.sh
+++ b/scripts/ci/test-editor-release-hook-precommit-consumer.sh
@@ -495,6 +495,26 @@ def main() -> None:
             raise SystemExit(1)
         return
 
+    if action == "check-review-record-root":
+        import importlib.util
+        checker_path, workflow_path, host_path = rest[0], rest[1], rest[2]
+        spec = importlib.util.spec_from_file_location(
+            "review_record_workflow", checker_path
+        )
+        if spec is None or spec.loader is None:
+            raise SystemExit(f"cannot load {checker_path}")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        problems = mod.contract_problems(
+            Path(workflow_path).read_text(encoding="utf-8"),
+            src,
+            Path(host_path).read_text(encoding="utf-8"),
+        )
+        if problems:
+            sys.stderr.write("\n".join(problems) + "\n")
+            raise SystemExit(1)
+        return
+
     if action == "mutate-ci":
         kind = rest[0]
         if src.count(CI_CONSUMER_STEP) != 1:
@@ -545,6 +565,18 @@ def main() -> None:
             without = src.replace(CI_CONSUMER_STEP, "", 1)
             if without.count(heading) != 1:
                 raise SystemExit("hardening heading lost after consumer removal")
+            Path(dest).write_text(
+                without.replace(heading, CI_CONSUMER_STEP + "\n" + heading, 1),
+                encoding="utf-8",
+            )
+            return
+        if kind == "after-finale":
+            heading = "      - name: Verify review-record workflow contract\n"
+            if src.count(heading) != 1:
+                raise SystemExit("review-record root heading is not unique")
+            without = src.replace(CI_CONSUMER_STEP, "", 1)
+            if without.count(heading) != 1:
+                raise SystemExit("review-record heading lost after consumer removal")
             Path(dest).write_text(
                 without.replace(heading, CI_CONSUMER_STEP + "\n" + heading, 1),
                 encoding="utf-8",
@@ -777,6 +809,9 @@ check_ci_producer() {
 }
 
 CALLSITE="$ROOT/scripts/ci/check-conformance-inventory-callsite.py"
+REVIEW_RECORD_CHECKER="$ROOT/scripts/ci/check-review-record-workflow.py"
+REVIEW_RECORD_WORKFLOW="$ROOT/.github/workflows/review-record-check.yml"
+HOST_WORKFLOW="$ROOT/.github/workflows/host-capability-check.yml"
 
 check_trusted_prefix() {
   local path="$1"
@@ -787,6 +822,21 @@ expect_prefix_red() {
   local label="$1" config="$2"
   if check_trusted_prefix "$config" >"$TMP/$label.prefix" 2>&1; then
     fail "$label — trusted-prefix checker stayed green"
+  else
+    ok "RED $label"
+  fi
+}
+
+check_review_record_root() {
+  local path="$1"
+  cfg check-review-record-root "$path" "$path" \
+    "$REVIEW_RECORD_CHECKER" "$REVIEW_RECORD_WORKFLOW" "$HOST_WORKFLOW"
+}
+
+expect_review_record_red() {
+  local label="$1" config="$2"
+  if check_review_record_root "$config" >"$TMP/$label.review-record" 2>&1; then
+    fail "$label — review-record checker stayed green"
   else
     ok "RED $label"
   fi
@@ -832,6 +882,13 @@ if check_trusted_prefix "$CI_WORKFLOW"; then
   ok 'live hardening step follows checkout + setup-python'
 else
   fail 'live hardening step follows checkout + setup-python'
+fi
+
+echo '== live review-record root =='
+if check_review_record_root "$CI_WORKFLOW"; then
+  ok 'live review-record root immediately follows finale'
+else
+  fail 'live review-record root immediately follows finale'
 fi
 
 echo '== pin behavior: unmutated consumer must fail closed =='
@@ -905,6 +962,10 @@ expect_ci_red 'continue-on-error on required-CI consumer step' \
 cfg mutate-ci "$CI_WORKFLOW" "$TMP/ci-before-hardening.yml" before-hardening
 expect_prefix_red 'consumer step between setup-python and hardening' \
   "$TMP/ci-before-hardening.yml"
+
+cfg mutate-ci "$CI_WORKFLOW" "$TMP/ci-after-finale.yml" after-finale
+expect_review_record_red 'consumer step between finale and review-record root' \
+  "$TMP/ci-after-finale.yml"
 
 cfg mutate "$CONFIG" "$TMP/flow-dup-editor.yaml" flow-duplicate "$EDITOR_ID"
 expect_wiring_red 'flow-mapping duplicate of editor-mcp-recipe-truth' \

--- a/scripts/ci/test-editor-release-hook-precommit-consumer.sh
+++ b/scripts/ci/test-editor-release-hook-precommit-consumer.sh
@@ -479,6 +479,22 @@ def main() -> None:
             raise SystemExit(1)
         return
 
+    if action == "check-trusted-prefix":
+        import importlib.util
+        checker_path = rest[0]
+        spec = importlib.util.spec_from_file_location(
+            "conformance_inventory_callsite", checker_path
+        )
+        if spec is None or spec.loader is None:
+            raise SystemExit(f"cannot load {checker_path}")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        problems = mod.hardening_guard_callsite_problems(src)
+        if problems:
+            sys.stderr.write("\n".join(problems) + "\n")
+            raise SystemExit(1)
+        return
+
     if action == "mutate-ci":
         kind = rest[0]
         if src.count(CI_CONSUMER_STEP) != 1:
@@ -519,6 +535,18 @@ def main() -> None:
                     CI_CONSUMER_STEP_HEAD + "        continue-on-error: true\n",
                     1,
                 ),
+                encoding="utf-8",
+            )
+            return
+        if kind == "before-hardening":
+            heading = "      - name: Verify CI hardening contracts\n"
+            if src.count(heading) != 1:
+                raise SystemExit("hardening step heading is not unique")
+            without = src.replace(CI_CONSUMER_STEP, "", 1)
+            if without.count(heading) != 1:
+                raise SystemExit("hardening heading lost after consumer removal")
+            Path(dest).write_text(
+                without.replace(heading, CI_CONSUMER_STEP + "\n" + heading, 1),
                 encoding="utf-8",
             )
             return
@@ -748,6 +776,22 @@ check_ci_producer() {
   cfg check-ci "$path" "$path" "$RULESET"
 }
 
+CALLSITE="$ROOT/scripts/ci/check-conformance-inventory-callsite.py"
+
+check_trusted_prefix() {
+  local path="$1"
+  cfg check-trusted-prefix "$path" "$path" "$CALLSITE"
+}
+
+expect_prefix_red() {
+  local label="$1" config="$2"
+  if check_trusted_prefix "$config" >"$TMP/$label.prefix" 2>&1; then
+    fail "$label — trusted-prefix checker stayed green"
+  else
+    ok "RED $label"
+  fi
+}
+
 expect_ci_red() {
   local label="$1" config="$2"
   if check_ci_producer "$config" >"$TMP/$label.ci" 2>&1; then
@@ -781,6 +825,13 @@ if check_ci_producer "$CI_WORKFLOW"; then
   ok 'live CI job direct consumer invocation reaches required context'
 else
   fail 'live CI job direct consumer invocation reaches required context'
+fi
+
+echo '== live trusted prefix =='
+if check_trusted_prefix "$CI_WORKFLOW"; then
+  ok 'live hardening step follows checkout + setup-python'
+else
+  fail 'live hardening step follows checkout + setup-python'
 fi
 
 echo '== pin behavior: unmutated consumer must fail closed =='
@@ -850,6 +901,10 @@ expect_ci_red 'if: false on required-CI consumer step' "$TMP/ci-if-false.yml"
 cfg mutate-ci "$CI_WORKFLOW" "$TMP/ci-continue.yml" continue-on-error
 expect_ci_red 'continue-on-error on required-CI consumer step' \
   "$TMP/ci-continue.yml"
+
+cfg mutate-ci "$CI_WORKFLOW" "$TMP/ci-before-hardening.yml" before-hardening
+expect_prefix_red 'consumer step between setup-python and hardening' \
+  "$TMP/ci-before-hardening.yml"
 
 cfg mutate "$CONFIG" "$TMP/flow-dup-editor.yaml" flow-duplicate "$EDITOR_ID"
 expect_wiring_red 'flow-mapping duplicate of editor-mcp-recipe-truth' \


### PR DESCRIPTION
## Wait-gate

- Head: `396c01fc8f15eea76706059605cbc5580b0324ca` (`ruley/2743-editor-recipe-pin`).
- Parent: `4d74a7cdbd1d4ac6b175e820be9c9aa84892b1cb`.
- Base: `73c24f2444985f3e9cc2eab335729f11cc98da94`.
- Fast-forward only from here. No rebase, no squash, no force-push.

Fixes #2743.

## Required CI ordering

`python3 scripts/ci/check-review-record-workflow.py` was RED on `4d74a7cd` (`CI aggregator root must immediately follow Verify this gate waits on every gating job`; hosted run 33683512112 / job 100425386278). The required sequence is now:

1. Verify CI hardening contracts
2. Verify this gate waits on every gating job
3. Verify review-record workflow contract
4. Editor-release hook pre-commit consumer
5. Evaluate required job results

The consumer stays unconditional (no `if:`, no `continue-on-error`). Owner checkers `check-conformance-inventory-callsite.py` and `check-review-record-workflow.py` are unchanged. The consumer contract pins both directions: consumer between setup-python and hardening → trusted-prefix RED; consumer between finale and review-record root → review-record checker RED.

## P2 recipe restart wording (unchanged)

`docs/guides/editor-mcp-recipe.md` no longer claims plugin updates require a restart. Bounded wording: updates may activate immediately; if the session still shows stale plugin state, run `/reload-plugins` in Claude Code or restart the session before inspecting. `/reload-plugins` is outside the shell fence. The existing editor-truth guard forbids `plugin updates require a restart`.

**GREEN**

- `check-conformance-inventory-callsite.py` exit 0
- `test-conformance-inventory-callsite.py` OK
- `check-review-record-workflow.py` exit 0
- `test-review-record-workflow.py` OK
- extractor 25 PASS
- editor-truth 39 PASS
- release-surface 101 mutations
- consumer contract PASS (trusted-prefix RED and review-record successor RED)
- `shellcheck -x` same pre-existing SC2030/SC2031 infos as parent; no new codes
- `git diff --check` exit 0
- no Cargo

Draft only. Do not ready or merge from this PR. Fresh exact-head review required.
