### PR TITLE
test(ci): separate positive controls from deadline probes

### DIFF
--- a/scripts/ci/test_run_bounded_stdin.py
+++ b/scripts/ci/test_run_bounded_stdin.py
@@ -24,6 +24,7 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / "scripts/ci/claude_plugin_install_workflow.py"
 STDIN_256K = b"x" * 262_144
 DEADLINE_S = "0.05"
+SUCCESS_DEADLINE_S = "0.5"
 SLEEP_S = 0.35
 WALL_S = 1.0
 SUBPROCESS_ENV = {**os.environ, "ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS": DEADLINE_S}
@@ -91,6 +92,7 @@ def _probe_body(action: str) -> str:
             "sys.stdout.buffer.write(b'got:%d\\n' % len(data))\n"
         ),
         "early_close": (
+            "time.sleep(0.08)\n"
             "os.close(0)\n"
             "raise SystemExit(0)\n"
         ),
@@ -348,11 +350,10 @@ class BoundedStdinTests(unittest.TestCase):
         self.assertLess(outcome.elapsed, SLEEP_S)
 
     def test_reader_succeeds(self) -> None:
-        outcome = self._run("reader", STDIN_256K)
+        outcome = self._run("reader", STDIN_256K, timeout_s=SUCCESS_DEADLINE_S)
         self.assertEqual(outcome.kind, "ok", outcome.reason)
         self.assertEqual(outcome.result.returncode, 0)
         self.assertEqual(outcome.result.stdout, b"got:262144\n")
-        self.assertLess(outcome.elapsed, SLEEP_S)
 
     def test_empty_stdin_still_times_out(self) -> None:
         outcome = self._run("non_reader", b"")
@@ -361,13 +362,12 @@ class BoundedStdinTests(unittest.TestCase):
         self.assertLess(outcome.elapsed, SLEEP_S)
 
     def test_empty_stdin_immediate_exit_succeeds(self) -> None:
-        outcome = self._run("true", b"")
+        outcome = self._run("true", b"", timeout_s=SUCCESS_DEADLINE_S)
         self.assertEqual(outcome.kind, "ok", outcome.reason)
         self.assertEqual(outcome.result.returncode, 0)
-        self.assertLess(outcome.elapsed, SLEEP_S)
 
     def test_early_stdin_close_preserves_success(self) -> None:
-        outcome = self._run("early_close", STDIN_256K)
+        outcome = self._run("early_close", STDIN_256K, timeout_s=SUCCESS_DEADLINE_S)
         self.assertEqual(outcome.kind, "ok", outcome.reason)
         self.assertEqual(outcome.result.returncode, 0)
 


### PR DESCRIPTION
Closes #2193.

## Problem

The negative deadline probes and positive scheduler-dependent controls all used `0.05s`. Twice during unrelated full hook runs, `test_early_stdin_close_preserves_success` exceeded that budget and blocked the commit/push; the immediate focused reruns were 38/38 green.

## Change

- Keep the non-reader, write-first, and empty-stdin timeout probes at `0.05s`.
- Give positive reader, immediate-exit, and early-close controls a separate bounded `0.5s` budget.
- Add an `0.08s` early-close fixture delay so the old coupled budget fails deterministically.
- Remove elapsed-time assertions from success tests; their contract is clean classification and output, not scheduler speed.

Production `run_bounded()` code is unchanged.

## RED to GREEN

Before the budget split, the delayed fixture produced exactly one failure:

```text
FAIL: test_early_stdin_close_preserves_success
reason: process tree exceeded 0.05s deadline
Ran 38 tests
FAILED (failures=1)
```

After the split:

```text
Ran 38 tests in 7.543s
OK
```

## Mutation

Replacing `SUCCESS_DEADLINE_S = "0.5"` with `SUCCESS_DEADLINE_S = DEADLINE_S` makes exactly the delayed early-close control fail with the 0.05s diagnosis. The unmodified control is green.

## Verification

- `python3 scripts/ci/test_run_bounded_stdin.py`
- `python3 -m py_compile scripts/ci/test_run_bounded_stdin.py`
- commit hooks: pass
- pre-push hooks: pass
- `git diff --check`

## Non-claims

- No production process-supervisor behavior changed.
- This does not prove a live Claude host journey.
- The negative deadline tests remain 50 ms and still own timeout enforcement.
- CI and independent exact-head review remain required before merge.
