### PR TITLE
fix(installer): verify release integrity before activation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -652,6 +652,13 @@ repos:
         pass_filenames: false
         files: ^(scripts/install\.sh|scripts/ci/test-install-version-normalization\.sh|\.pre-commit-config\.yaml)$
 
+      - id: install-release-verification-self-test
+        name: installer release verification contract
+        entry: bash scripts/ci/test-install-release-verification.sh
+        language: system
+        pass_filenames: false
+        files: ^(scripts/install\.sh|scripts/ci/test-install-release-verification\.sh|README\.md|\.pre-commit-config\.yaml)$
+
       - id: deps-security-toolchain-contract-self-test
         name: deps-security toolchain contract
         entry: bash scripts/ci/test-deps-security-toolchain-contract.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -657,7 +657,16 @@ repos:
         entry: bash scripts/ci/test-install-release-verification.sh
         language: system
         pass_filenames: false
-        files: ^(scripts/install\.sh|scripts/ci/test-install-release-verification\.sh|README\.md|\.pre-commit-config\.yaml)$
+        stages: [pre-commit]
+        files: ^(scripts/install\.sh|scripts/ci/(check-install-release-verification-hook|test-install-release-verification)\.sh|README\.md|\.pre-commit-config\.yaml)$
+
+      - id: install-release-verification-hook-contract
+        name: installer release verification hook contract
+        entry: bash scripts/ci/check-install-release-verification-hook.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
 
       - id: deps-security-toolchain-contract-self-test
         name: deps-security toolchain contract

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Agents got real tool access through MCP — and tool poisoning, rug pulls, and c
 # Fast path: release installer for Linux and macOS.
 curl -fsSL https://getassay.dev/install.sh | sh
 
+# Strict mode also verifies the release attestation (requires GitHub CLI).
+curl -fsSL https://getassay.dev/install.sh | ASSAY_REQUIRE_PROVENANCE=1 sh
+
 # Confirm the command resolves; if setup fails, run `assay doctor`.
 assay --version
 
@@ -47,8 +50,12 @@ python3 examples/mcp-quickstart/run.py
 ```
 
 For v5.5.2, run the last command from a source checkout or an extracted published CLI archive.
-The installer is binary-only and does not carry the bounded quickstart assets. The installer
-downloads over HTTPS but does not consume the published checksum or provenance sidecars.
+The installer is binary-only and does not carry the bounded quickstart assets. Every install
+verifies the selected archive against its published SHA-256 sidecar before extraction. Strict mode
+additionally requires GitHub's attestation verifier and binds the archive to this repository, the
+release workflow, the GitHub Actions OIDC issuer, the SLSA v1 predicate, and the release tag's
+commit while refusing self-hosted provenance. These checks establish byte and producer-workflow
+identity under those bindings; they do not establish runtime safety or semantic correctness.
 
 Captured runner output (the bundled local mock performs no external action):
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,10 @@ python3 examples/mcp-quickstart/run.py
 ```
 
 For v5.5.2, run the last command from a source checkout or an extracted published CLI archive.
-The installer is binary-only and does not carry the bounded quickstart assets. Every install
-verifies the selected archive against its published SHA-256 sidecar before extraction. Strict mode
-additionally requires GitHub's attestation verifier and binds the archive to this repository, the
-release workflow, the GitHub Actions OIDC issuer, the SLSA v1 predicate, and the release tag's
-commit while refusing self-hosted provenance. These checks establish byte and producer-workflow
-identity under those bindings; they do not establish runtime safety or semantic correctness.
+The installer is binary-only and does not carry the bounded quickstart assets. The live
+`getassay.dev` installer downloads over HTTPS but does not yet consume the published checksum or
+provenance sidecars. The verified source installer will replace it through the separately measured
+deployment tracked in `Rul1an/getassay-site#6`.
 
 Captured runner output (the bundled local mock performs no external action):
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ Agents got real tool access through MCP — and tool poisoning, rug pulls, and c
 # Fast path: release installer for Linux and macOS.
 curl -fsSL https://getassay.dev/install.sh | sh
 
-# Strict mode also verifies the release attestation (requires an authenticated GitHub CLI or GH_TOKEN).
-curl -fsSL https://getassay.dev/install.sh | ASSAY_REQUIRE_PROVENANCE=1 sh
-
 # Confirm the command resolves; if setup fails, run `assay doctor`.
 assay --version
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Agents got real tool access through MCP — and tool poisoning, rug pulls, and c
 # Fast path: release installer for Linux and macOS.
 curl -fsSL https://getassay.dev/install.sh | sh
 
-# Strict mode also verifies the release attestation (requires GitHub CLI).
+# Strict mode also verifies the release attestation (requires an authenticated GitHub CLI or GH_TOKEN).
 curl -fsSL https://getassay.dev/install.sh | ASSAY_REQUIRE_PROVENANCE=1 sh
 
 # Confirm the command resolves; if setup fails, run `assay doctor`.

--- a/scripts/ci/check-install-release-verification-hook.sh
+++ b/scripts/ci/check-install-release-verification-hook.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONFIG="${PRECOMMIT_CONFIG:-$ROOT/.pre-commit-config.yaml}"
+
+ruby -EUTF-8:UTF-8 - "$CONFIG" <<'RUBY'
+require "yaml"
+
+config = YAML.safe_load_file(ARGV.fetch(0), aliases: false)
+repos = config.is_a?(Hash) ? config["repos"] : nil
+abort "pre-commit config has no repos list" unless repos.is_a?(Array)
+
+expected = {
+  "install-release-verification-self-test" => {
+    "entry" => "bash scripts/ci/test-install-release-verification.sh",
+    "language" => "system",
+    "pass_filenames" => false,
+    "stages" => ["pre-commit"],
+    "files" => "^(scripts/install\\.sh|scripts/ci/(check-install-release-verification-hook|test-install-release-verification)\\.sh|README\\.md|\\.pre-commit-config\\.yaml)$",
+  },
+  "install-release-verification-hook-contract" => {
+    "entry" => "bash scripts/ci/check-install-release-verification-hook.sh",
+    "language" => "system",
+    "pass_filenames" => false,
+    "always_run" => true,
+    "stages" => ["pre-commit"],
+  },
+}
+
+found = Hash.new { |hash, key| hash[key] = [] }
+repos.each do |repo|
+  next unless repo.is_a?(Hash)
+  hooks = repo["hooks"]
+  next unless hooks.is_a?(Array)
+  hooks.each do |hook|
+    next unless hook.is_a?(Hash) && expected.key?(hook["id"])
+    found[hook["id"]] << [repo["repo"], hook]
+  end
+end
+
+expected.each do |hook_id, required|
+  rows = found.fetch(hook_id)
+  abort "expected exactly one #{hook_id}, found #{rows.length}" unless rows.length == 1
+  owner, hook = rows.fetch(0)
+  abort "#{hook_id} must be owned by repo: local" unless owner == "local"
+  required.each do |key, value|
+    actual = hook[key]
+    abort "#{hook_id} #{key}=#{actual.inspect}, expected #{value.inspect}" unless actual == value
+  end
+end
+
+puts "install-release-verification-hook=pass"
+RUBY

--- a/scripts/ci/test-install-release-verification.sh
+++ b/scripts/ci/test-install-release-verification.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 INSTALLER="${INSTALLER:-$ROOT/scripts/install.sh}"
+HOOK_CHECKER="${HOOK_CHECKER:-$ROOT/scripts/ci/check-install-release-verification-hook.sh}"
 TEST_TMP=""
 
 fail() {
@@ -20,43 +21,64 @@ compute_sha256() {
 }
 
 assert_precommit_wiring() {
-  python3 - "$ROOT/.pre-commit-config.yaml" <<'PY'
-import re
+  bash "$HOOK_CHECKER"
+
+  local mutation_dir="$TEST_TMP/hook-mutations"
+  mkdir -p "$mutation_dir"
+  python3 - "$ROOT/.pre-commit-config.yaml" "$mutation_dir" <<'PY'
 import sys
 from pathlib import Path
 
-path = Path(sys.argv[1])
-text = path.read_text(encoding="utf-8")
-hook_id = "install-release-verification-self-test"
-matches = list(re.finditer(rf"^\s*- id: {re.escape(hook_id)}\s*$", text, re.MULTILINE))
-if len(matches) != 1:
-    raise SystemExit(f"expected exactly one {hook_id} hook, found {len(matches)}")
-
-start = matches[0].start()
-next_hook = re.search(r"^\s*- id: ", text[matches[0].end():], re.MULTILINE)
-end = matches[0].end() + next_hook.start() if next_hook else len(text)
-block = text[start:end]
-
-expected_entry = "entry: bash scripts/ci/test-install-release-verification.sh"
-if expected_entry not in block:
-    raise SystemExit(f"{hook_id} does not invoke the contract test")
-if not re.search(r"^\s*pass_filenames:\s*false\s*$", block, re.MULTILINE):
-    raise SystemExit(f"{hook_id} must set pass_filenames: false")
-
-files_match = re.search(r"^\s*files:\s*(.+?)\s*$", block, re.MULTILINE)
-if files_match is None:
-    raise SystemExit(f"{hook_id} has no files selector")
-selector = re.compile(files_match.group(1))
-required = (
-    "scripts/install.sh",
-    "scripts/ci/test-install-release-verification.sh",
-    "README.md",
-    ".pre-commit-config.yaml",
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+dest = Path(sys.argv[2])
+hook_pos = source.index("      - id: install-release-verification-self-test\n")
+owner_pos = source.rfind("  - repo: local\n", 0, hook_pos)
+if owner_pos < 0:
+    raise SystemExit("test mutation wrong-owner could not find owning repo")
+wrong_owner = (
+    source[:owner_pos]
+    + "  - repo: https://example.invalid/hooks\n"
+    + source[owner_pos + len("  - repo: local\n"):]
 )
-missed = [candidate for candidate in required if selector.fullmatch(candidate) is None]
-if missed:
-    raise SystemExit(f"{hook_id} files selector misses: {', '.join(missed)}")
+mutations = {
+    "wrong-owner": wrong_owner,
+    "comment-decoy-entry": source.replace(
+        "entry: bash scripts/ci/test-install-release-verification.sh",
+        "entry: true # entry: bash scripts/ci/test-install-release-verification.sh",
+        1,
+    ),
+    "empty-selector": source.replace(
+        "files: ^(scripts/install\\.sh|scripts/ci/(check-install-release-verification-hook|test-install-release-verification)\\.sh|README\\.md|\\.pre-commit-config\\.yaml)$",
+        "files: ^$",
+        1,
+    ),
+    "manual-stage": source.replace(
+        "      - id: install-release-verification-self-test\n"
+        "        name: installer release verification contract\n"
+        "        entry: bash scripts/ci/test-install-release-verification.sh\n"
+        "        language: system\n"
+        "        pass_filenames: false\n"
+        "        stages: [pre-commit]\n",
+        "      - id: install-release-verification-self-test\n"
+        "        name: installer release verification contract\n"
+        "        entry: bash scripts/ci/test-install-release-verification.sh\n"
+        "        language: system\n"
+        "        pass_filenames: false\n"
+        "        stages: [manual]\n",
+        1,
+    ),
+}
+for name, text in mutations.items():
+    if text == source:
+        raise SystemExit(f"test mutation {name} did not apply")
+    (dest / f"{name}.yaml").write_text(text, encoding="utf-8")
 PY
+  local mutated
+  for mutated in "$mutation_dir"/*.yaml; do
+    if PRECOMMIT_CONFIG="$mutated" bash "$HOOK_CHECKER" >/dev/null 2>&1; then
+      fail "hook checker accepted mutation $(basename "$mutated")"
+    fi
+  done
 }
 
 make_fixture() {
@@ -99,6 +121,7 @@ set -eu
 
 out=""
 wants_status=0
+max_filesize=""
 url=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -108,6 +131,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     -w)
       wants_status=1
+      shift 2
+      ;;
+    --max-filesize)
+      max_filesize="$2"
       shift 2
       ;;
     -*)
@@ -126,6 +153,7 @@ case "$url" in
     asset_name="$(basename "${url%.sha256}")"
     fixture_archive="$FIXTURE_DIR/$asset_name"
     fixture_sidecar="${fixture_archive}.sha256"
+    printf '%s\n' "${max_filesize:-none}" >> "$CURL_LIMIT_LOG"
     case "${CURL_MODE:-ok}" in
       missing-sidecar) exit 22 ;;
       malformed-sidecar) printf '%s\n' 'not-a-sidecar' > "$out" ;;
@@ -136,6 +164,13 @@ case "$url" in
       trailing-garbage)
         cat "$fixture_sidecar" > "$out"
         printf '%s' 'garbage' >> "$out"
+        ;;
+      oversized-sidecar)
+        if [ -n "$max_filesize" ] && [ "$max_filesize" -lt 4096 ]; then
+          dd if=/dev/zero bs=1 count="$max_filesize" 2>/dev/null | tr '\000' a > "$out"
+          exit 63
+        fi
+        dd if=/dev/zero bs=1 count=4096 2>/dev/null | tr '\000' a > "$out"
         ;;
       mismatch)
         printf '%064d  %s\n' 0 "$asset_name" > "$out"
@@ -222,7 +257,7 @@ EOF
 new_case() {
   local name="$1"
   local case_dir="$TEST_TMP/$name"
-  mkdir -p "$case_dir/bin" "$case_dir/home" "$case_dir/install"
+  mkdir -p "$case_dir/bin" "$case_dir/home" "$case_dir/install" "$case_dir/tmp"
   make_uname_stub "$case_dir/bin"
   make_curl_stub "$case_dir/bin"
   make_gh_stub "$case_dir/bin"
@@ -241,6 +276,7 @@ run_installer() {
     ASSAY_INSTALL_DIR="$case_dir/install" \
     FIXTURE_DIR="$TEST_TMP" \
     CURL_LOG="$case_dir/curl.log" \
+    CURL_LIMIT_LOG="$case_dir/curl-limit.log" \
     GH_LOG="$case_dir/gh.log" \
     "$@" \
     sh "$INSTALLER"
@@ -291,8 +327,12 @@ def matches(actual):
             return False
     return True
 
-match_count = sum(matches(invocation) for invocation in invocations)
-if match_count != 1:
+attestation_invocations = [
+    invocation for invocation in invocations
+    if invocation[:2] == ["attestation", "verify"]
+]
+match_count = sum(matches(invocation) for invocation in attestation_invocations)
+if match_count != 1 or len(attestation_invocations) != 1:
     raise SystemExit(
         f"expected exactly one gh invocation {expected!r}, found {match_count}; "
         f"observed={invocations!r}"
@@ -300,9 +340,36 @@ if match_count != 1:
 PY
 }
 
+assert_extra_attestation_invocation_is_rejected() {
+  local source_log="$1"
+  local extra_log="$2"
+  cp "$source_log" "$extra_log"
+  cat >> "$extra_log" <<'EOF'
+--- invocation ---
+attestation
+verify
+/tmp/evil.tar.gz
+--repo
+evil/repo
+--signer-workflow
+evil/workflow
+EOF
+  if assert_exact_gh_invocation "$extra_log" \
+    attestation verify '<ARCHIVE>' \
+    --repo Rul1an/assay \
+    --signer-workflow Rul1an/assay/.github/workflows/release.yml \
+    --cert-oidc-issuer https://token.actions.githubusercontent.com \
+    --predicate-type https://slsa.dev/provenance/v1 \
+    --source-digest bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+    --deny-self-hosted-runners >/dev/null 2>&1; then
+    fail 'exact gh invocation guard accepted an additional attestation call'
+  fi
+}
+
 assert_default_success() {
   local os="$1"
   local label="$2"
+  local target archive_name expected_sidecar_bytes
   local case_dir
   case_dir="$(new_case "default-success-$label")"
   run_installer "$case_dir" FAKE_OS="$os" > "$case_dir/stdout" 2> "$case_dir/stderr"
@@ -314,6 +381,15 @@ assert_default_success() {
   grep -F 'assay 5.5.2 fixture' "$case_dir/install/assay" >/dev/null || fail 'default install did not activate fixture'
   test "$(file_mode "$case_dir/install/assay")" = 755 || fail 'activated binary mode is not exactly 0755'
   test "$(wc -l < "$case_dir/curl.log" | tr -d ' ')" -eq 2 || fail 'default install did not fetch exactly archive and sidecar'
+  case "$os" in
+    Linux) target=x86_64-unknown-linux-gnu ;;
+    Darwin) target=x86_64-apple-darwin ;;
+    *) fail "test bug: unsupported fixture OS $os" ;;
+  esac
+  archive_name="assay-v5.5.2-${target}.tar.gz"
+  expected_sidecar_bytes=$((64 + 2 + ${#archive_name} + 1))
+  grep -Fx "$expected_sidecar_bytes" "$case_dir/curl-limit.log" >/dev/null || \
+    fail 'sidecar download did not apply its exact pre-materialization byte ceiling'
   test ! -s "$case_dir/gh.log" || fail 'default install invoked gh'
 }
 
@@ -341,8 +417,11 @@ assert_activation_failure_preserves_binary() {
 }
 
 assert_signal_stops_before_next_network_step() {
-  local case_dir marker pid rc=0
-  case_dir="$(new_case signal-term)"
+  local signal="$1"
+  local expected_rc="$2"
+  local label="$3"
+  local case_dir marker rc
+  case_dir="$(new_case "signal-$label")"
   marker="$case_dir/archive-downloaded"
 
   env \
@@ -352,24 +431,42 @@ assert_signal_stops_before_next_network_step() {
     ASSAY_INSTALL_DIR="$case_dir/install" \
     FIXTURE_DIR="$TEST_TMP" \
     CURL_LOG="$case_dir/curl.log" \
+    CURL_LIMIT_LOG="$case_dir/curl-limit.log" \
     GH_LOG="$case_dir/gh.log" \
     CURL_MODE=block-after-archive \
     SIGNAL_MARKER="$marker" \
-    sh "$INSTALLER" > "$case_dir/stdout" 2> "$case_dir/stderr" &
-  pid=$!
+    TMPDIR="$case_dir/tmp" \
+    python3 - "$INSTALLER" "$marker" "$case_dir/stdout" "$case_dir/stderr" "$case_dir/rc" "$signal" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
 
-  for _ in $(seq 1 100); do
-    test -f "$marker" && break
-    sleep 0.02
-  done
-  test -f "$marker" || fail 'signal test did not reach the bounded archive-download witness'
-
-  kill -TERM "$pid"
-  wait "$pid" || rc=$?
-  test "$rc" -ne 0 || fail 'TERM allowed the installer to report success'
+installer, marker, stdout_path, stderr_path, rc_path, signal_name = sys.argv[1:]
+with open(stdout_path, "wb") as stdout, open(stderr_path, "wb") as stderr:
+    proc = subprocess.Popen(["sh", installer], stdout=stdout, stderr=stderr, env=os.environ.copy())
+    for _ in range(100):
+        if Path(marker).is_file():
+            break
+        time.sleep(0.02)
+    else:
+        proc.kill()
+        proc.wait()
+        raise SystemExit("signal test did not reach the bounded archive-download witness")
+    os.kill(proc.pid, getattr(signal, f"SIG{signal_name}"))
+    rc = proc.wait(timeout=10)
+Path(rc_path).write_text(f"{rc}\n", encoding="utf-8")
+PY
+  rc="$(cat "$case_dir/rc")"
+  test "$rc" -eq "$expected_rc" || fail "$signal exited $rc, expected $expected_rc"
   assert_old_binary "$case_dir"
   test "$(wc -l < "$case_dir/curl.log" | tr -d ' ')" -eq 1 || \
-    fail 'TERM allowed the installer to continue to another network step'
+    fail "$signal allowed the installer to continue to another network step"
+  if find "$case_dir/tmp" -mindepth 1 -print -quit | grep -q .; then
+    fail "$signal left installer scratch residue"
+  fi
 }
 
 assert_checksum_failure_preserves_binary() {
@@ -377,9 +474,8 @@ assert_checksum_failure_preserves_binary() {
   local expected_error
   case "$mode" in
     mismatch) expected_error='Archive checksum mismatch' ;;
-    missing-sidecar) expected_error='Download failed' ;;
-    malformed-sidecar|wrong-asset-sidecar) expected_error='Checksum sidecar does not name the selected archive' ;;
-    trailing-garbage) expected_error='Checksum sidecar must contain exactly one newline-terminated record' ;;
+    missing-sidecar|oversized-sidecar) expected_error='Download failed' ;;
+    malformed-sidecar|wrong-asset-sidecar|trailing-garbage) expected_error='Checksum sidecar must contain exactly one newline-terminated record' ;;
     *) fail "test bug: no expected error for checksum mode $mode" ;;
   esac
   local case_dir
@@ -470,15 +566,15 @@ assert_invalid_tag_digest_refuses() {
 }
 
 main() {
-  assert_precommit_wiring
   TEST_TMP="$(mktemp -d)"
   trap 'rm -rf "$TEST_TMP"' EXIT
+  assert_precommit_wiring
   make_fixture "$TEST_TMP" x86_64-unknown-linux-gnu
   make_fixture "$TEST_TMP" x86_64-apple-darwin
 
   assert_default_success Linux linux
   assert_default_success Darwin macos
-  for mode in mismatch missing-sidecar malformed-sidecar wrong-asset-sidecar trailing-garbage; do
+  for mode in mismatch missing-sidecar malformed-sidecar wrong-asset-sidecar trailing-garbage oversized-sidecar; do
     assert_checksum_failure_preserves_binary "$mode"
   done
   assert_invalid_provenance_mode_refuses_before_network 0 zero
@@ -486,9 +582,14 @@ main() {
   assert_invalid_provenance_mode_refuses_before_network yes yes
   assert_missing_verifier_refuses
   assert_strict_success
+  assert_extra_attestation_invocation_is_rejected \
+    "$TEST_TMP/strict-success/gh.log" \
+    "$TEST_TMP/strict-success/gh-extra.log"
   assert_strict_failure_preserves_binary
   assert_invalid_tag_digest_refuses
-  assert_signal_stops_before_next_network_step
+  assert_signal_stops_before_next_network_step HUP 129 hup
+  assert_signal_stops_before_next_network_step INT 130 int
+  assert_signal_stops_before_next_network_step TERM 143 term
   assert_activation_failure_preserves_binary
   assert_relative_install_dir_resolves_from_invocation_directory
 

--- a/scripts/ci/test-install-release-verification.sh
+++ b/scripts/ci/test-install-release-verification.sh
@@ -164,7 +164,10 @@ make_gh_stub() {
   cat > "$bin_dir/gh" <<'EOF'
 #!/bin/sh
 set -eu
-printf '%s\n' "$*" >> "$GH_LOG"
+{
+  printf '%s\n' '--- invocation ---'
+  printf '%s\n' "$@"
+} >> "$GH_LOG"
 
 if [ "$1" = api ]; then
   case "$2" in
@@ -245,6 +248,20 @@ assert_old_binary() {
     fail "verification failure replaced the existing binary in $case_dir"
 }
 
+file_mode() {
+  if stat -f '%Lp' "$1" >/dev/null 2>&1; then
+    stat -f '%Lp' "$1"
+  else
+    stat -c '%a' "$1"
+  fi
+}
+
+assert_exact_gh_argument() {
+  local log="$1"
+  local expected="$2"
+  grep -Fx -- "$expected" "$log" >/dev/null || fail "missing exact gh argument: $expected"
+}
+
 assert_default_success() {
   local os="$1"
   local label="$2"
@@ -257,8 +274,20 @@ assert_default_success() {
     fail 'checksum-only install claimed provenance_verified'
   fi
   grep -F 'assay 5.5.2 fixture' "$case_dir/install/assay" >/dev/null || fail 'default install did not activate fixture'
+  test "$(file_mode "$case_dir/install/assay")" = 755 || fail 'activated binary mode is not exactly 0755'
   test "$(wc -l < "$case_dir/curl.log" | tr -d ' ')" -eq 2 || fail 'default install did not fetch exactly archive and sidecar'
   test ! -s "$case_dir/gh.log" || fail 'default install invoked gh'
+}
+
+assert_relative_install_dir_resolves_from_invocation_directory() {
+  local case_dir
+  case_dir="$(new_case relative-install-dir)"
+  (
+    cd "$case_dir"
+    run_installer "$case_dir" ASSAY_INSTALL_DIR=relative-install > "$case_dir/stdout" 2> "$case_dir/stderr"
+  )
+  grep -F 'assay 5.5.2 fixture' "$case_dir/relative-install/assay" >/dev/null || \
+    fail 'relative ASSAY_INSTALL_DIR did not resolve from the invocation directory'
 }
 
 assert_activation_failure_preserves_binary() {
@@ -361,15 +390,26 @@ assert_strict_success() {
   fi
 
   local log="$case_dir/gh.log"
-  grep -F 'api repos/Rul1an/assay/git/ref/tags/v5.5.2' "$log" >/dev/null
-  grep -F 'api repos/Rul1an/assay/git/tags/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' "$log" >/dev/null
-  grep -F 'attestation verify' "$log" >/dev/null
-  grep -F -- '--repo Rul1an/assay' "$log" >/dev/null
-  grep -F -- '--signer-workflow Rul1an/assay/.github/workflows/release.yml' "$log" >/dev/null
-  grep -F -- '--cert-oidc-issuer https://token.actions.githubusercontent.com' "$log" >/dev/null
-  grep -F -- '--predicate-type https://slsa.dev/provenance/v1' "$log" >/dev/null
-  grep -F -- '--source-digest bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' "$log" >/dev/null
-  grep -F -- '--deny-self-hosted-runners' "$log" >/dev/null
+  for expected in \
+    api \
+    repos/Rul1an/assay/git/ref/tags/v5.5.2 \
+    repos/Rul1an/assay/git/tags/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+    attestation \
+    verify \
+    --repo \
+    Rul1an/assay \
+    --signer-workflow \
+    Rul1an/assay/.github/workflows/release.yml \
+    --cert-oidc-issuer \
+    https://token.actions.githubusercontent.com \
+    --predicate-type \
+    https://slsa.dev/provenance/v1 \
+    --source-digest \
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+    --deny-self-hosted-runners
+  do
+    assert_exact_gh_argument "$log" "$expected"
+  done
 }
 
 assert_strict_failure_preserves_binary() {
@@ -417,6 +457,7 @@ main() {
   assert_invalid_tag_digest_refuses
   assert_signal_stops_before_next_network_step
   assert_activation_failure_preserves_binary
+  assert_relative_install_dir_resolves_from_invocation_directory
 
   echo 'install release verification: PASS'
 }

--- a/scripts/ci/test-install-release-verification.sh
+++ b/scripts/ci/test-install-release-verification.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALLER="${INSTALLER:-$ROOT/scripts/install.sh}"
+TEST_TMP=""
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+compute_sha256() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  else
+    shasum -a 256 "$file" | awk '{print $1}'
+  fi
+}
+
+make_fixture() {
+  local root="$1"
+  local target="$2"
+  local version="v5.5.2"
+  local archive_name="assay-${version}-${target}.tar.gz"
+  local archive="$root/$archive_name"
+  local payload_root="$root/payload-$target"
+  local payload="$payload_root/assay-${version}-${target}"
+
+  mkdir -p "$payload"
+  cat > "$payload/assay" <<'EOF'
+#!/bin/sh
+echo 'assay 5.5.2 fixture'
+EOF
+  chmod +x "$payload/assay"
+  tar -C "$payload_root" -czf "$archive" "assay-${version}-${target}"
+  printf '%s  %s\n' "$(compute_sha256 "$archive")" "$archive_name" > "${archive}.sha256"
+}
+
+make_uname_stub() {
+  local bin_dir="$1"
+  cat > "$bin_dir/uname" <<'EOF'
+#!/bin/sh
+case "$1" in
+  -s) printf '%s\n' "${FAKE_OS:-Linux}" ;;
+  -m) printf '%s\n' x86_64 ;;
+  *) exit 2 ;;
+esac
+EOF
+  chmod +x "$bin_dir/uname"
+}
+
+make_curl_stub() {
+  local bin_dir="$1"
+  cat > "$bin_dir/curl" <<'EOF'
+#!/bin/sh
+set -eu
+
+out=""
+wants_status=0
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    -w)
+      wants_status=1
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+printf '%s\n' "$url" >> "$CURL_LOG"
+case "$url" in
+  *.tar.gz.sha256)
+    asset_name="$(basename "${url%.sha256}")"
+    fixture_archive="$FIXTURE_DIR/$asset_name"
+    fixture_sidecar="${fixture_archive}.sha256"
+    case "${CURL_MODE:-ok}" in
+      missing-sidecar) exit 22 ;;
+      malformed-sidecar) printf '%s\n' 'not-a-sidecar' > "$out" ;;
+      wrong-asset-sidecar)
+        digest="$(cut -d' ' -f1 "$fixture_sidecar")"
+        printf '%s  %s\n' "$digest" 'assay-v5.5.2-aarch64-unknown-linux-gnu.tar.gz' > "$out"
+        ;;
+      mismatch)
+        printf '%064d  %s\n' 0 "$asset_name" > "$out"
+        ;;
+      *) cp "$fixture_sidecar" "$out" ;;
+    esac
+    ;;
+  *.tar.gz)
+    cp "$FIXTURE_DIR/$(basename "$url")" "$out"
+    ;;
+  *)
+    echo "unexpected curl URL: $url" >&2
+    exit 2
+    ;;
+esac
+
+if [ "$wants_status" -eq 1 ]; then
+  printf '%s' 200
+fi
+EOF
+  chmod +x "$bin_dir/curl"
+}
+
+make_gh_stub() {
+  local bin_dir="$1"
+  cat > "$bin_dir/gh" <<'EOF'
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$GH_LOG"
+
+if [ "$1" = api ]; then
+  case "$2" in
+    repos/Rul1an/assay/git/ref/tags/v5.5.2)
+      if [ "${GH_TAG_MODE:-ok}" = invalid-digest ]; then
+        printf '%s\n' 'commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      else
+        printf '%s\n' 'tag aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      fi
+      ;;
+    repos/Rul1an/assay/git/tags/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+      printf '%s\n' 'commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+      ;;
+    *)
+      echo "unexpected gh api request: $2" >&2
+      exit 2
+      ;;
+  esac
+  exit 0
+fi
+
+if [ "$1" = attestation ] && [ "$2" = verify ]; then
+  if [ "${GH_VERIFY_MODE:-ok}" = fail ]; then
+    echo 'simulated attestation refusal' >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 2
+EOF
+  chmod +x "$bin_dir/gh"
+}
+
+make_chmod_stub() {
+  local bin_dir="$1"
+  cat > "$bin_dir/chmod" <<'EOF'
+#!/bin/sh
+if [ "${CHMOD_MODE:-ok}" = fail ]; then
+  exit 1
+fi
+exec /bin/chmod "$@"
+EOF
+  chmod +x "$bin_dir/chmod"
+}
+
+new_case() {
+  local name="$1"
+  local case_dir="$TEST_TMP/$name"
+  mkdir -p "$case_dir/bin" "$case_dir/home" "$case_dir/install"
+  make_uname_stub "$case_dir/bin"
+  make_curl_stub "$case_dir/bin"
+  make_gh_stub "$case_dir/bin"
+  make_chmod_stub "$case_dir/bin"
+  printf '%s\n' 'old binary' > "$case_dir/install/assay"
+  printf '%s\n' "$case_dir"
+}
+
+run_installer() {
+  local case_dir="$1"
+  shift
+  env \
+    HOME="$case_dir/home" \
+    PATH="$case_dir/bin:/usr/bin:/bin" \
+    ASSAY_VERSION=5.5.2 \
+    ASSAY_INSTALL_DIR="$case_dir/install" \
+    FIXTURE_DIR="$TEST_TMP" \
+    CURL_LOG="$case_dir/curl.log" \
+    GH_LOG="$case_dir/gh.log" \
+    "$@" \
+    sh "$INSTALLER"
+}
+
+assert_old_binary() {
+  local case_dir="$1"
+  grep -Fx 'old binary' "$case_dir/install/assay" >/dev/null || \
+    fail "verification failure replaced the existing binary in $case_dir"
+}
+
+assert_default_success() {
+  local os="$1"
+  local label="$2"
+  local case_dir
+  case_dir="$(new_case "default-success-$label")"
+  run_installer "$case_dir" FAKE_OS="$os" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  grep -F 'checksum_verified' "$case_dir/stdout" >/dev/null || fail 'default install did not report checksum_verified'
+  grep -F 'provenance_not_requested' "$case_dir/stdout" >/dev/null || fail 'default install did not report provenance_not_requested'
+  if grep -F 'provenance_verified' "$case_dir/stdout" >/dev/null; then
+    fail 'checksum-only install claimed provenance_verified'
+  fi
+  grep -F 'assay 5.5.2 fixture' "$case_dir/install/assay" >/dev/null || fail 'default install did not activate fixture'
+  test "$(wc -l < "$case_dir/curl.log" | tr -d ' ')" -eq 2 || fail 'default install did not fetch exactly archive and sidecar'
+  test ! -s "$case_dir/gh.log" || fail 'default install invoked gh'
+}
+
+assert_activation_failure_preserves_binary() {
+  local case_dir
+  case_dir="$(new_case activation-failure)"
+  if run_installer "$case_dir" CHMOD_MODE=fail > "$case_dir/stdout" 2> "$case_dir/stderr"; then
+    fail 'installer succeeded after candidate preparation failed'
+  fi
+  assert_old_binary "$case_dir"
+  if find "$case_dir/install" -name '.assay.install.*' -print -quit | grep -q .; then
+    fail 'failed activation left a same-directory candidate behind'
+  fi
+}
+
+assert_checksum_failure_preserves_binary() {
+  local mode="$1"
+  local expected_error
+  case "$mode" in
+    mismatch) expected_error='Archive checksum mismatch' ;;
+    missing-sidecar) expected_error='Download failed' ;;
+    malformed-sidecar|wrong-asset-sidecar) expected_error='Checksum sidecar does not name the selected archive' ;;
+    *) fail "test bug: no expected error for checksum mode $mode" ;;
+  esac
+  local case_dir
+  case_dir="$(new_case "checksum-$mode")"
+  if run_installer "$case_dir" CURL_MODE="$mode" > "$case_dir/stdout" 2> "$case_dir/stderr"; then
+    fail "$mode sidecar unexpectedly installed"
+  fi
+  if ! grep -F "$expected_error" "$case_dir/stdout" "$case_dir/stderr" >/dev/null; then
+    cat "$case_dir/stdout" "$case_dir/stderr" >&2
+    fail "$mode failed for an unrelated reason"
+  fi
+  assert_old_binary "$case_dir"
+  test ! -s "$case_dir/gh.log" || fail "$mode sidecar invoked gh"
+}
+
+assert_invalid_provenance_mode_refuses_before_network() {
+  local value="$1"
+  local label="$2"
+  local case_dir
+  case_dir="$(new_case "invalid-provenance-$label")"
+  if run_installer "$case_dir" ASSAY_REQUIRE_PROVENANCE="$value" > "$case_dir/stdout" 2> "$case_dir/stderr"; then
+    fail "ASSAY_REQUIRE_PROVENANCE=$label unexpectedly installed"
+  fi
+  assert_old_binary "$case_dir"
+  test ! -s "$case_dir/curl.log" || fail "ASSAY_REQUIRE_PROVENANCE=$label reached curl"
+  test ! -s "$case_dir/gh.log" || fail "ASSAY_REQUIRE_PROVENANCE=$label reached gh"
+}
+
+assert_missing_verifier_refuses() {
+  local case_dir
+  case_dir="$(new_case strict-missing-gh)"
+  rm "$case_dir/bin/gh"
+  if run_installer "$case_dir" ASSAY_REQUIRE_PROVENANCE=1 > "$case_dir/stdout" 2> "$case_dir/stderr"; then
+    fail 'strict mode installed without gh'
+  fi
+  assert_old_binary "$case_dir"
+}
+
+assert_strict_success() {
+  local case_dir
+  case_dir="$(new_case strict-success)"
+  run_installer "$case_dir" ASSAY_REQUIRE_PROVENANCE=1 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  grep -F 'checksum_verified' "$case_dir/stdout" >/dev/null || fail 'strict install did not report checksum_verified'
+  grep -F 'provenance_verified' "$case_dir/stdout" >/dev/null || fail 'strict install did not report provenance_verified'
+  if grep -F 'provenance_not_requested' "$case_dir/stdout" >/dev/null; then
+    fail 'strict install reported provenance_not_requested'
+  fi
+
+  local log="$case_dir/gh.log"
+  grep -F 'api repos/Rul1an/assay/git/ref/tags/v5.5.2' "$log" >/dev/null
+  grep -F 'api repos/Rul1an/assay/git/tags/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' "$log" >/dev/null
+  grep -F 'attestation verify' "$log" >/dev/null
+  grep -F -- '--repo Rul1an/assay' "$log" >/dev/null
+  grep -F -- '--signer-workflow Rul1an/assay/.github/workflows/release.yml' "$log" >/dev/null
+  grep -F -- '--cert-oidc-issuer https://token.actions.githubusercontent.com' "$log" >/dev/null
+  grep -F -- '--predicate-type https://slsa.dev/provenance/v1' "$log" >/dev/null
+  grep -F -- '--source-digest bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' "$log" >/dev/null
+  grep -F -- '--deny-self-hosted-runners' "$log" >/dev/null
+}
+
+assert_strict_failure_preserves_binary() {
+  local case_dir
+  case_dir="$(new_case strict-refusal)"
+  if run_installer "$case_dir" ASSAY_REQUIRE_PROVENANCE=1 GH_VERIFY_MODE=fail > "$case_dir/stdout" 2> "$case_dir/stderr"; then
+    fail 'strict mode installed after attestation refusal'
+  fi
+  assert_old_binary "$case_dir"
+  if grep -F 'provenance_verified' "$case_dir/stdout" >/dev/null; then
+    fail 'strict refusal reported provenance_verified'
+  fi
+}
+
+assert_invalid_tag_digest_refuses() {
+  local case_dir
+  case_dir="$(new_case strict-invalid-tag-digest)"
+  if run_installer "$case_dir" ASSAY_REQUIRE_PROVENANCE=1 GH_TAG_MODE=invalid-digest > "$case_dir/stdout" 2> "$case_dir/stderr"; then
+    fail 'strict mode installed with an invalid tag object digest'
+  fi
+  assert_old_binary "$case_dir"
+  if grep -F 'attestation verify' "$case_dir/gh.log" >/dev/null; then
+    fail 'invalid tag object digest reached attestation verification'
+  fi
+}
+
+main() {
+  TEST_TMP="$(mktemp -d)"
+  trap 'rm -rf "$TEST_TMP"' EXIT
+  make_fixture "$TEST_TMP" x86_64-unknown-linux-gnu
+  make_fixture "$TEST_TMP" x86_64-apple-darwin
+
+  assert_default_success Linux linux
+  assert_default_success Darwin macos
+  for mode in mismatch missing-sidecar malformed-sidecar wrong-asset-sidecar; do
+    assert_checksum_failure_preserves_binary "$mode"
+  done
+  assert_invalid_provenance_mode_refuses_before_network 0 zero
+  assert_invalid_provenance_mode_refuses_before_network '' empty
+  assert_invalid_provenance_mode_refuses_before_network yes yes
+  assert_missing_verifier_refuses
+  assert_strict_success
+  assert_strict_failure_preserves_binary
+  assert_invalid_tag_digest_refuses
+  assert_activation_failure_preserves_binary
+
+  echo 'install release verification: PASS'
+}
+
+main "$@"

--- a/scripts/ci/test-install-release-verification.sh
+++ b/scripts/ci/test-install-release-verification.sh
@@ -133,6 +133,10 @@ case "$url" in
         digest="$(cut -d' ' -f1 "$fixture_sidecar")"
         printf '%s  %s\n' "$digest" 'assay-v5.5.2-aarch64-unknown-linux-gnu.tar.gz' > "$out"
         ;;
+      trailing-garbage)
+        cat "$fixture_sidecar" > "$out"
+        printf '%s' 'garbage' >> "$out"
+        ;;
       mismatch)
         printf '%064d  %s\n' 0 "$asset_name" > "$out"
         ;;
@@ -256,10 +260,44 @@ file_mode() {
   fi
 }
 
-assert_exact_gh_argument() {
+assert_exact_gh_invocation() {
   local log="$1"
-  local expected="$2"
-  grep -Fx -- "$expected" "$log" >/dev/null || fail "missing exact gh argument: $expected"
+  shift
+  python3 - "$log" "$@" <<'PY'
+import sys
+from pathlib import Path
+
+lines = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+expected = sys.argv[2:]
+invocations = []
+current = None
+for line in lines:
+    if line == "--- invocation ---":
+        if current is not None:
+            invocations.append(current)
+        current = []
+    elif current is not None:
+        current.append(line)
+if current is not None:
+    invocations.append(current)
+def matches(actual):
+    if len(actual) != len(expected):
+        return False
+    for observed, wanted in zip(actual, expected):
+        if wanted == "<ARCHIVE>":
+            if Path(observed).name != "assay-v5.5.2-x86_64-unknown-linux-gnu.tar.gz":
+                return False
+        elif observed != wanted:
+            return False
+    return True
+
+match_count = sum(matches(invocation) for invocation in invocations)
+if match_count != 1:
+    raise SystemExit(
+        f"expected exactly one gh invocation {expected!r}, found {match_count}; "
+        f"observed={invocations!r}"
+    )
+PY
 }
 
 assert_default_success() {
@@ -341,6 +379,7 @@ assert_checksum_failure_preserves_binary() {
     mismatch) expected_error='Archive checksum mismatch' ;;
     missing-sidecar) expected_error='Download failed' ;;
     malformed-sidecar|wrong-asset-sidecar) expected_error='Checksum sidecar does not name the selected archive' ;;
+    trailing-garbage) expected_error='Checksum sidecar must contain exactly one newline-terminated record' ;;
     *) fail "test bug: no expected error for checksum mode $mode" ;;
   esac
   local case_dir
@@ -389,13 +428,10 @@ assert_strict_success() {
     fail 'strict install reported provenance_not_requested'
   fi
 
-  local log="$case_dir/gh.log"
-  for expected in \
-    api \
-    repos/Rul1an/assay/git/ref/tags/v5.5.2 \
-    repos/Rul1an/assay/git/tags/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  assert_exact_gh_invocation "$case_dir/gh.log" \
     attestation \
     verify \
+    '<ARCHIVE>' \
     --repo \
     Rul1an/assay \
     --signer-workflow \
@@ -407,9 +443,6 @@ assert_strict_success() {
     --source-digest \
     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
     --deny-self-hosted-runners
-  do
-    assert_exact_gh_argument "$log" "$expected"
-  done
 }
 
 assert_strict_failure_preserves_binary() {
@@ -445,7 +478,7 @@ main() {
 
   assert_default_success Linux linux
   assert_default_success Darwin macos
-  for mode in mismatch missing-sidecar malformed-sidecar wrong-asset-sidecar; do
+  for mode in mismatch missing-sidecar malformed-sidecar wrong-asset-sidecar trailing-garbage; do
     assert_checksum_failure_preserves_binary "$mode"
   done
   assert_invalid_provenance_mode_refuses_before_network 0 zero

--- a/scripts/ci/test-install-release-verification.sh
+++ b/scripts/ci/test-install-release-verification.sh
@@ -141,6 +141,10 @@ case "$url" in
     ;;
   *.tar.gz)
     cp "$FIXTURE_DIR/$(basename "$url")" "$out"
+    if [ "${CURL_MODE:-ok}" = block-after-archive ]; then
+      : > "$SIGNAL_MARKER"
+      sleep 2
+    fi
     ;;
   *)
     echo "unexpected curl URL: $url" >&2
@@ -269,6 +273,38 @@ assert_activation_failure_preserves_binary() {
   fi
 }
 
+assert_signal_stops_before_next_network_step() {
+  local case_dir marker pid rc=0
+  case_dir="$(new_case signal-term)"
+  marker="$case_dir/archive-downloaded"
+
+  env \
+    HOME="$case_dir/home" \
+    PATH="$case_dir/bin:/usr/bin:/bin" \
+    ASSAY_VERSION=5.5.2 \
+    ASSAY_INSTALL_DIR="$case_dir/install" \
+    FIXTURE_DIR="$TEST_TMP" \
+    CURL_LOG="$case_dir/curl.log" \
+    GH_LOG="$case_dir/gh.log" \
+    CURL_MODE=block-after-archive \
+    SIGNAL_MARKER="$marker" \
+    sh "$INSTALLER" > "$case_dir/stdout" 2> "$case_dir/stderr" &
+  pid=$!
+
+  for _ in $(seq 1 100); do
+    test -f "$marker" && break
+    sleep 0.02
+  done
+  test -f "$marker" || fail 'signal test did not reach the bounded archive-download witness'
+
+  kill -TERM "$pid"
+  wait "$pid" || rc=$?
+  test "$rc" -ne 0 || fail 'TERM allowed the installer to report success'
+  assert_old_binary "$case_dir"
+  test "$(wc -l < "$case_dir/curl.log" | tr -d ' ')" -eq 1 || \
+    fail 'TERM allowed the installer to continue to another network step'
+}
+
 assert_checksum_failure_preserves_binary() {
   local mode="$1"
   local expected_error
@@ -379,6 +415,7 @@ main() {
   assert_strict_success
   assert_strict_failure_preserves_binary
   assert_invalid_tag_digest_refuses
+  assert_signal_stops_before_next_network_step
   assert_activation_failure_preserves_binary
 
   echo 'install release verification: PASS'

--- a/scripts/ci/test-install-release-verification.sh
+++ b/scripts/ci/test-install-release-verification.sh
@@ -249,6 +249,12 @@ make_chmod_stub() {
 if [ "${CHMOD_MODE:-ok}" = fail ]; then
   exit 1
 fi
+if [ "${CHMOD_MODE:-ok}" = block-after-directory-change ]; then
+  : > "$SIGNAL_MARKER"
+  while :; do
+    sleep 1
+  done
+fi
 exec /bin/chmod "$@"
 EOF
   chmod +x "$bin_dir/chmod"
@@ -404,6 +410,21 @@ assert_relative_install_dir_resolves_from_invocation_directory() {
     fail 'relative ASSAY_INSTALL_DIR did not resolve from the invocation directory'
 }
 
+assert_relative_tmpdir_cleans_after_success() {
+  local case_dir
+  case_dir="$(new_case relative-tmpdir-success)"
+  mkdir -p "$case_dir/relative-tmp"
+  (
+    cd "$case_dir"
+    run_installer "$case_dir" TMPDIR=relative-tmp > "$case_dir/stdout" 2> "$case_dir/stderr"
+  )
+  grep -F 'assay 5.5.2 fixture' "$case_dir/install/assay" >/dev/null || \
+    fail 'relative TMPDIR install did not activate fixture'
+  if find "$case_dir/relative-tmp" -mindepth 1 -print -quit | grep -q .; then
+    fail 'successful install left scratch under relative TMPDIR'
+  fi
+}
+
 assert_activation_failure_preserves_binary() {
   local case_dir
   case_dir="$(new_case activation-failure)"
@@ -420,9 +441,26 @@ assert_signal_stops_before_next_network_step() {
   local signal="$1"
   local expected_rc="$2"
   local label="$3"
-  local case_dir marker rc
+  local tmp_mode="${4:-absolute}"
+  local signal_stage="${5:-download}"
+  local case_dir marker rc tmpdir_value tmpdir_path curl_mode chmod_mode expected_requests
   case_dir="$(new_case "signal-$label")"
   marker="$case_dir/archive-downloaded"
+  tmpdir_value="$case_dir/tmp"
+  tmpdir_path="$case_dir/tmp"
+  if [ "$tmp_mode" = relative ]; then
+    tmpdir_value=relative-tmp
+    tmpdir_path="$case_dir/relative-tmp"
+    mkdir -p "$tmpdir_path"
+  fi
+  curl_mode=block-after-archive
+  chmod_mode=ok
+  expected_requests=1
+  if [ "$signal_stage" = after-directory-change ]; then
+    curl_mode=ok
+    chmod_mode=block-after-directory-change
+    expected_requests=2
+  fi
 
   env \
     HOME="$case_dir/home" \
@@ -433,10 +471,11 @@ assert_signal_stops_before_next_network_step() {
     CURL_LOG="$case_dir/curl.log" \
     CURL_LIMIT_LOG="$case_dir/curl-limit.log" \
     GH_LOG="$case_dir/gh.log" \
-    CURL_MODE=block-after-archive \
+    CURL_MODE="$curl_mode" \
+    CHMOD_MODE="$chmod_mode" \
     SIGNAL_MARKER="$marker" \
-    TMPDIR="$case_dir/tmp" \
-    python3 - "$INSTALLER" "$marker" "$case_dir/stdout" "$case_dir/stderr" "$case_dir/rc" "$signal" <<'PY'
+    TMPDIR="$tmpdir_value" \
+    python3 - "$INSTALLER" "$marker" "$case_dir/stdout" "$case_dir/stderr" "$case_dir/rc" "$signal" "$case_dir" "$signal_stage" <<'PY'
 import os
 import signal
 import subprocess
@@ -444,9 +483,17 @@ import sys
 import time
 from pathlib import Path
 
-installer, marker, stdout_path, stderr_path, rc_path, signal_name = sys.argv[1:]
+installer, marker, stdout_path, stderr_path, rc_path, signal_name, cwd, stage = sys.argv[1:]
+signal_group = stage == "after-directory-change"
 with open(stdout_path, "wb") as stdout, open(stderr_path, "wb") as stderr:
-    proc = subprocess.Popen(["sh", installer], stdout=stdout, stderr=stderr, env=os.environ.copy())
+    proc = subprocess.Popen(
+        ["sh", installer],
+        stdout=stdout,
+        stderr=stderr,
+        env=os.environ.copy(),
+        cwd=cwd,
+        start_new_session=signal_group,
+    )
     for _ in range(100):
         if Path(marker).is_file():
             break
@@ -455,17 +502,21 @@ with open(stdout_path, "wb") as stdout, open(stderr_path, "wb") as stderr:
         proc.kill()
         proc.wait()
         raise SystemExit("signal test did not reach the bounded archive-download witness")
-    os.kill(proc.pid, getattr(signal, f"SIG{signal_name}"))
+    signal_number = getattr(signal, f"SIG{signal_name}")
+    if signal_group:
+        os.killpg(proc.pid, signal_number)
+    else:
+        os.kill(proc.pid, signal_number)
     rc = proc.wait(timeout=10)
 Path(rc_path).write_text(f"{rc}\n", encoding="utf-8")
 PY
   rc="$(cat "$case_dir/rc")"
   test "$rc" -eq "$expected_rc" || fail "$signal exited $rc, expected $expected_rc"
   assert_old_binary "$case_dir"
-  test "$(wc -l < "$case_dir/curl.log" | tr -d ' ')" -eq 1 || \
+  test "$(wc -l < "$case_dir/curl.log" | tr -d ' ')" -eq "$expected_requests" || \
     fail "$signal allowed the installer to continue to another network step"
-  if find "$case_dir/tmp" -mindepth 1 -print -quit | grep -q .; then
-    fail "$signal left installer scratch residue"
+  if find "$tmpdir_path" -mindepth 1 -print -quit | grep -q .; then
+    fail "$signal left installer scratch residue ($tmp_mode TMPDIR, $signal_stage stage)"
   fi
 }
 
@@ -590,8 +641,11 @@ main() {
   assert_signal_stops_before_next_network_step HUP 129 hup
   assert_signal_stops_before_next_network_step INT 130 int
   assert_signal_stops_before_next_network_step TERM 143 term
+  assert_signal_stops_before_next_network_step \
+    TERM 143 term-relative relative after-directory-change
   assert_activation_failure_preserves_binary
   assert_relative_install_dir_resolves_from_invocation_directory
+  assert_relative_tmpdir_cleans_after_success
 
   echo 'install release verification: PASS'
 }

--- a/scripts/ci/test-install-release-verification.sh
+++ b/scripts/ci/test-install-release-verification.sh
@@ -19,6 +19,46 @@ compute_sha256() {
   fi
 }
 
+assert_precommit_wiring() {
+  python3 - "$ROOT/.pre-commit-config.yaml" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+hook_id = "install-release-verification-self-test"
+matches = list(re.finditer(rf"^\s*- id: {re.escape(hook_id)}\s*$", text, re.MULTILINE))
+if len(matches) != 1:
+    raise SystemExit(f"expected exactly one {hook_id} hook, found {len(matches)}")
+
+start = matches[0].start()
+next_hook = re.search(r"^\s*- id: ", text[matches[0].end():], re.MULTILINE)
+end = matches[0].end() + next_hook.start() if next_hook else len(text)
+block = text[start:end]
+
+expected_entry = "entry: bash scripts/ci/test-install-release-verification.sh"
+if expected_entry not in block:
+    raise SystemExit(f"{hook_id} does not invoke the contract test")
+if not re.search(r"^\s*pass_filenames:\s*false\s*$", block, re.MULTILINE):
+    raise SystemExit(f"{hook_id} must set pass_filenames: false")
+
+files_match = re.search(r"^\s*files:\s*(.+?)\s*$", block, re.MULTILINE)
+if files_match is None:
+    raise SystemExit(f"{hook_id} has no files selector")
+selector = re.compile(files_match.group(1))
+required = (
+    "scripts/install.sh",
+    "scripts/ci/test-install-release-verification.sh",
+    "README.md",
+    ".pre-commit-config.yaml",
+)
+missed = [candidate for candidate in required if selector.fullmatch(candidate) is None]
+if missed:
+    raise SystemExit(f"{hook_id} files selector misses: {', '.join(missed)}")
+PY
+}
+
 make_fixture() {
   local root="$1"
   local target="$2"
@@ -321,6 +361,7 @@ assert_invalid_tag_digest_refuses() {
 }
 
 main() {
+  assert_precommit_wiring
   TEST_TMP="$(mktemp -d)"
   trap 'rm -rf "$TEST_TMP"' EXIT
   make_fixture "$TEST_TMP" x86_64-unknown-linux-gnu

--- a/scripts/ci/test-release-attestation-enforce.sh
+++ b/scripts/ci/test-release-attestation-enforce.sh
@@ -156,7 +156,7 @@ for line in lines:
         current.append(line)
 if current is not None:
     invocations.append(current)
-if invocations.count(expected) != 1:
+if invocations != [expected]:
     raise SystemExit(
         f"expected exactly one gh invocation {expected!r}, found {invocations.count(expected)}; "
         f"observed={invocations!r}"
@@ -206,6 +206,32 @@ run_success_case() {
     --deny-self-hosted-runners \
     --format json \
     --source-ref refs/tags/v9.9.9
+
+  local extra_log="$temp_dir/gh-success-extra.log"
+  cp "$log" "$extra_log"
+  cat >> "$extra_log" <<'EOF'
+--- invocation ---
+attestation
+verify
+/tmp/evil.tar.gz
+--repo
+evil/repo
+--signer-workflow
+evil/workflow
+EOF
+  if assert_exact_gh_invocation "$extra_log" \
+    attestation verify "$assets_dir/test-asset.tar.gz" \
+    --repo Rul1an/assay \
+    --signer-workflow Rul1an/assay/.github/workflows/release.yml \
+    --cert-oidc-issuer https://token.actions.githubusercontent.com \
+    --predicate-type https://slsa.dev/provenance/v1 \
+    --source-digest abc123 \
+    --deny-self-hosted-runners \
+    --format json \
+    --source-ref refs/tags/v9.9.9 >/dev/null 2>&1; then
+    echo 'exact release gh invocation guard accepted an additional attestation call' >&2
+    exit 1
+  fi
 }
 
 run_retry_success_case() {

--- a/scripts/ci/test-release-attestation-enforce.sh
+++ b/scripts/ci/test-release-attestation-enforce.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-SCRIPT="$ROOT/scripts/ci/release_attestation_enforce.sh"
+SCRIPT="${SCRIPT:-$ROOT/scripts/ci/release_attestation_enforce.sh}"
 TEST_TEMP_DIR=""
 
 compute_sha256() {
@@ -166,7 +166,10 @@ run_success_case() {
   jq -e '.assets[0].verified_timestamp_count == 1' "$summary" >/dev/null
   test -f "$raw_dir/test-asset.tar.gz.attestation.json"
   grep -F -- '--source-digest abc123' "$log" >/dev/null
+  grep -F -- '--repo Rul1an/assay' "$log" >/dev/null
   grep -F -- '--signer-workflow Rul1an/assay/.github/workflows/release.yml' "$log" >/dev/null
+  grep -F -- '--cert-oidc-issuer https://token.actions.githubusercontent.com' "$log" >/dev/null
+  grep -F -- '--predicate-type https://slsa.dev/provenance/v1' "$log" >/dev/null
   grep -F -- '--source-ref refs/tags/v9.9.9' "$log" >/dev/null
   grep -F -- '--deny-self-hosted-runners' "$log" >/dev/null
 }

--- a/scripts/ci/test-release-attestation-enforce.sh
+++ b/scripts/ci/test-release-attestation-enforce.sh
@@ -20,7 +20,10 @@ make_fake_gh() {
 #!/usr/bin/env bash
 set -euo pipefail
 
-printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+{
+  printf '%s\n' '--- invocation ---'
+  printf '%s\n' "$@"
+} >> "$FAKE_GH_LOG"
 
 if [ "$#" -lt 3 ] || [ "$1" != "attestation" ] || [ "$2" != "verify" ]; then
   echo "unexpected gh invocation: $*" >&2
@@ -133,6 +136,34 @@ write_empty_verification_json() {
 EOF
 }
 
+assert_exact_gh_invocation() {
+  local log="$1"
+  shift
+  python3 - "$log" "$@" <<'PY'
+import sys
+from pathlib import Path
+
+lines = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+expected = sys.argv[2:]
+invocations = []
+current = None
+for line in lines:
+    if line == "--- invocation ---":
+        if current is not None:
+            invocations.append(current)
+        current = []
+    elif current is not None:
+        current.append(line)
+if current is not None:
+    invocations.append(current)
+if invocations.count(expected) != 1:
+    raise SystemExit(
+        f"expected exactly one gh invocation {expected!r}, found {invocations.count(expected)}; "
+        f"observed={invocations!r}"
+    )
+PY
+}
+
 run_success_case() {
   local temp_dir="$1"
   local assets_dir="$temp_dir/assets-success"
@@ -165,13 +196,16 @@ run_success_case() {
   jq -e --arg digest "$digest" '.assets[0].sha256 == $digest' "$summary" >/dev/null
   jq -e '.assets[0].verified_timestamp_count == 1' "$summary" >/dev/null
   test -f "$raw_dir/test-asset.tar.gz.attestation.json"
-  grep -F -- '--source-digest abc123' "$log" >/dev/null
-  grep -F -- '--repo Rul1an/assay' "$log" >/dev/null
-  grep -F -- '--signer-workflow Rul1an/assay/.github/workflows/release.yml' "$log" >/dev/null
-  grep -F -- '--cert-oidc-issuer https://token.actions.githubusercontent.com' "$log" >/dev/null
-  grep -F -- '--predicate-type https://slsa.dev/provenance/v1' "$log" >/dev/null
-  grep -F -- '--source-ref refs/tags/v9.9.9' "$log" >/dev/null
-  grep -F -- '--deny-self-hosted-runners' "$log" >/dev/null
+  assert_exact_gh_invocation "$log" \
+    attestation verify "$assets_dir/test-asset.tar.gz" \
+    --repo Rul1an/assay \
+    --signer-workflow Rul1an/assay/.github/workflows/release.yml \
+    --cert-oidc-issuer https://token.actions.githubusercontent.com \
+    --predicate-type https://slsa.dev/provenance/v1 \
+    --source-digest abc123 \
+    --deny-self-hosted-runners \
+    --format json \
+    --source-ref refs/tags/v9.9.9
 }
 
 run_retry_success_case() {
@@ -240,11 +274,15 @@ run_digest_only_success_case() {
   bash "$SCRIPT"
 
   jq -e '.verification_policy.source_ref == null' "$summary" >/dev/null
-  grep -F -- '--source-digest abc123' "$log" >/dev/null
-  if grep -F -- '--source-ref' "$log" >/dev/null; then
-    echo "digest-only verification unexpectedly passed --source-ref" >&2
-    exit 1
-  fi
+  assert_exact_gh_invocation "$log" \
+    attestation verify "$assets_dir/test-asset.tar.gz" \
+    --repo Rul1an/assay \
+    --signer-workflow Rul1an/assay/.github/workflows/release.yml \
+    --cert-oidc-issuer https://token.actions.githubusercontent.com \
+    --predicate-type https://slsa.dev/provenance/v1 \
+    --source-digest abc123 \
+    --deny-self-hosted-runners \
+    --format json
 }
 
 run_missing_witness_case() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -100,7 +100,11 @@ compute_sha256() {
 download_file() {
     _download_url="$1"
     _download_path="$2"
-    if ! _http_code=$(curl -fsSL -w "%{http_code}" -o "$_download_path" "$_download_url"); then
+    _download_limit="${3:-}"
+    if [ -n "$_download_limit" ]; then
+        _http_code=$(curl -fsSL --max-filesize "$_download_limit" -w "%{http_code}" -o "$_download_path" "$_download_url") || \
+            log_error "Download failed. URL: $_download_url"
+    elif ! _http_code=$(curl -fsSL -w "%{http_code}" -o "$_download_path" "$_download_url"); then
         log_error "Download failed. URL: $_download_url"
     fi
     if [ "$_http_code" != "200" ]; then
@@ -113,6 +117,11 @@ verify_archive_checksum() {
     _sidecar_path="$2"
     _archive_name="$3"
 
+    _expected_record_bytes=$((64 + 2 + ${#_archive_name} + 1))
+    _sidecar_bytes=$(wc -c < "$_sidecar_path" | tr -d '[:space:]')
+    if [ "$_sidecar_bytes" != "$_expected_record_bytes" ]; then
+        log_error "Checksum sidecar must contain exactly one newline-terminated record."
+    fi
     _line_count=$(wc -l < "$_sidecar_path" | tr -d '[:space:]')
     if [ "$_line_count" != "1" ]; then
         log_error "Checksum sidecar must contain exactly one newline-terminated record."
@@ -120,7 +129,6 @@ verify_archive_checksum() {
     if ! IFS= read -r _checksum_line < "$_sidecar_path"; then
         log_error "Checksum sidecar is empty."
     fi
-    _sidecar_bytes=$(wc -c < "$_sidecar_path" | tr -d '[:space:]')
     _record_bytes=$(printf '%s\n' "$_checksum_line" | wc -c | tr -d '[:space:]')
     if [ "$_sidecar_bytes" != "$_record_bytes" ]; then
         log_error "Checksum sidecar must contain exactly one newline-terminated record."
@@ -284,7 +292,8 @@ main() {
     CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
 
     # 4. Download
-    TMP_DIR=$(mktemp -d)
+    TMP_ROOT="${TMPDIR:-/tmp}"
+    TMP_DIR=$(mktemp -d "${TMP_ROOT%/}/assay-install.XXXXXX")
     INSTALL_CANDIDATE=""
     cleanup_install() {
         rm -rf "$TMP_DIR"
@@ -300,7 +309,8 @@ main() {
     log_info "Downloading from $DOWNLOAD_URL ..."
     if command -v curl >/dev/null 2>&1; then
         download_file "$DOWNLOAD_URL" "$TMP_DIR/$ARCHIVE_NAME"
-        download_file "$CHECKSUM_URL" "$TMP_DIR/${ARCHIVE_NAME}.sha256"
+        CHECKSUM_MAX_BYTES=$((64 + 2 + ${#ARCHIVE_NAME} + 1))
+        download_file "$CHECKSUM_URL" "$TMP_DIR/${ARCHIVE_NAME}.sha256" "$CHECKSUM_MAX_BYTES"
     else
         log_error "curl is required but not found."
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -277,7 +277,16 @@ main() {
     # 4. Download
     TMP_DIR=$(mktemp -d)
     INSTALL_CANDIDATE=""
-    trap 'rm -rf "$TMP_DIR"; if [ -n "$INSTALL_CANDIDATE" ]; then rm -f "$INSTALL_CANDIDATE"; fi' EXIT HUP INT TERM
+    cleanup_install() {
+        rm -rf "$TMP_DIR"
+        if [ -n "$INSTALL_CANDIDATE" ]; then
+            rm -f "$INSTALL_CANDIDATE"
+        fi
+    }
+    trap cleanup_install EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
 
     log_info "Downloading from $DOWNLOAD_URL ..."
     if command -v curl >/dev/null 2>&1; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,10 @@ set -e
 GITHUB_REPO="Rul1an/assay"
 
 INSTALL_DIR="${ASSAY_INSTALL_DIR:-$HOME/.local/bin}"
+case "$INSTALL_DIR" in
+    /*) ;;
+    *) INSTALL_DIR="$(pwd)/$INSTALL_DIR" ;;
+esac
 # Unset defaults to latest. An explicitly empty value is malformed and must
 # not be rewritten to latest (that would hit the network).
 if [ -z "${ASSAY_VERSION+x}" ]; then
@@ -26,8 +30,8 @@ else
     VERSION="$ASSAY_VERSION"
 fi
 
-# Provenance verification is opt-in because it requires the GitHub CLI and
-# network access to the attestation service. Any explicitly set value other
+# Provenance verification is opt-in because it requires authenticated GitHub CLI
+# access (an authenticated session or GH_TOKEN) and the attestation service. Any explicitly set value other
 # than 1 is malformed; it must not silently become checksum-only mode.
 if [ -z "${ASSAY_REQUIRE_PROVENANCE+x}" ]; then
     REQUIRE_PROVENANCE=0
@@ -348,7 +352,7 @@ main() {
         fi
         INSTALL_CANDIDATE=$(mktemp "$INSTALL_DIR/.assay.install.XXXXXX")
         cp "$EXTRACTED_BINARY" "$INSTALL_CANDIDATE"
-        chmod +x "$INSTALL_CANDIDATE"
+        chmod 755 "$INSTALL_CANDIDATE"
         mv -f "$INSTALL_CANDIDATE" "$INSTALL_DIR/assay"
         INSTALL_CANDIDATE=""
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -120,6 +120,11 @@ verify_archive_checksum() {
     if ! IFS= read -r _checksum_line < "$_sidecar_path"; then
         log_error "Checksum sidecar is empty."
     fi
+    _sidecar_bytes=$(wc -c < "$_sidecar_path" | tr -d '[:space:]')
+    _record_bytes=$(printf '%s\n' "$_checksum_line" | wc -c | tr -d '[:space:]')
+    if [ "$_sidecar_bytes" != "$_record_bytes" ]; then
+        log_error "Checksum sidecar must contain exactly one newline-terminated record."
+    fi
 
     _checksum_suffix="  $_archive_name"
     case "$_checksum_line" in

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,11 +16,17 @@ set -e
 
 # --- Configuration ---
 GITHUB_REPO="Rul1an/assay"
+INVOCATION_DIR=$(pwd)
 
 INSTALL_DIR="${ASSAY_INSTALL_DIR:-$HOME/.local/bin}"
 case "$INSTALL_DIR" in
     /*) ;;
-    *) INSTALL_DIR="$(pwd)/$INSTALL_DIR" ;;
+    *) INSTALL_DIR="$INVOCATION_DIR/$INSTALL_DIR" ;;
+esac
+TMP_ROOT="${TMPDIR:-/tmp}"
+case "$TMP_ROOT" in
+    /*) ;;
+    *) TMP_ROOT="$INVOCATION_DIR/$TMP_ROOT" ;;
 esac
 # Unset defaults to latest. An explicitly empty value is malformed and must
 # not be rewritten to latest (that would hit the network).
@@ -292,7 +298,6 @@ main() {
     CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
 
     # 4. Download
-    TMP_ROOT="${TMPDIR:-/tmp}"
     TMP_DIR=$(mktemp -d "${TMP_ROOT%/}/assay-install.XXXXXX")
     INSTALL_CANDIDATE=""
     cleanup_install() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,6 +26,18 @@ else
     VERSION="$ASSAY_VERSION"
 fi
 
+# Provenance verification is opt-in because it requires the GitHub CLI and
+# network access to the attestation service. Any explicitly set value other
+# than 1 is malformed; it must not silently become checksum-only mode.
+if [ -z "${ASSAY_REQUIRE_PROVENANCE+x}" ]; then
+    REQUIRE_PROVENANCE=0
+elif [ "$ASSAY_REQUIRE_PROVENANCE" = "1" ]; then
+    REQUIRE_PROVENANCE=1
+else
+    printf '%s\n' "ASSAY_REQUIRE_PROVENANCE must be unset or exactly 1" >&2
+    exit 1
+fi
+
 # --- Colors ---
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -69,6 +81,122 @@ normalize_install_version() {
         return 1
     fi
     printf '%s\n' "$_candidate"
+}
+
+compute_sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        log_error "sha256sum or shasum is required but not found."
+    fi
+}
+
+download_file() {
+    _download_url="$1"
+    _download_path="$2"
+    if ! _http_code=$(curl -fsSL -w "%{http_code}" -o "$_download_path" "$_download_url"); then
+        log_error "Download failed. URL: $_download_url"
+    fi
+    if [ "$_http_code" != "200" ]; then
+        log_error "Download failed (HTTP $_http_code). URL: $_download_url"
+    fi
+}
+
+verify_archive_checksum() {
+    _archive_path="$1"
+    _sidecar_path="$2"
+    _archive_name="$3"
+
+    _line_count=$(wc -l < "$_sidecar_path" | tr -d '[:space:]')
+    if [ "$_line_count" != "1" ]; then
+        log_error "Checksum sidecar must contain exactly one newline-terminated record."
+    fi
+    if ! IFS= read -r _checksum_line < "$_sidecar_path"; then
+        log_error "Checksum sidecar is empty."
+    fi
+
+    _checksum_suffix="  $_archive_name"
+    case "$_checksum_line" in
+        *"$_checksum_suffix")
+            _expected_sha256=${_checksum_line%"$_checksum_suffix"}
+            ;;
+        *)
+            log_error "Checksum sidecar does not name the selected archive."
+            ;;
+    esac
+    if [ "${#_expected_sha256}" -ne 64 ]; then
+        log_error "Checksum sidecar does not contain a 64-character SHA-256 digest."
+    fi
+    case "$_expected_sha256" in
+        *[!0-9a-f]*)
+            log_error "Checksum sidecar SHA-256 must be lowercase hexadecimal."
+            ;;
+    esac
+
+    _actual_sha256=$(compute_sha256 "$_archive_path")
+    if [ "$_actual_sha256" != "$_expected_sha256" ]; then
+        log_error "Archive checksum mismatch for $_archive_name."
+    fi
+    log_success "verification=checksum_verified asset=$_archive_name sha256=$_actual_sha256"
+}
+
+resolve_release_commit() {
+    if ! _tag_object=$(gh api "repos/$GITHUB_REPO/git/ref/tags/$VERSION" --jq '.object.type + " " + .object.sha'); then
+        log_error "Failed to resolve the release tag object for provenance verification."
+    fi
+
+    _peel_count=0
+    while :; do
+        _old_ifs=$IFS
+        IFS=' '
+        # The gh query emits exactly two whitespace-free fields.
+        # shellcheck disable=SC2086
+        set -- $_tag_object
+        IFS=$_old_ifs
+        if [ "$#" -ne 2 ]; then
+            log_error "Release tag lookup returned an unexpected shape."
+        fi
+        _object_type="$1"
+        _object_sha="$2"
+
+        if [ "${#_object_sha}" -ne 40 ]; then
+            log_error "Release tag lookup returned an invalid object digest."
+        fi
+        case "$_object_sha" in
+            *[!0-9a-f]*)
+                log_error "Release tag lookup returned an invalid object digest."
+                ;;
+        esac
+
+        if [ "$_object_type" = "commit" ]; then
+            printf '%s\n' "$_object_sha"
+            return 0
+        fi
+        if [ "$_object_type" != "tag" ] || [ "$_peel_count" -ge 4 ]; then
+            log_error "Release tag did not resolve to a bounded commit object."
+        fi
+        if ! _tag_object=$(gh api "repos/$GITHUB_REPO/git/tags/$_object_sha" --jq '.object.type + " " + .object.sha'); then
+            log_error "Failed to peel the release tag for provenance verification."
+        fi
+        _peel_count=$((_peel_count + 1))
+    done
+}
+
+verify_archive_provenance() {
+    _archive_path="$1"
+    _source_digest=$(resolve_release_commit)
+    if ! gh attestation verify "$_archive_path" \
+        --repo "$GITHUB_REPO" \
+        --signer-workflow "$GITHUB_REPO/.github/workflows/release.yml" \
+        --cert-oidc-issuer "https://token.actions.githubusercontent.com" \
+        --predicate-type "https://slsa.dev/provenance/v1" \
+        --source-digest "$_source_digest" \
+        --deny-self-hosted-runners >/dev/null; then
+        log_error "Release provenance verification failed."
+    fi
+    log_success "verification=provenance_verified asset=$ARCHIVE_NAME source_digest=$_source_digest"
 }
 
 # --- Main ---
@@ -132,7 +260,11 @@ main() {
 
     log_info "Target version: $VERSION"
 
-    # 3. Construct Download URL
+    if [ "$REQUIRE_PROVENANCE" -eq 1 ] && ! command -v gh >/dev/null 2>&1; then
+        log_error "gh is required when ASSAY_REQUIRE_PROVENANCE=1."
+    fi
+
+    # 3. Construct Download URLs from the selected asset once.
     if [ "$OS" = "windows" ]; then
         ARCHIVE_NAME="assay-${VERSION}-${TARGET}.zip"
     else
@@ -140,20 +272,30 @@ main() {
     fi
 
     DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/$VERSION/$ARCHIVE_NAME"
+    CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
 
     # 4. Download
     TMP_DIR=$(mktemp -d)
-    trap 'rm -rf "$TMP_DIR"' EXIT
+    INSTALL_CANDIDATE=""
+    trap 'rm -rf "$TMP_DIR"; if [ -n "$INSTALL_CANDIDATE" ]; then rm -f "$INSTALL_CANDIDATE"; fi' EXIT HUP INT TERM
 
     log_info "Downloading from $DOWNLOAD_URL ..."
-    # Check if curl supports -w
     if command -v curl >/dev/null 2>&1; then
-        HTTP_CODE=$(curl -fsSL -w "%{http_code}" -o "$TMP_DIR/$ARCHIVE_NAME" "$DOWNLOAD_URL")
-        if [ "$HTTP_CODE" != "200" ]; then
-            log_error "Download failed (HTTP $HTTP_CODE). URL: $DOWNLOAD_URL"
-        fi
+        download_file "$DOWNLOAD_URL" "$TMP_DIR/$ARCHIVE_NAME"
+        download_file "$CHECKSUM_URL" "$TMP_DIR/${ARCHIVE_NAME}.sha256"
     else
         log_error "curl is required but not found."
+    fi
+
+    verify_archive_checksum \
+        "$TMP_DIR/$ARCHIVE_NAME" \
+        "$TMP_DIR/${ARCHIVE_NAME}.sha256" \
+        "$ARCHIVE_NAME"
+
+    if [ "$REQUIRE_PROVENANCE" -eq 1 ]; then
+        verify_archive_provenance "$TMP_DIR/$ARCHIVE_NAME"
+    else
+        log_info "verification=provenance_not_requested"
     fi
 
     # 5. Extract
@@ -176,23 +318,30 @@ main() {
     fi
 
     if [ "$OS" = "windows" ]; then
-        # Check if extracted dir structure is correct, fallback to look for binary
         if [ -f "$EXTRACTED_DIR/assay.exe" ]; then
-             mv "$EXTRACTED_DIR/assay.exe" "$INSTALL_DIR/assay.exe"
+             EXTRACTED_BINARY="$EXTRACTED_DIR/assay.exe"
         elif [ -f "assay.exe" ]; then
-             mv "assay.exe" "$INSTALL_DIR/assay.exe"
+             EXTRACTED_BINARY="assay.exe"
         else
              log_error "Could not find assay.exe after extraction"
         fi
+        INSTALL_CANDIDATE=$(mktemp "$INSTALL_DIR/.assay.exe.install.XXXXXX")
+        cp "$EXTRACTED_BINARY" "$INSTALL_CANDIDATE"
+        mv -f "$INSTALL_CANDIDATE" "$INSTALL_DIR/assay.exe"
+        INSTALL_CANDIDATE=""
     else
         if [ -f "$EXTRACTED_DIR/assay" ]; then
-             mv "$EXTRACTED_DIR/assay" "$INSTALL_DIR/assay"
+             EXTRACTED_BINARY="$EXTRACTED_DIR/assay"
         elif [ -f "assay" ]; then
-             mv "assay" "$INSTALL_DIR/assay"
+             EXTRACTED_BINARY="assay"
         else
              log_error "Could not find assay binary after extraction"
         fi
-        chmod +x "$INSTALL_DIR/assay"
+        INSTALL_CANDIDATE=$(mktemp "$INSTALL_DIR/.assay.install.XXXXXX")
+        cp "$EXTRACTED_BINARY" "$INSTALL_CANDIDATE"
+        chmod +x "$INSTALL_CANDIDATE"
+        mv -f "$INSTALL_CANDIDATE" "$INSTALL_DIR/assay"
+        INSTALL_CANDIDATE=""
     fi
 
     printf "\n"


### PR DESCRIPTION
Advances #2749. Final closure remains gated on Rul1an/getassay-site#6 deploying and measuring these exact installer bytes, followed by a separate outward-truth change that publishes the strict quickstart.

## Contract

- verifies the exact selected release archive against its published SHA-256 sidecar before extraction;
- exposes only the closed opt-in `ASSAY_REQUIRE_PROVENANCE=1` for strict GitHub attestation verification;
- binds strict verification to repository, release workflow, GitHub Actions OIDC issuer, SLSA v1 predicate, peeled release commit, and hosted-runner provenance;
- prepares the binary in the destination directory and activates it with one rename, preserving an existing install on every preceding failure;
- resolves relative `ASSAY_INSTALL_DIR` and `TMPDIR` values against the invocation directory before entering installer scratch space;
- installs POSIX binaries with exact mode `0755`;
- reports `checksum_verified`, `provenance_verified`, or `provenance_not_requested` without conflating them.

## RED to GREEN

Focused contracts on `dc0043311b12d5fca2d1cc8be4d5c8e333c8acd3`:

- `bash scripts/ci/test-install-release-verification.sh` -> PASS;
- `bash scripts/ci/test-release-attestation-enforce.sh` -> PASS;
- `bash scripts/ci/test-install-version-normalization.sh` -> PASS;
- `shellcheck` on all changed shell surfaces -> PASS;
- pre-commit commit hooks -> PASS;
- pre-push hooks -> PASS;
- `git diff --check` -> clean.

Mutation evidence:

- bypass archive digest comparison -> RED;
- use the wrong attestation repository -> RED;
- extend or duplicate the signer workflow argument with a malicious suffix -> RED on exact ordered invocation matching;
- suffix the release-enforcer signer workflow argument -> RED on exact ordered invocation matching;
- skip sidecar download -> RED;
- append non-newline-terminated bytes after an otherwise valid sidecar record -> RED;
- remove the exact pre-materialization sidecar byte ceiling -> RED;
- add a second nonconforming attestation-verification invocation beside the correct one -> RED in both installer and release-enforcer contracts;
- change HUP, INT, or TERM handling to exit 1 instead of 129, 130, or 143 -> RED independently;
- remove EXIT cleanup -> RED with witnessed installer scratch residue;
- remove relative `TMPDIR` normalization -> RED after a post-`cd` TERM leaves scratch residue;
- move the installer hook outside `repo: local`, replace its entry with a comment decoy/no-op, empty its selector, or move it to manual-only -> RED through an independently invoked YAML consumer;
- overwrite the installed binary before candidate preparation completes -> RED;
- remove the complete pre-commit hook -> RED;
- replace the terminating `TERM` handler with cleanup-only handling -> RED, with a witnessed forbidden second network step;
- remove each of repository, signer workflow, OIDC issuer, predicate type, source digest, or self-hosted-runner denial from the installer's attestation policy -> RED independently.

Review-discovered behavioral regressions were reproduced before repair: the prior candidate installed POSIX binaries as `0711`, and a relative install directory was interpreted after `cd` into scratch and then deleted while reporting success. Both now have behavioral assertions. A later exact-head review also found that relative `TMPDIR` could be reinterpreted after `cd`; successful and post-directory-change TERM cleanup now pin that path.

## Non-claims

- A checksum proves byte equality with the published sidecar, not producer identity.
- Strict verification requires authenticated GitHub CLI access (an authenticated session or `GH_TOKEN`) and proves only the named GitHub attestation bindings, not runtime safety or semantic correctness.
- The installer and release enforcement script still encode neighboring attestation policies separately; this PR does not introduce a shared policy artifact.
- This PR changes source installer bytes only. Rul1an/getassay-site#6 still owns exact-byte deployment and live default/strict smoke against a published release.
- The strict `getassay.dev` quickstart is deliberately withheld until getassay-site#6 deploys and measures the reviewed bytes; merging this source PR does not make the current live URL provenance-aware.
- It does not add a self-update or rollback lifecycle.


