### PR TITLE
docs(installer): publish measured verification truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ python3 examples/mcp-quickstart/run.py
 
 For v5.5.2, run the last command from a source checkout or an extracted published CLI archive.
 The installer is binary-only and does not carry the bounded quickstart assets. The live
-`getassay.dev` installer downloads over HTTPS but does not yet consume the published checksum or
-provenance sidecars. The verified source installer will replace it through the separately measured
-deployment tracked in `Rul1an/getassay-site#6`.
+`getassay.dev` installer verifies the selected archive against its published SHA-256 sidecar before
+extraction. Set `ASSAY_REQUIRE_PROVENANCE=1` to additionally require GitHub artifact provenance;
+the default reports `provenance_not_requested` and strict success reports `provenance_verified`.
+A checksum proves byte equality with the published sidecar, not producer identity. Provenance
+identifies the source and build, not runtime safety or semantic correctness.
 
 Captured runner output (the bundled local mock performs no external action):
 

--- a/scripts/ci/check-release-surface.sh
+++ b/scripts/ci/check-release-surface.sh
@@ -345,6 +345,19 @@ check_rge_bench_claims() {
 check_rust_cli_installs README.md 1
 check_absent_regex README.md 'verified release installer' \
   'installer wording must not imply checksum or provenance verification'
+check_contains_fixed README.md \
+  'verifies the selected archive against its published SHA-256 sidecar' \
+  'live installer verification contract drift'
+check_contains_fixed README.md 'ASSAY_REQUIRE_PROVENANCE=1' \
+  'live installer strict provenance selector drift'
+check_contains_fixed README.md 'provenance_not_requested' \
+  'live installer default verification state drift'
+check_contains_fixed README.md 'provenance_verified' \
+  'live installer strict verification state drift'
+check_contains_fixed README.md 'not producer identity' \
+  'live installer checksum non-claim drift'
+check_contains_fixed README.md 'not runtime safety or semantic correctness' \
+  'live installer provenance non-claim drift'
 check_absent_regex examples/mcp-quickstart/README.md 'verified release installer' \
   'quickstart installer wording must not imply checksum or provenance verification'
 check_contains_fixed examples/mcp-quickstart/README.md \

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -116,6 +116,8 @@ Current release: [`v5.1.0`](https://github.com/Rul1an/assay/releases/tag/v5.1.0)
 - Published v5.1.0 CLI archives cover Linux x86_64/arm64.
 Historical note: v5.0.0 shipped earlier.
 Claude and Cursor config-path only.
+The live installer verifies the selected archive against its published SHA-256 sidecar before extraction. Set `ASSAY_REQUIRE_PROVENANCE=1` to additionally require GitHub artifact provenance; the default reports `provenance_not_requested` and strict success reports `provenance_verified`.
+A checksum proves byte equality with the published sidecar, not producer identity. Provenance identifies the source and build, not runtime safety or semantic correctness.
 DOC
 printf '%s\n' "- [RGE-Bench](https://github.com/rge-bench/rge-bench) — $rge_claim" >> "$TMP/README.md"
 printf '%s\n' "- [RGE-Bench](https://github.com/rge-bench/rge-bench): $rge_claim" > "$TMP/llms.txt"
@@ -314,6 +316,24 @@ mutate_and_expect_failure unsupported-codex-literal README.md \
 mutate_and_expect_failure misleading-installer-verification README.md \
   's/Claude and Cursor config-path only./Claude and Cursor config-path only. Fast path: verified release installer./' \
   'installer wording must not imply checksum or provenance verification'
+mutate_and_expect_failure stale-installer-verification-contract README.md \
+  's/verifies the selected archive against its published SHA-256 sidecar/downloads the selected archive over HTTPS/' \
+  'live installer verification contract drift'
+mutate_and_expect_failure stale-installer-provenance-selector README.md \
+  's/ASSAY_REQUIRE_PROVENANCE=1/ASSAY_PROVENANCE=1/' \
+  'live installer strict provenance selector drift'
+mutate_and_expect_failure stale-installer-default-state README.md \
+  's/provenance_not_requested/provenance_skipped/' \
+  'live installer default verification state drift'
+mutate_and_expect_failure stale-installer-strict-state README.md \
+  's/provenance_verified/provenance_checked/' \
+  'live installer strict verification state drift'
+mutate_and_expect_failure missing-installer-checksum-nonclaim README.md \
+  's/not producer identity/producer identity/' \
+  'live installer checksum non-claim drift'
+mutate_and_expect_failure missing-installer-provenance-nonclaim README.md \
+  's/not runtime safety or semantic correctness/runtime safety/' \
+  'live installer provenance non-claim drift'
 mutate_and_expect_failure misleading-example-installer examples/mcp-quickstart/README.md \
   's/release installer/verified release installer/' \
   'quickstart installer wording must not imply checksum or provenance verification'
@@ -491,8 +511,8 @@ mutate_and_expect_failure stale-codespaces-host demo/CODESPACES-PLAYBOOK.md \
   's#https://getassay.dev/install.sh#https://assay.dev/install.sh#' \
   'unrelated assay.dev onboarding URL'
 
-if [ "$mutation_count" -ne 70 ]; then
-  echo "FAIL: expected 70 release-surface mutations, observed $mutation_count" >&2
+if [ "$mutation_count" -ne 76 ]; then
+  echo "FAIL: expected 76 release-surface mutations, observed $mutation_count" >&2
   exit 1
 fi
 echo "release-surface mutations: $mutation_count observed"


### PR DESCRIPTION
## Summary

- replace the stale README statement that the live installer does not consume checksum/provenance evidence
- state the now-measured default and strict verification semantics
- keep the blanket phrase `verified release installer` forbidden
- make every new outward-truth guard bite through a dedicated mutation

Tracks #2749. Do not infer a new binary release from this docs/guard change.

## Production basis

Measured after getassay-site PR #7 merged:

- Assay installer source: `125b036c5dfe7d81bd611bc148375292ae48a666`
- site commit: `0396b2f2c68cbc7193afa1b92e20dfe67b16d53d`
- hosted live-drift run: `33676418035`, success on the site commit
- live installer SHA-256: `75491d9786c30f89da8e31510d4208215e7ce99e55ab10206c1b054f404aac96`
- default live install: checksum verified, provenance not requested, `assay 5.5.2`
- strict live install: checksum and provenance verified at source digest `d813af0e52f2846d3e5f47a53c042aa169304dc3`, `assay 5.5.2`

## RED -> GREEN

RED before the checker change:

```text
FAIL: mutation stale-installer-verification-contract was not observed
```

GREEN covers the full release-surface suite plus six installer wording mutations:

- checksum contract weakened to HTTPS-only
- strict selector renamed
- default output state renamed
- strict output state renamed
- checksum non-claim removed
- provenance non-claim removed

The existing misleading blanket-claim mutation remains green-to-red as before.

## Non-claims

- checksum equality does not establish producer identity
- provenance does not establish runtime safety or semantic correctness
- the installer remains binary-only and does not carry the bounded quickstart assets
- this PR does not change installer behavior or release artifacts

Final reviewed head: `4fea47076c7edba43225472d322a5d9967c24000`
