### PR TITLE
ci: route runner schema changes through semver checks

### DIFF
--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -38,6 +38,7 @@ jobs:
       assay_common_changed: ${{ steps.detect.outputs.assay_common_changed }}
       assay_policy_changed: ${{ steps.detect.outputs.assay_policy_changed }}
       assay_metrics_changed: ${{ steps.detect.outputs.assay_metrics_changed }}
+      assay_runner_schema_changed: ${{ steps.detect.outputs.assay_runner_schema_changed }}
       unmatched_assay_crate_changed: ${{ steps.detect.outputs.unmatched_assay_crate_changed }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -95,10 +96,11 @@ jobs:
           assay_common_changed="$(flag_from_prefix 'crates/assay-common/')"
           assay_policy_changed="$(flag_from_prefix 'crates/assay-policy/')"
           assay_metrics_changed="$(flag_from_prefix 'crates/assay-metrics/')"
+          assay_runner_schema_changed="$(flag_from_prefix 'crates/assay-runner-schema/')"
           if [[ "${run_all}" == "true" || "${global_changed}" == "true" ]]; then
             unmatched_assay_crate_changed=true
           elif grep -Eq '^crates/assay-[^/]+/' "$changed_file" && \
-               ! grep -Eq '^crates/(assay-core|assay-cli|assay-registry|assay-evidence|assay-common|assay-policy|assay-metrics)/' "$changed_file"; then
+               ! grep -Eq '^crates/(assay-core|assay-cli|assay-registry|assay-evidence|assay-common|assay-policy|assay-metrics|assay-runner-schema)/' "$changed_file"; then
             unmatched_assay_crate_changed=true
           else
             unmatched_assay_crate_changed=false
@@ -110,7 +112,7 @@ jobs:
             hotspot_changed=false
           fi
 
-          if [[ "${global_changed}" == "true" || "${hotspot_changed}" == "true" || "${assay_common_changed}" == "true" || "${assay_policy_changed}" == "true" || "${assay_metrics_changed}" == "true" || "${unmatched_assay_crate_changed}" == "true" ]]; then
+          if [[ "${global_changed}" == "true" || "${hotspot_changed}" == "true" || "${assay_common_changed}" == "true" || "${assay_policy_changed}" == "true" || "${assay_metrics_changed}" == "true" || "${assay_runner_schema_changed}" == "true" || "${unmatched_assay_crate_changed}" == "true" ]]; then
             any_relevant=true
             semver_relevant=true
           else
@@ -132,6 +134,7 @@ jobs:
             echo "assay_common_changed=${assay_common_changed}"
             echo "assay_policy_changed=${assay_policy_changed}"
             echo "assay_metrics_changed=${assay_metrics_changed}"
+            echo "assay_runner_schema_changed=${assay_runner_schema_changed}"
             echo "unmatched_assay_crate_changed=${unmatched_assay_crate_changed}"
           } >> "$GITHUB_OUTPUT"
 
@@ -150,6 +153,7 @@ jobs:
             echo "- hotspot_changed: ${hotspot_changed}"
             echo "- any_relevant: ${any_relevant}"
             echo "- semver_relevant: ${semver_relevant}"
+            echo "- assay_runner_schema_changed: ${assay_runner_schema_changed}"
             echo "- unmatched_assay_crate_changed: ${unmatched_assay_crate_changed}"
             if [[ "${run_all}" == "false" || -n "${simulated}" ]]; then
               echo ""
@@ -161,6 +165,9 @@ jobs:
               fi
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify split-wave semver routing
+        run: bash scripts/ci/test-split-wave0-semver-routing.sh
 
   feature-matrix:
     name: Wave 0 feature matrix
@@ -440,6 +447,7 @@ jobs:
           COMMON_CHANGED: ${{ needs.detect-changes.outputs.assay_common_changed }}
           POLICY_CHANGED: ${{ needs.detect-changes.outputs.assay_policy_changed }}
           METRICS_CHANGED: ${{ needs.detect-changes.outputs.assay_metrics_changed }}
+          RUNNER_SCHEMA_CHANGED: ${{ needs.detect-changes.outputs.assay_runner_schema_changed }}
         run: |
           set -euo pipefail
 
@@ -473,6 +481,9 @@ jobs:
           fi
           if [[ "${RUN_ALL}" == "true" || "${GLOBAL_CHANGED}" == "true" || "${EVIDENCE_CHANGED}" == "true" ]]; then
             run_semver_for assay-evidence
+          fi
+          if [[ "${RUN_ALL}" == "true" || "${GLOBAL_CHANGED}" == "true" || "${RUNNER_SCHEMA_CHANGED}" == "true" ]]; then
+            run_semver_for assay-runner-schema
           fi
 
   nightly-safety:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -765,6 +765,13 @@ repos:
         # crate, so it runs under ASSAY_SEMVER_GATE_FULL=1 and in the workflow's own CI job.
         stages: [pre-push]
         files: ^(scripts/ci/test-semver-gate\.sh|\.github/workflows/split-wave0-gates\.yml)$
+      - id: split-wave0-semver-routing-contract
+        name: Split Wave 0 semver routing contract
+        entry: bash scripts/ci/test-split-wave0-semver-routing.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit, pre-push]
+        files: ^(\.github/workflows/split-wave0-gates\.yml|scripts/ci/test-split-wave0-semver-routing\.sh|docs/contributing/WAVE0-GATES\.md|\.pre-commit-config\.yaml)$
       - id: linux-gate-self-test
         name: Linux compile gate self-test
         entry: bash scripts/ci/test-check-linux.sh

--- a/docs/contributing/WAVE0-GATES.md
+++ b/docs/contributing/WAVE0-GATES.md
@@ -15,7 +15,10 @@ Wave 0 gates are the pre-refactor guardrails for:
 - Source of truth: the newest `v[0-9]*` release tag, resolved at job time
   (`git tag --list 'v[0-9]*' --sort=-v:refname`).
 - There is no pinned baseline SHA. A missing tag fails the job.
-- The contract is `scripts/ci/test-semver-gate.sh`.
+- Baseline selection and the real lint's ability to reject a planted API break are pinned by
+  `scripts/ci/test-semver-gate.sh`.
+- Change detection and the route from a touched crate to its semver invocation are pinned by
+  `scripts/ci/test-split-wave0-semver-routing.sh`.
 
 ## Runtime budget targets
 
@@ -47,6 +50,7 @@ crates.io contract:
 - `assay-core`
 - `assay-registry`
 - `assay-evidence`
+- `assay-runner-schema`
 
 Checks are still conditional on touched/global change detection.
 
@@ -62,10 +66,13 @@ The Assay-Runner substrate crates — `assay-runner-schema`,
 `v3.11.3`, but their package descriptions explicitly
 frame them as internal/experimental substrate (no standalone product
 guarantee, intentionally undocumented for third-party use, semver tracks
-the Assay workspace). They are intentionally **not** in the Wave 0 library
-semver allowlist; they exist on crates.io only because `assay-cli` depends
-on them and cargo publish requires every declared dep to be resolvable
-from crates.io.
+the Assay workspace). `assay-runner-schema` is the narrow exception in this
+allowlist: ADR-048 requires its existing public type paths to survive a move
+to shared definitions, so that migration needs a real semver check. This does
+not grant a standalone-product guarantee. `assay-runner-core` and
+`assay-runner-linux` remain outside the Wave 0 library semver allowlist; the
+substrate crates exist on crates.io because `assay-cli` depends on them and
+cargo publish requires every declared dependency to be resolvable there.
 
 As of `v3.11.3`, `check-public-crate-policy.sh` also runs as a PR-CI
 guardrail (job `Public crate policy` in `ci.yml`), so the policy gate

--- a/scripts/ci/test-split-wave0-semver-routing.sh
+++ b/scripts/ci/test-split-wave0-semver-routing.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Prove that an assay-runner-schema change reaches its cargo-semver-checks invocation.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT}/.github/workflows/split-wave0-gates.yml"
+scratch="$(mktemp -d)"
+trap 'rm -rf "${scratch}"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+job_block() {
+  local workflow="$1" job="$2"
+  awk -v heading="  ${job}:" '
+    $0 == heading { in_job=1; print; next }
+    in_job && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
+    in_job { print }
+  ' "${workflow}"
+}
+
+step_block() {
+  local workflow="$1" job="$2" marker="$3"
+  job_block "${workflow}" "${job}" | awk -v marker="${marker}" '
+    $0 == marker { in_step=1; print; next }
+    in_step && /^      - / { exit }
+    in_step { print }
+  '
+}
+
+step_run() {
+  local workflow="$1" job="$2" marker="$3"
+  step_block "${workflow}" "${job}" "${marker}" | awk '
+    /^[[:space:]]*run:[[:space:]]*\|[-+]?[[:space:]]*$/ { in_run=1; next }
+    in_run && /^          / { sub(/^          /, ""); print; next }
+    in_run && /^$/ { print; next }
+    in_run { exit }
+  '
+}
+
+require_one_line() {
+  local text="$1" line="$2" description="$3" count
+  count="$(printf '%s\n' "${text}" | grep -Fxc -- "${line}" || true)"
+  [[ "${count}" -eq 1 ]] \
+    || fail "${description}: expected one active line, found ${count}"
+}
+
+output_value() {
+  local output_file="$1" key="$2"
+  awk -F= -v key="${key}" '$1 == key { value=substr($0, length(key) + 2) } END { print value }' \
+    "${output_file}"
+}
+
+check_contract() (
+  set -euo pipefail
+  local workflow="$1" case_dir detector detector_job semver_step
+  case_dir="$(mktemp -d "${scratch}/case.XXXXXX")"
+  detector="${case_dir}/detect.sh"
+  detector_job="$(job_block "${workflow}" detect-changes)"
+  semver_step="$(step_block "${workflow}" semver-public '      - name: Run semver checks (allowlist)')"
+
+  step_run "${workflow}" detect-changes '      - id: detect' > "${detector}"
+  [[ -s "${detector}" ]] || fail "could not extract detect step run block"
+  mkdir -p "${case_dir}/runner"
+  : > "${case_dir}/outputs"
+  : > "${case_dir}/summary"
+  RUNNER_TEMP="${case_dir}/runner" \
+  GITHUB_OUTPUT="${case_dir}/outputs" \
+  GITHUB_STEP_SUMMARY="${case_dir}/summary" \
+  GITHUB_EVENT_NAME=workflow_dispatch \
+  SIMULATED_CHANGED_FILES=crates/assay-runner-schema/src/lib.rs \
+    bash "${detector}"
+
+  [[ "$(output_value "${case_dir}/outputs" assay_runner_schema_changed)" == "true" ]] \
+    || fail "assay-runner-schema change did not emit assay_runner_schema_changed=true"
+  [[ "$(output_value "${case_dir}/outputs" semver_relevant)" == "true" ]] \
+    || fail "assay-runner-schema change did not emit semver_relevant=true"
+  [[ "$(output_value "${case_dir}/outputs" unmatched_assay_crate_changed)" == "false" ]] \
+    || fail "assay-runner-schema remains classified as an unmatched Assay crate"
+
+  require_one_line "${detector_job}" \
+    "      assay_runner_schema_changed: \${{ steps.detect.outputs.assay_runner_schema_changed }}" \
+    "detect output is not projected to the job"
+  require_one_line "${semver_step}" \
+    "          RUNNER_SCHEMA_CHANGED: \${{ needs.detect-changes.outputs.assay_runner_schema_changed }}" \
+    "runner-schema job output is not consumed by the semver step"
+
+  step_run "${workflow}" semver-public '      - name: Run semver checks (allowlist)' \
+    > "${case_dir}/semver.sh"
+  [[ -s "${case_dir}/semver.sh" ]] || fail "could not extract semver run block"
+  mkdir -p "${case_dir}/bin"
+  cat > "${case_dir}/bin/cargo" <<'CARGO'
+#!/usr/bin/env bash
+printf 'toolchain=%s argv=%s\n' "${RUSTUP_TOOLCHAIN:-}" "$*" >> "${CARGO_LOG}"
+CARGO
+  chmod +x "${case_dir}/bin/cargo"
+  : > "${case_dir}/cargo.log"
+
+  PATH="${case_dir}/bin:${PATH}" \
+  CARGO_LOG="${case_dir}/cargo.log" \
+  GITHUB_STEP_SUMMARY="${case_dir}/summary" \
+  BASELINE_TAG=test-baseline \
+  RUN_ALL=false \
+  GLOBAL_CHANGED=false \
+  CORE_CHANGED=false \
+  REGISTRY_CHANGED=false \
+  EVIDENCE_CHANGED=false \
+  COMMON_CHANGED=false \
+  POLICY_CHANGED=false \
+  METRICS_CHANGED=false \
+  RUNNER_SCHEMA_CHANGED=true \
+    bash "${case_dir}/semver.sh"
+
+  expected='toolchain=stable argv=semver-checks check-release -p assay-runner-schema --baseline-rev test-baseline'
+  [[ "$(cat "${case_dir}/cargo.log")" == "${expected}" ]] \
+    || fail "runner-schema route did not make exactly the expected cargo invocation; got: $(cat "${case_dir}/cargo.log")"
+)
+
+expect_mutation_to_fail() {
+  local name="$1" workflow="$2"
+  if check_contract "${workflow}" >/dev/null 2>"${scratch}/${name}.err"; then
+    fail "${name} mutation survived"
+  fi
+  echo "ok   ${name} mutation bites"
+}
+
+check_contract "${WORKFLOW}"
+
+cp "${WORKFLOW}" "${scratch}/missing-job-output.yml"
+sed -i.bak '/^[[:space:]]*assay_runner_schema_changed: \${{ steps\.detect\.outputs\.assay_runner_schema_changed }}[[:space:]]*$/d' \
+  "${scratch}/missing-job-output.yml"
+expect_mutation_to_fail missing-job-output "${scratch}/missing-job-output.yml"
+
+cp "${WORKFLOW}" "${scratch}/missing-step-env.yml"
+sed -i.bak '/^[[:space:]]*RUNNER_SCHEMA_CHANGED: \${{ needs\.detect-changes\.outputs\.assay_runner_schema_changed }}[[:space:]]*$/d' \
+  "${scratch}/missing-step-env.yml"
+expect_mutation_to_fail missing-step-env "${scratch}/missing-step-env.yml"
+
+cp "${WORKFLOW}" "${scratch}/missing-invocation.yml"
+sed -i.bak 's/^[[:space:]]*run_semver_for assay-runner-schema[[:space:]]*$/            : # runner-schema invocation removed/' \
+  "${scratch}/missing-invocation.yml"
+expect_mutation_to_fail missing-invocation "${scratch}/missing-invocation.yml"
+
+cp "${WORKFLOW}" "${scratch}/control.yml"
+printf '\n# comment-only control\n' >> "${scratch}/control.yml"
+check_contract "${scratch}/control.yml"
+echo "ok   comment-only control remains green"
+echo "split-wave0 semver routing: PASS"


### PR DESCRIPTION
## Purpose

Close the ADR-048 prerequisite false green: a change under `crates/assay-runner-schema/` currently schedules the Wave 0 semver job but makes that job run zero semver checks.

## Exact scope

- Base: `30a4d89126f6869e314c4cebc5e94e420631d314`
- Head: `978f9e42cf7ad2256f0d10d4ab4d3ed55b361841`
- Add a named runner-schema detector output and carry it through job output, step env, and one `run_semver_for assay-runner-schema` call.
- Add a behavioral routing contract that executes the workflow's detector and semver run blocks.
- Register the contract for pre-commit/pre-push and run it unconditionally in the hosted detect job.
- Correct the Wave 0 allowlist documentation.

## RED to GREEN

RED on unchanged main:

`FAIL: assay-runner-schema change did not emit assay_runner_schema_changed=true`

GREEN on this head:

- expected runner-schema output: true
- `semver_relevant`: true
- unmatched crate classification: false
- exact captured command: `RUSTUP_TOOLCHAIN=stable cargo semver-checks check-release -p assay-runner-schema --baseline-rev test-baseline`

## Mutations

- delete detector job-output projection: killed
- delete semver step env consumer: killed
- neutralize the runner-schema invocation: killed
- comment-only control: remains green

## Verification

- focused routing contract: passed
- ShellCheck: passed
- pre-commit config validation: passed
- check-yaml and actionlint: passed
- cheap semver baseline contract: passed
- CI programme-truth contract: passed
- split-wave plugin-version contract: passed
- complete normal pre-commit and pre-push hook sets: passed
- workspace clippy with deny warnings: passed
- Linux cross-target compile gate: passed
- `git diff --check`: passed

## Non-claims

- This does not move the ADR-048 enums or add the new crate edge.
- This does not test cargo-semver-checks correctness; the hosted semver job owns the real comparison.
- This does not add every published or runner crate to Wave 0.
- This does not generalize crate routing or fix the pre-existing mixed matched/unmatched-path classifier behavior.
- Internal/experimental runner-schema wording remains; semver coverage grants no standalone-product guarantee.

Fresh independent exact-head review is required before ready or merge.


## Exact-head hosted proof

- Head: `978f9e42cf7ad2256f0d10d4ab4d3ed55b361841`
- Workflow dispatch: https://github.com/Rul1an/assay/actions/runs/33703482130
- Simulated changed path: `crates/assay-runner-schema/src/lib.rs`
- Result: all dispatched jobs succeeded.
- Semver baseline: `v5.5.2` at `d813af0e`.
- The semver job actually built, parsed, and checked `assay-runner-schema v5.5.2 -> v5.5.2`; this is not inferred from the detector output alone.
