### PR TITLE
fix(ci): make current Codex host proof executable

### DIFF
--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -25,6 +25,7 @@ import {
   HARD_MAX_SNAPSHOT_BYTES,
   HARD_MAX_TIMEOUT_MS,
   HOST_ENV_NAMES,
+  HOST_SUBJECTS,
   SCHEMA,
   SKILL_NAME,
   boundedPositiveInt,
@@ -347,10 +348,8 @@ export function resolveHostIdentity(options = {}) {
     throw new Error("proofRoot is required for proof-owned host subjects");
   }
   const codexSource = resolveRegularBinary(codexPath, "codex");
-  const codeModeHostName =
-    process.platform === "win32" ? "codex-code-mode-host.exe" : "codex-code-mode-host";
+  const codeModeHostName = HOST_SUBJECTS[1];
   const codeModeHostSource = path.join(path.dirname(codexSource), codeModeHostName);
-  resolveRegularBinary(codeModeHostSource, "codex-code-mode-host");
   const snapRoot = requirePrivateProofRoot(options.proofRoot);
   const codexSnap = path.join(snapRoot, "codex.snapshot");
   const codeModeHostSnap = path.join(snapRoot, codeModeHostName);

--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -346,10 +346,16 @@ export function resolveHostIdentity(options = {}) {
   if (typeof options.proofRoot !== "string" || options.proofRoot.length === 0) {
     throw new Error("proofRoot is required for proof-owned host subjects");
   }
+  const codexSource = resolveRegularBinary(codexPath, "codex");
+  const codeModeHostName =
+    process.platform === "win32" ? "codex-code-mode-host.exe" : "codex-code-mode-host";
+  const codeModeHostSource = path.join(path.dirname(codexSource), codeModeHostName);
+  resolveRegularBinary(codeModeHostSource, "codex-code-mode-host");
   const snapRoot = requirePrivateProofRoot(options.proofRoot);
   const codexSnap = path.join(snapRoot, "codex.snapshot");
+  const codeModeHostSnap = path.join(snapRoot, codeModeHostName);
   const mcpSnap = path.join(snapRoot, "assay-mcp-server.snapshot");
-  if (fs.existsSync(codexSnap) || fs.existsSync(mcpSnap)) {
+  if (fs.existsSync(codexSnap) || fs.existsSync(codeModeHostSnap) || fs.existsSync(mcpSnap)) {
     throw new Error("proof-owned host subject already exists");
   }
   try {
@@ -357,7 +363,8 @@ export function resolveHostIdentity(options = {}) {
       testOnlySnapshotMaxBytes: options.testOnlySnapshotMaxBytes,
       testOnlyAfterSnapshotRead: options.testOnlyAfterSnapshotRead,
     };
-    snapshotNamedBinary(codexPath, snapRoot, "codex.snapshot", snapOpts);
+    snapshotNamedBinary(codexSource, snapRoot, "codex.snapshot", snapOpts);
+    snapshotNamedBinary(codeModeHostSource, snapRoot, codeModeHostName, snapOpts);
     snapshotNamedBinary(mcpPath, snapRoot, "assay-mcp-server.snapshot", snapOpts);
     const identity = {
       os: os.platform(),
@@ -368,6 +375,11 @@ export function resolveHostIdentity(options = {}) {
         sha256: sha256File(codexSnap),
         installSource: "PATH",
       },
+      codexCodeModeHost: {
+        path: fs.realpathSync(codeModeHostSnap),
+        sha256: sha256File(codeModeHostSnap),
+        installSource: "codex-sibling",
+      },
       assayMcp: {
         path: fs.realpathSync(mcpSnap),
         version: probeAssayMcpVersion(mcpSnap),
@@ -375,10 +387,13 @@ export function resolveHostIdentity(options = {}) {
         installSource: "PATH",
       },
     };
-    identity[BOUND_EXEC] = { codexPath: codexSnap, mcpPath: mcpSnap };
+    identity[BOUND_EXEC] = {
+      codexPath: codexSnap,
+      mcpPath: mcpSnap,
+    };
     return identity;
   } catch (error) {
-    for (const subject of [codexSnap, mcpSnap]) {
+    for (const subject of [codexSnap, codeModeHostSnap, mcpSnap]) {
       try {
         fs.rmSync(subject, { force: true });
       } catch {

--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -14,6 +14,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  CODEX_APP_SERVER_ARGS,
   DECIDE_INPUT,
   DECIDE_TOOL,
   EXPECTED_TOOLS,
@@ -411,7 +412,7 @@ function writeProofFiles(options, pack) {
   const hostIdentity = projectHostIdentity(options.hostIdentity ?? null);
   const invocationArgv = persistableArgv(
     options.hostIdentity?.codex?.path
-      ? [options.hostIdentity.codex.path, "app-server"]
+      ? [options.hostIdentity.codex.path, ...CODEX_APP_SERVER_ARGS]
       : Array.isArray(options.childArgv)
         ? options.childArgv
         : ["<test-only-child>"],
@@ -604,7 +605,7 @@ export async function runProof(options) {
   };
   const child = options.testOnlyChild
     ? options.testOnlyChild
-    : spawn(bound.codexPath, ["app-server"], spawnOpts);
+    : spawn(bound.codexPath, CODEX_APP_SERVER_ARGS, spawnOpts);
   const childClosed = new Promise((resolve) => {
     child.on("close", (code, signal) => {
       childAlive = false;

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -9,7 +9,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const SCHEMA = "assay.codex-host-proof.v3";
+export const SCHEMA = "assay.codex-host-proof.v4";
 export const FAKE_USER_AGENT = "assay-codex-host-proof-fake/1";
 export const SKILL_NAME = "assay-golden-path";
 export const DECIDE_TOOL = "assay_policy_decide";
@@ -40,6 +40,15 @@ export const HOST_SUBJECTS = Object.freeze([
 export const HOST_ALLOWLIST = Object.freeze([...ALLOWLIST, ...HOST_SUBJECTS]);
 export const EXTERNAL_ATTESTATION = "not_provided";
 export const HOST_ENV_NAMES = Object.freeze(["PATH", "HOME", "CODEX_HOME"]);
+export const CODEX_APP_SERVER_ARGS = Object.freeze([
+  "--disable",
+  "apps",
+  "--disable",
+  "plugins",
+  "--disable",
+  "remote_plugin",
+  "app-server",
+]);
 
 export function requirePrivateDirectory(directory, label) {
   if (typeof directory !== "string" || directory.length === 0) {
@@ -402,9 +411,7 @@ export function liveInvocationBound(identity, invocation) {
     liveIdentityBound(identity) &&
     exactKeys(invocation, ["argv", "envNames"]) &&
     Array.isArray(invocation.argv) &&
-    invocation.argv.length === 2 &&
-    invocation.argv[0] === identity.codex.path &&
-    invocation.argv[1] === "app-server" &&
+    sameJson(invocation.argv, [identity.codex.path, ...CODEX_APP_SERVER_ARGS]) &&
     sameJson(invocation.envNames, HOST_ENV_NAMES)
   );
 }
@@ -685,6 +692,12 @@ function retainedItemReason(item, label = "item/completed") {
     return `${label} item is not a typed retained item`;
   }
   switch (item.type) {
+    case "reasoning":
+    case "agentMessage":
+      if (exactKeys(item, ["type", "id"])) {
+        return null;
+      }
+      return `${label} ${item.type} is not the closed non-evidentiary projection`;
     case "mcpToolCall":
       if (
         isNonemptyString(item.server) &&
@@ -2065,6 +2078,9 @@ function projectRetainedItem(item) {
   }
   if (item.type === "userMessage") {
     return { type: "userMessage", id: projectedScalar(item.id), content: [] };
+  }
+  if (item.type === "reasoning" || item.type === "agentMessage") {
+    return { type: item.type, id: projectedScalar(item.id) };
   }
   const out = {
     type: projectedScalar(item.type),

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -35,6 +35,7 @@ export const ALLOWLIST = Object.freeze([
 ]);
 export const HOST_SUBJECTS = Object.freeze([
   "codex.snapshot",
+  process.platform === "win32" ? "codex-code-mode-host.exe" : "codex-code-mode-host",
   "assay-mcp-server.snapshot",
 ]);
 export const HOST_ALLOWLIST = Object.freeze([...ALLOWLIST, ...HOST_SUBJECTS]);
@@ -100,9 +101,9 @@ export const HARD_MAX_FRAMES = 8192;
 export const HARD_MAX_RETAINED_BYTES = 4 * 1024 * 1024;
 export const HARD_MAX_DIR_ENTRIES = 64;
 // 512 MiB per-binary PATH snapshot ceiling (536870912). Prepared v5.5.2 host
-// assets: bundled Codex at /Applications/ChatGPT.app/Contents/Resources/codex
-// is 231,697,328 bytes; assay-mcp-server is 11,105,184 bytes. 256 MiB would
-// sit one routine host growth away from false-unavailable.
+// assets: bundled Codex is 231,697,328 bytes, its code-mode host is 62,704,224
+// bytes, and assay-mcp-server is 11,105,184 bytes. 256 MiB would sit one
+// routine host growth away from false-unavailable.
 export const HARD_MAX_SNAPSHOT_BYTES = 512 * 1024 * 1024;
 export const RECORD_CONSISTENCY_NONCLAIM =
   "record consistency does not authenticate origin, authorship, signature, or attestation";
@@ -271,6 +272,7 @@ export function projectHostIdentity(identity) {
   }
   return {
     codex: projectBoundBinary(identity.codex),
+    codexCodeModeHost: projectBoundBinary(identity.codexCodeModeHost),
     assayMcp: projectBoundBinary(identity.assayMcp),
   };
 }
@@ -286,10 +288,14 @@ function boundBinary(bin) {
 }
 
 export function liveIdentityBound(identity) {
-  if (!exactKeys(identity, ["codex", "assayMcp"])) {
+  if (!exactKeys(identity, ["codex", "codexCodeModeHost", "assayMcp"])) {
     return false;
   }
-  return boundBinary(identity.codex) && boundBinary(identity.assayMcp);
+  return (
+    boundBinary(identity.codex) &&
+    boundBinary(identity.codexCodeModeHost) &&
+    boundBinary(identity.assayMcp)
+  );
 }
 
 export function consumeBoundedBinary(file, maxBytes, onChunk, options = {}) {
@@ -376,14 +382,20 @@ function verifyLiveIdentityBound(
     return false;
   }
   const expectedCodex = path.join(canonicalRoot, HOST_SUBJECTS[0]);
-  const expectedMcp = path.join(canonicalRoot, HOST_SUBJECTS[1]);
+  const expectedCodeModeHost = path.join(canonicalRoot, HOST_SUBJECTS[1]);
+  const expectedMcp = path.join(canonicalRoot, HOST_SUBJECTS[2]);
   if (
     path.resolve(identity.codex.path) !== expectedCodex ||
+    path.resolve(identity.codexCodeModeHost.path) !== expectedCodeModeHost ||
     path.resolve(identity.assayMcp.path) !== expectedMcp
   ) {
     return false;
   }
-  if (!verifyObservedBinary(identity.codex) || !verifyObservedBinary(identity.assayMcp)) {
+  if (
+    !verifyObservedBinary(identity.codex) ||
+    !verifyObservedBinary(identity.codexCodeModeHost) ||
+    !verifyObservedBinary(identity.assayMcp)
+  ) {
     return false;
   }
   if (journey !== "discovery" && !allowMissingCommand) {

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -607,10 +607,13 @@ export function journeyPairCounts(journey) {
 
 export const ALLOWED_SERVER_REQUESTS = Object.freeze(["mcpServer/elicitation/request"]);
 export const LIFECYCLE_SERVER_NOTIFICATIONS = Object.freeze([
+  "account/rateLimits/updated",
+  "item/agentMessage/delta",
   "remoteControl/status/changed",
   "thread/started",
   "mcpServer/startupStatus/updated",
   "thread/status/changed",
+  "thread/tokenUsage/updated",
   "turn/started",
   "item/started",
 ]);

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -23,6 +23,7 @@ import {
   DECIDE_TOOL,
   EXPECTED_TOOLS,
   HARD_MAX_SNAPSHOT_BYTES,
+  HOST_SUBJECTS,
   classifyRecord,
   classifyStoredEvent,
   consumeJourneyTopology,
@@ -113,7 +114,18 @@ void import(${JSON.stringify(`data:text/javascript,${encodeURIComponent(body)}`)
 `,
     { mode: 0o755 },
   );
+  if (path.basename(filePath) === "codex") {
+    writeCodeModeHostSibling(filePath);
+  }
   return filePath;
+}
+
+function writeCodeModeHostSibling(codexPath) {
+  const helperPath = path.join(path.dirname(codexPath), HOST_SUBJECTS[1]);
+  if (!fs.existsSync(helperPath)) {
+    fs.writeFileSync(helperPath, "#!/usr/bin/env node\n", { mode: 0o755 });
+  }
+  return helperPath;
 }
 
 function writeShadowCodex(childArgv) {
@@ -525,12 +537,11 @@ test("malformed JSON line writes unavailable evidence; CLI proof root is not emp
   const cli = driveCliInline(childArgv, { timeoutMs: 800 });
   assert.equal(cli.stderr.includes("SyntaxError"), false, "parse errors must not escape the data callback");
   assert.deepEqual(proofFiles(cli.proofRoot), [
-    "assay-mcp-server.snapshot",
     "classification.json",
-    "codex.snapshot",
     "events.json",
     "manifest.json",
-  ]);
+    ...HOST_SUBJECTS,
+  ].sort());
   const stored = JSON.parse(
     fs.readFileSync(path.join(cli.proofRoot, "classification.json"), "utf8"),
   );
@@ -594,12 +605,11 @@ test("production driver creates and verifies its disposable CODEX_HOME before sp
   const projectRoot = seedProject();
   const codexHome = path.join(projectRoot, ".codex-home");
   const retainedFilesWithIdentity = [
-    "assay-mcp-server.snapshot",
     "classification.json",
-    "codex.snapshot",
     "events.json",
     "manifest.json",
-  ];
+    ...HOST_SUBJECTS,
+  ].sort();
   assert.equal(fs.existsSync(codexHome), false, "control starts without CODEX_HOME");
 
   const binDir = scratch();
@@ -1278,8 +1288,8 @@ test("production host identity is observed from proof-owned binaries before CLI 
     const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
     const identity = manifest.hostIdentity;
     assert.ok(identity && typeof identity === "object", "production CLI must construct hostIdentity");
-    assert.deepEqual(Object.keys(identity).sort(), ["assayMcp", "codex"]);
-    for (const role of ["codex", "assayMcp"]) {
+    assert.deepEqual(Object.keys(identity).sort(), ["assayMcp", "codex", "codexCodeModeHost"]);
+    for (const role of ["codex", "codexCodeModeHost", "assayMcp"]) {
       assert.deepEqual(Object.keys(identity[role]).sort(), ["path", "sha256"]);
       assert.equal(path.isAbsolute(identity[role].path), true, `${role} path must be absolute`);
       assert.match(identity[role].sha256, /^[a-f0-9]{64}$/);
@@ -1670,9 +1680,12 @@ test("PATH shadows drive observed Codex and Assay MCP identities", () => {
       codexBin: flagCodex,
       assayMcpBin: flagMcp,
     });
+    const codeModeHost = path.join(path.dirname(codexBin), HOST_SUBJECTS[1]);
     assert.equal(ignored.codex.sha256, sha256File(codexBin));
+    assert.equal(ignored.codexCodeModeHost.sha256, sha256File(codeModeHost));
     assert.equal(ignored.assayMcp.sha256, sha256File(mcpBin));
     assert.equal(sha256File(ignored.codex.path), sha256File(codexBin));
+    assert.equal(sha256File(ignored.codexCodeModeHost.path), sha256File(codeModeHost));
     assert.equal(sha256File(ignored.assayMcp.path), sha256File(mcpBin));
     assert.equal(ignored.codex.installSource, "PATH");
     assert.equal(ignored.assayMcp.installSource, "PATH");
@@ -1711,12 +1724,21 @@ test("PATH shadows drive observed Codex and Assay MCP identities", () => {
   );
   assert.equal(typeof cli.status, "number");
   const manifest = JSON.parse(fs.readFileSync(path.join(proofRoot, "manifest.json"), "utf8"));
+  const codeModeHost = path.join(path.dirname(codexBin), HOST_SUBJECTS[1]);
   assert.equal(manifest.hostIdentity.codex.sha256, sha256File(codexBin));
+  assert.equal(manifest.hostIdentity.codexCodeModeHost.sha256, sha256File(codeModeHost));
   assert.equal(manifest.hostIdentity.assayMcp.sha256, sha256File(mcpBin));
   assert.equal(sha256File(manifest.hostIdentity.codex.path), sha256File(codexBin));
   assert.equal(sha256File(manifest.hostIdentity.assayMcp.path), sha256File(mcpBin));
-  assert.deepEqual(Object.keys(manifest.hostIdentity).sort(), ["assayMcp", "codex"]);
+  assert.deepEqual(
+    Object.keys(manifest.hostIdentity).sort(),
+    ["assayMcp", "codex", "codexCodeModeHost"],
+  );
   assert.deepEqual(Object.keys(manifest.hostIdentity.codex).sort(), ["path", "sha256"]);
+  assert.deepEqual(
+    Object.keys(manifest.hostIdentity.codexCodeModeHost).sort(),
+    ["path", "sha256"],
+  );
   assert.deepEqual(Object.keys(manifest.hostIdentity.assayMcp).sort(), ["path", "sha256"]);
   const events = JSON.parse(fs.readFileSync(path.join(proofRoot, "events.json"), "utf8"));
   const start = events.find(
@@ -2512,6 +2534,23 @@ function writeVersionOnlyBin(name, version) {
   return bin;
 }
 
+test("host identity refuses a Codex installation without its code-mode host", () => {
+  const codex = writeVersionOnlyBin("codex", "codex-control/0.0.0");
+  fs.rmSync(path.join(path.dirname(codex), HOST_SUBJECTS[1]));
+  const mcp = writeVersionOnlyBin("assay-mcp-server", "assay-mcp-control/0.0.0");
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${path.dirname(codex)}${path.delimiter}${path.dirname(mcp)}${path.delimiter}${previousPath}`;
+  try {
+    assert.throws(
+      () => resolveHostIdentity(),
+      /codex-code-mode-host/i,
+      "the proof must refuse before Codex can resolve an unbound sibling helper",
+    );
+  } finally {
+    process.env.PATH = previousPath;
+  }
+});
+
 test("version observation rejects output from a failed probe", () => {
   const codex = path.join(scratch(), "codex");
   writePortableNodeExecutable(
@@ -2664,7 +2703,11 @@ function writeSparseFile(filePath, size) {
 }
 
 function writeSparseBin(name, size) {
-  return writeSparseFile(path.join(scratch(), name), size);
+  const bin = writeSparseFile(path.join(scratch(), name), size);
+  if (name === "codex") {
+    writeCodeModeHostSibling(bin);
+  }
+  return bin;
 }
 
 function snapRoots() {
@@ -3610,7 +3653,7 @@ test("review closeout: host subjects are proof-owned and independently revalidat
     const manifest = JSON.parse(fs.readFileSync(path.join(proofRoot, "manifest.json"), "utf8"));
     const leaked = snapRoots().filter((name) => !before.has(name));
     assert.deepEqual(leaked, [], "successful capture must not leave an unowned temp snapshot");
-    for (const role of ["codex", "assayMcp"]) {
+    for (const role of ["codex", "codexCodeModeHost", "assayMcp"]) {
       const relative = path.relative(proofRoot, manifest.hostIdentity[role].path);
       assert.equal(relative.startsWith("..") || path.isAbsolute(relative), false);
       assert.equal(fs.existsSync(manifest.hostIdentity[role].path), true);
@@ -3620,6 +3663,10 @@ test("review closeout: host subjects are proof-owned and independently revalidat
     const events = JSON.parse(fs.readFileSync(path.join(proofRoot, "events.json"), "utf8"));
     const topology = consumeJourneyTopology(events, manifest.journey);
     assert.equal(sha256File(manifest.hostIdentity.codex.path), manifest.hostIdentity.codex.sha256);
+    assert.equal(
+      sha256File(manifest.hostIdentity.codexCodeModeHost.path),
+      manifest.hostIdentity.codexCodeModeHost.sha256,
+    );
     assert.equal(sha256File(manifest.hostIdentity.assayMcp.path), manifest.hostIdentity.assayMcp.sha256);
     assert.equal(
       topology.primaryThread.request.params.config.mcp_servers.assay.command,
@@ -3716,6 +3763,7 @@ test("review closeout: proof-owned subject mutations fail closed", () => {
     });
     const manifest = JSON.parse(fs.readFileSync(path.join(proofRoot, "manifest.json"), "utf8"));
     const codex = manifest.hostIdentity.codex.path;
+    const codeModeHost = manifest.hostIdentity.codexCodeModeHost.path;
     const assayMcp = manifest.hostIdentity.assayMcp.path;
     const original = fs.readFileSync(codex);
     const originalMode = fs.statSync(codex).mode & 0o777;
@@ -3755,6 +3803,13 @@ test("review closeout: proof-owned subject mutations fail closed", () => {
     }
 
     assert.equal(validateProofRoot(proofRoot).ok, true, "restored no-op control must validate");
+
+    const helperOriginal = fs.readFileSync(codeModeHost);
+    fs.appendFileSync(codeModeHost, "\nmutated helper\n");
+    rejects("altered code-mode host subject");
+    fs.rmSync(codeModeHost, { force: true });
+    fs.writeFileSync(codeModeHost, helperOriginal, { mode: 0o700 });
+    assert.equal(validateProofRoot(proofRoot).ok, true, "restored helper control must validate");
   } finally {
     if (observed) {
       fs.rmSync(path.dirname(observed.codexBin), { recursive: true, force: true });
@@ -3894,7 +3949,7 @@ test("review repair: host-observation cannot omit proof-owned identity subjects"
 
     manifest.hostIdentity = null;
     manifest.allowlist = ["classification.json", "events.json", "manifest.json"];
-    for (const subject of ["codex.snapshot", "assay-mcp-server.snapshot"]) {
+    for (const subject of HOST_SUBJECTS) {
       fs.rmSync(path.join(proofRoot, subject));
     }
     const identityFree = classifyRecord({ ...manifest, events });

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -2538,16 +2538,84 @@ test("host identity refuses a Codex installation without its code-mode host", ()
   const codex = writeVersionOnlyBin("codex", "codex-control/0.0.0");
   fs.rmSync(path.join(path.dirname(codex), HOST_SUBJECTS[1]));
   const mcp = writeVersionOnlyBin("assay-mcp-server", "assay-mcp-control/0.0.0");
+  const proofRoot = scratch();
   const previousPath = process.env.PATH;
   process.env.PATH = `${path.dirname(codex)}${path.delimiter}${path.dirname(mcp)}${path.delimiter}${previousPath}`;
   try {
     assert.throws(
-      () => resolveHostIdentity(),
+      () => resolveHostIdentity({ proofRoot }),
       /codex-code-mode-host/i,
       "the proof must refuse before Codex can resolve an unbound sibling helper",
     );
+    for (const subject of HOST_SUBJECTS) {
+      assert.equal(
+        fs.existsSync(path.join(proofRoot, subject)),
+        false,
+        `missing helper must not leave ${subject}`,
+      );
+    }
   } finally {
     process.env.PATH = previousPath;
+    fs.rmSync(proofRoot, { recursive: true, force: true });
+  }
+});
+
+test("code-mode host subject uses the platform runtime name", () => {
+  assert.equal(
+    HOST_SUBJECTS[1],
+    process.platform === "win32" ? "codex-code-mode-host.exe" : "codex-code-mode-host",
+  );
+});
+
+test("pre-existing proof subjects are refused without being deleted", () => {
+  const proofRoot = scratch();
+  const sentinel = path.join(proofRoot, HOST_SUBJECTS[1]);
+  fs.writeFileSync(sentinel, "pre-existing\n", { mode: 0o700 });
+  const codex = writeVersionOnlyBin("codex", "codex-control/0.0.0");
+  const mcp = writeVersionOnlyBin("assay-mcp-server", "assay-mcp-control/0.0.0");
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${path.dirname(codex)}${path.delimiter}${path.dirname(mcp)}${path.delimiter}${previousPath}`;
+  try {
+    assert.throws(
+      () => resolveHostIdentity({ proofRoot }),
+      /already exists/i,
+      "acquisition must refuse before touching an existing proof subject",
+    );
+    assert.equal(fs.readFileSync(sentinel, "utf8"), "pre-existing\n");
+  } finally {
+    process.env.PATH = previousPath;
+    fs.rmSync(proofRoot, { recursive: true, force: true });
+  }
+});
+
+test("partial acquisition removes every proof-owned subject", () => {
+  const proofRoot = scratch();
+  const codex = writeVersionOnlyBin("codex", "codex-control/0.0.0");
+  const mcp = writeVersionOnlyBin("assay-mcp-server", "assay-mcp-control/0.0.0");
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${path.dirname(codex)}${path.delimiter}${path.dirname(mcp)}${path.delimiter}${previousPath}`;
+  try {
+    assert.throws(
+      () => resolveHostIdentity({
+        proofRoot,
+        testOnlyAfterSnapshotRead(copied, _src, destName) {
+          if (destName === "assay-mcp-server.snapshot" && copied === 0) {
+            throw new Error("injected third-subject failure");
+          }
+        },
+      }),
+      /injected third-subject failure/i,
+    );
+    for (const subject of HOST_SUBJECTS) {
+      assert.equal(
+        fs.existsSync(path.join(proofRoot, subject)),
+        false,
+        `partial acquisition must remove ${subject}`,
+      );
+    }
+  } finally {
+    process.env.PATH = previousPath;
+    fs.rmSync(proofRoot, { recursive: true, force: true });
   }
 });
 
@@ -3814,6 +3882,57 @@ test("review closeout: proof-owned subject mutations fail closed", () => {
     if (observed) {
       fs.rmSync(path.dirname(observed.codexBin), { recursive: true, force: true });
       fs.rmSync(path.dirname(observed.mcpBin), { recursive: true, force: true });
+    }
+    fs.rmSync(proofRoot, { recursive: true, force: true });
+  }
+});
+
+test("review closeout: host identity is bound to the closed proof-root shape", () => {
+  const proofRoot = portableLiveProofRoot();
+  let observed;
+  let outsideRoot;
+  try {
+    observed = driveCli("valid", "tool", {
+      captureMode: "synthetic-fixture",
+      proofRoot,
+    });
+    assert.equal(validateProofRoot(proofRoot).ok, true, "unchanged control must validate");
+    const manifestPath = path.join(proofRoot, "manifest.json");
+    const control = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+    outsideRoot = scratch();
+    const outsideHelper = path.join(outsideRoot, HOST_SUBJECTS[1]);
+    fs.copyFileSync(control.hostIdentity.codexCodeModeHost.path, outsideHelper);
+    fs.chmodSync(outsideHelper, 0o700);
+    const rebound = structuredClone(control);
+    rebound.hostIdentity.codexCodeModeHost.path = fs.realpathSync(outsideHelper);
+    assert.equal(
+      sha256File(outsideHelper),
+      rebound.hostIdentity.codexCodeModeHost.sha256,
+      "the path mutation must preserve the helper digest",
+    );
+    fs.writeFileSync(manifestPath, stableStringify(rebound));
+    assert.equal(
+      validateProofRoot(proofRoot).ok,
+      false,
+      "an identical helper outside the proof root must not satisfy path binding",
+    );
+
+    const widened = structuredClone(control);
+    widened.hostIdentity.codexCodeModeHost.unexpected = true;
+    fs.writeFileSync(manifestPath, stableStringify(widened));
+    assert.equal(
+      validateProofRoot(proofRoot).ok,
+      false,
+      "the helper identity must remain the exact path+sha256 projection",
+    );
+  } finally {
+    if (observed) {
+      fs.rmSync(path.dirname(observed.codexBin), { recursive: true, force: true });
+      fs.rmSync(path.dirname(observed.mcpBin), { recursive: true, force: true });
+    }
+    if (outsideRoot) {
+      fs.rmSync(outsideRoot, { recursive: true, force: true });
     }
     fs.rmSync(proofRoot, { recursive: true, force: true });
   }

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -24,6 +24,7 @@ import {
   EXPECTED_TOOLS,
   HARD_MAX_SNAPSHOT_BYTES,
   classifyRecord,
+  classifyStoredEvent,
   consumeJourneyTopology,
   decidePrompt,
   driverOutcomeFrom,
@@ -4086,6 +4087,12 @@ const OBSERVED_NON_EVIDENTIARY_ITEMS = Object.freeze([
   }),
 ]);
 
+const OBSERVED_NON_EVIDENTIARY_NOTIFICATIONS = Object.freeze([
+  "account/rateLimits/updated",
+  "item/agentMessage/delta",
+  "thread/tokenUsage/updated",
+]);
+
 test("stableStringify refuses non-JSON primitives; JSON null stays a valid token", () => {
   assert.equal(stableStringify({ a: null }), '{"a":null}\n');
   assert.equal(stableStringify([null, 1, "x", true]), '[null,1,"x",true]\n');
@@ -4166,7 +4173,19 @@ test("current Codex non-evidentiary items are scrubbed and do not invalidate a r
       },
     }),
   );
-  events.splice(toolIndex, 0, ...chatterRows);
+  const lifecycleRows = OBSERVED_NON_EVIDENTIARY_NOTIFICATIONS.map((method) =>
+    projectRetainedEvent({
+      direction: "server",
+      id: null,
+      method,
+      params: { sensitiveHostValue: "must-not-be-retained" },
+    }),
+  );
+  for (const row of lifecycleRows) {
+    assert.deepEqual(row.params, {}, `${row.method} payload must be scrubbed`);
+    assert.equal(classifyStoredEvent(row).type, "server-notification");
+  }
+  events.splice(toolIndex, 0, ...chatterRows, ...lifecycleRows);
   const terminalIndex = events.findIndex((event) => event.method === "turn/completed");
   assert.notEqual(terminalIndex, -1, "control run must contain the terminal turn");
   const terminal = events[terminalIndex];

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -204,7 +204,7 @@ test("driver calls the validator classification function; no extra classify modu
 test("synthetic positive control: cells pass without inventing external attestation", async () => {
   const { classified, manifest, proofRoot, driverOutcome, childExitCode, events } = await drive("valid");
   assert.equal(manifest.captureMode, "synthetic-fixture");
-  assert.equal(manifest.schema, "assay.codex-host-proof.v3");
+  assert.equal(manifest.schema, "assay.codex-host-proof.v4");
   assert.equal(childExitCode, 0);
   assert.equal(driverOutcome.exitCode, 0);
   assert.equal(manifest.childExitCode, 0);
@@ -4005,9 +4005,85 @@ test("review repair: host manifest invocation is exact and credential-free", () 
   }
 });
 
-const OBSERVED_DRIFT_ITEMS = Object.freeze([
-  Object.freeze({ type: "reasoning", id: "item_0", text: "Considering the assay decide tool." }),
-  Object.freeze({ type: "agentMessage", id: "item_2", text: "The decision endpoint returned allow." }),
+test("host observation disables unrelated app and plugin surfaces before app-server", () => {
+  const proofRoot = portableLiveProofRoot();
+  const argvMarker = path.join(scratch(), "codex-argv.json");
+  const codexBin = path.join(scratch(), "codex");
+  const projectRoot = seedProject();
+  writePortableNodeExecutable(
+    codexBin,
+    `import fs from "node:fs";
+import { spawn } from "node:child_process";
+if (process.argv.includes("--version")) {
+  process.stdout.write("codex-shadow/0.0.0\\n");
+  process.exit(0);
+}
+fs.writeFileSync(${JSON.stringify(argvMarker)}, JSON.stringify(process.argv.slice(2)));
+const child = spawn(${JSON.stringify(process.execPath)}, ${JSON.stringify([
+      FAKE,
+      "--scenario",
+      "valid",
+      "--project-root",
+      projectRoot,
+    ])}, { stdio: "inherit" });
+const stop = () => { try { child.kill("SIGTERM"); } catch { /* already exited */ } };
+process.on("SIGTERM", stop);
+process.on("SIGINT", stop);
+child.on("close", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
+`,
+  );
+  const observed = driveCli("valid", "failures", {
+    captureMode: "host-observation",
+    proofRoot,
+    projectRoot,
+    codexBin,
+  });
+  try {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(observed.proofRoot, "manifest.json"), "utf8"),
+    );
+    assert.deepEqual(manifest.invocation.argv, [
+      manifest.hostIdentity.codex.path,
+      "--disable",
+      "apps",
+      "--disable",
+      "plugins",
+      "--disable",
+      "remote_plugin",
+      "app-server",
+    ]);
+    assert.deepEqual(JSON.parse(fs.readFileSync(argvMarker, "utf8")), [
+      "--disable",
+      "apps",
+      "--disable",
+      "plugins",
+      "--disable",
+      "remote_plugin",
+      "app-server",
+    ]);
+  } finally {
+    fs.rmSync(path.dirname(observed.codexBin), { recursive: true, force: true });
+    fs.rmSync(path.dirname(observed.mcpBin), { recursive: true, force: true });
+    fs.rmSync(observed.proofRoot, { recursive: true, force: true });
+    fs.rmSync(observed.projectRoot, { recursive: true, force: true });
+  }
+});
+
+const OBSERVED_NON_EVIDENTIARY_ITEMS = Object.freeze([
+  Object.freeze({
+    type: "reasoning",
+    id: "item_0",
+    summary: [],
+    content: [{ type: "text", text: "Considering the assay decide tool." }],
+  }),
+  Object.freeze({
+    type: "agentMessage",
+    id: "item_2",
+    phase: "final_answer",
+    text: "The decision endpoint returned allow.",
+    delivery: "final",
+    memoryCitation: null,
+  }),
 ]);
 
 test("stableStringify refuses non-JSON primitives; JSON null stays a valid token", () => {
@@ -4028,7 +4104,7 @@ test("stableStringify refuses non-JSON primitives; JSON null stays a valid token
   }
 });
 
-test("absent scalar fields project to explicit invalid markers, never undefined", () => {
+test("known non-evidentiary items project to a closed type and id only", () => {
   const projected = projectRetainedEvent({
     direction: "server",
     method: "item/completed",
@@ -4037,13 +4113,11 @@ test("absent scalar fields project to explicit invalid markers, never undefined"
       completedAtMs: 5,
       threadId: "t",
       turnId: "u",
-      item: OBSERVED_DRIFT_ITEMS[0],
+      item: OBSERVED_NON_EVIDENTIARY_ITEMS[0],
     },
   });
   const item = projected.params.item;
-  for (const key of ["server", "tool", "arguments", "status"]) {
-    assert.notEqual(typeof item[key], "undefined", `${key} must not project to undefined`);
-  }
+  assert.deepEqual(item, { type: "reasoning", id: "item_0" });
   const serialized = stableStringify(projected);
   assert.doesNotMatch(
     serialized,
@@ -4051,7 +4125,7 @@ test("absent scalar fields project to explicit invalid markers, never undefined"
     "a bare undefined token must never appear; the quoted marker string is the valid form",
   );
   assert.equal(
-    serialized.includes(OBSERVED_DRIFT_ITEMS[0].text),
+    serialized.includes("Considering the assay decide tool."),
     false,
     "reasoning text must not be retained",
   );
@@ -4070,7 +4144,7 @@ test("absent scalar fields project to explicit invalid markers, never undefined"
   assert.equal(withNull.params.item.id, null, "JSON null must survive the scalar boundary");
 });
 
-test("observed Codex item drift retains valid JSON and classifies fail-closed", async () => {
+test("current Codex non-evidentiary items are scrubbed and do not invalidate a real tool row", async () => {
   const control = await drive("valid");
   assert.equal(validateProofRoot(control.proofRoot).ok, true, "unchanged control must validate");
   const events = structuredClone(control.events);
@@ -4079,7 +4153,7 @@ test("observed Codex item drift retains valid JSON and classifies fail-closed", 
   );
   assert.notEqual(toolIndex, -1, "control run must contain the tool item to replace");
   const toolRow = events[toolIndex];
-  const driftRows = OBSERVED_DRIFT_ITEMS.map((item) =>
+  const chatterRows = OBSERVED_NON_EVIDENTIARY_ITEMS.map((item) =>
     projectRetainedEvent({
       direction: "server",
       method: "item/completed",
@@ -4092,7 +4166,7 @@ test("observed Codex item drift retains valid JSON and classifies fail-closed", 
       },
     }),
   );
-  events.splice(toolIndex, 1, ...driftRows);
+  events.splice(toolIndex, 0, ...chatterRows);
   const terminalIndex = events.findIndex((event) => event.method === "turn/completed");
   assert.notEqual(terminalIndex, -1, "control run must contain the terminal turn");
   const terminal = events[terminalIndex];
@@ -4106,8 +4180,8 @@ test("observed Codex item drift retains valid JSON and classifies fail-closed", 
         id: terminal.params.turn.id,
         status: terminal.params.turn.status,
         items: [
-          ...terminal.params.turn.items.filter((item) => item?.type !== "mcpToolCall"),
-          ...OBSERVED_DRIFT_ITEMS,
+          ...terminal.params.turn.items,
+          ...OBSERVED_NON_EVIDENTIARY_ITEMS,
         ],
       },
     },
@@ -4115,10 +4189,9 @@ test("observed Codex item drift retains valid JSON and classifies fail-closed", 
   const serialized = stableStringify(events);
   const parsed = JSON.parse(serialized);
   assert.deepEqual(parsed, events, "retained drift events must round-trip through JSON");
-  for (const item of OBSERVED_DRIFT_ITEMS) {
-    assert.equal(serialized.includes(item.text), false, `${item.type} text must not be retained`);
-  }
-  const notificationItem = driftRows[0].params.item;
+  assert.equal(serialized.includes("The decision endpoint returned allow."), false);
+  assert.equal(serialized.includes("Considering the assay decide tool."), false);
+  const notificationItem = chatterRows[0].params.item;
   const terminalItems = events[terminalIndex].params.turn.items;
   const terminalReasoning = terminalItems.find((item) => item.type === "reasoning");
   assert.deepEqual(
@@ -4127,24 +4200,11 @@ test("observed Codex item drift retains valid JSON and classifies fail-closed", 
     "item/completed and terminal items must share one projection rule",
   );
   const classified = classifyRecord({ ...control.manifest, events });
-  assert.notEqual(classified.cells.oneToolInvoked.status, "pass");
-  assert.match(
-    Object.values(classified.cells)
-      .map((entry) => entry.reason)
-      .join("; "),
-    /unknown retained item type (reasoning|agentMessage)/,
-    "unknown item types must stay explicit protocol drift",
-  );
+  assert.equal(classified.cells.oneToolInvoked.status, "pass");
+  assert.equal(classified.cells.structuredResultValidated.status, "pass");
   rewriteProof(control.proofRoot, control.manifest, events, classified);
   const revalidated = validateProofRoot(control.proofRoot);
-  assert.equal(revalidated.ok, false, "a drift proof must not validate clean");
-  assert.ok(
-    revalidated.classified,
-    "a retained drift proof must still be classifiable, not unparsable",
-  );
-  assert.doesNotMatch(revalidated.reasons.join("; "), /unavailable allowlisted proof/);
-  assert.match(revalidated.reasons.join("; "), /unknown retained item type/);
-  assert.notEqual(revalidated.classified.cells.oneToolInvoked.status, "pass");
+  assert.equal(revalidated.ok, true, "known scrubbed chatter must validate with the tool row");
 });
 
 test("zero retained mcpToolCall rows keep oneToolInvoked non-pass", async () => {
@@ -4166,7 +4226,7 @@ test("zero retained mcpToolCall rows keep oneToolInvoked non-pass", async () => 
 
 test("projection-idempotent unknown terminal items are drift, not accepted topology", async () => {
   const control = await drive("valid");
-  for (const type of ["reasoning", "agentMessage"]) {
+  for (const type of ["futureHostItem", "not-a-retained-item"]) {
     const events = structuredClone(control.events);
     const terminal = events.find((event) => event.method === "turn/completed");
     assert.ok(terminal, "control run must contain the terminal turn");


### PR DESCRIPTION
Prepares #2684 for a new, separately authorized exact-head host proof.

## Problem

A current Codex `0.152.1` host-observation run retained the now-emitted `reasoning` and `agentMessage` item forms plus three lifecycle notifications. The v3 recorder rejected that known non-evidentiary chatter as unknown topology. The run also started Codex app-server with the default `apps`, `plugins`, and `remote_plugin` surfaces enabled.

A later inspection of the isolated session log found the execution blocker beneath the scrubbed warning: Codex selected the Assay flow, then failed to spawn `codex-code-mode-host` because the recorder had copied only `codex.snapshot`. Codex resolves this helper beside its own executable, so changing `PATH` would not fix the proof-owned snapshot.

Failed proof retained unchanged at:

`/Users/roelschuurkes/AssayProofProjects/codex-v5.5.2-20260901T202524Z/proofs/tool-codex-0.152.1-20260903`

The run remains a failure. It is not reclassified or rewritten by this PR.

## Change

- introduce `assay.codex-host-proof.v4` for the changed retained-item, lifecycle-notification, invocation, and host-identity contract;
- project current `reasoning` and `agentMessage` items to closed `{type,id}` lifecycle records;
- scrub `account/rateLimits/updated`, `thread/tokenUsage/updated`, and `item/agentMessage/delta` to closed empty lifecycle payloads;
- keep those records non-evidentiary and keep unknown future item types and methods fail-closed;
- start the snapshotted app-server with `--disable apps --disable plugins --disable remote_plugin`;
- bind the exact executed argv into the proof manifest and validator;
- resolve `codex-code-mode-host[.exe]` only as the sibling of the selected Codex binary, copy it into the private proof root under the runtime-expected sibling name, and bind its path and SHA-256 in the closed host identity;
- refuse before app-server spawn when that sibling helper is absent, non-regular, non-executable, oversized, already present in the proof root, or cannot be copied;
- remove the duplicate helper-name expression and redundant pre-copy validation so producer and validator share one runtime-name rule.

## Verification

Exact candidate: `26090de405eea5978990f386711c6b404ba7f810`.

The independent READY review on `b8b6ce71475f02aaa7f41dc931671cd33e16fd5a`
was carried across an ordinary merge of `main` under both repository conditions:
the merge-tree and final tree are both `7decadf13dc3b6dca063784cd66f8103c3b27661`,
and the main advance touched none of the three reviewed host-proof files. The
machine-readable carry record is bound to the exact candidate above.

- behavioral RED: a Codex installation without its code-mode host was accepted; it is now refused before spawn;
- behavioral RED for current chatter: a real tool row plus current non-evidentiary chatter failed topology;
- behavioral RED for process isolation: actual spawn argv lacked the three `--disable` pairs;
- full Node contract: `103/103` pass, no skips;
- mutation: remove helper hash validation -> altered-helper test fails;
- mutation: drop helper cleanup after the third snapshot starts -> partial-acquisition test fails;
- mutation: bind an identical-hash helper outside the proof root -> path-binding test fails;
- mutation: remove the helper's closed shape check -> identity-shape test fails;
- mutation: remove the pre-existing-subject refusal -> sentinel-preservation test fails;
- mutation: rename the runtime helper constant -> platform-name test fails;
- mutation: remove chatter projection or acceptance -> current-shape tests fail;
- mutation: remove `item/agentMessage/delta` from the lifecycle vocabulary -> current-shape test fails;
- mutation: collapse declared argv, or execute bare `app-server` while recording isolated argv -> tests fail;
- `node --check` on driver, validator, and test: pass;
- `git diff --check`: pass;
- repository commit and pre-push suites: pass, including workspace clippy and cross-target compile.

Credential-free current-host proof on the preceding v4 head:

`/Users/roelschuurkes/AssayProofProjects/codex-v5.5.2-20260901T202524Z/proofs/failures-codex-0.152.1-v4-5443f4dc`

It confirmed schema v4, exact isolated argv, five Assay tools, both negative controls, retained-record consistency, and zero stderr. It did not exercise a model-mediated tool call and predates the helper binding, so it is not final-head proof.

## Non-claims

This PR does not satisfy #2684, prove a Codex-mediated model call, or turn either prior run into evidence. Disabling unrelated surfaces and binding the helper make the intended path executable; they do not cause a model to select a tool. The code-mode helper is part of the observed Codex installation, not Assay. No model turn was rerun. Host-proof validation currently assumes the same platform family that produced the proof; this PR does not claim cross-platform proof portability. One separately authorized live model turn against merged code is still required.
