### PR TITLE
ci: give kernel lint a measured timeout class

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -97,7 +97,10 @@ jobs:
   lint:
     name: Lint (pre-commit)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # The all-files hook catalogue has measured warm runs above 9 minutes and cold
+    # cargo-deny setup adds about 2 minutes. Keep a bounded 15-minute class so
+    # healthy variance does not turn into a cancelled, false-red summary (#2760).
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -537,6 +537,15 @@ repos:
         # 360-minute default; this hook rejects that, wrong classes, and eBPF drift.
         files: ^(scripts/ci/test-ci-job-timeouts-contract\.sh|\.github/workflows/ci\.yml|\.pre-commit-config\.yaml)$
 
+      - id: kernel-matrix-job-timeout-contract-self-test
+        name: Kernel matrix lint timeout contract
+        entry: bash scripts/ci/test-kernel-matrix-job-timeouts-contract.sh --self-test
+        language: system
+        pass_filenames: false
+        # The all-files catalogue regularly needs more than the old ten-minute ceiling.
+        # Pin the measured bounded class and the summary's cancelled/failure handling together.
+        files: ^(scripts/ci/test-kernel-matrix-job-timeouts-contract\.sh|\.github/workflows/kernel-matrix\.yml|\.pre-commit-config\.yaml)$
+
       - id: mcp-preflight-windows-contract-self-test
         name: Native Windows MCP preflight workflow contract
         entry: bash scripts/ci/test-mcp-preflight-windows-contract.sh --self-test

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -1529,6 +1529,7 @@ seed_case "$case_root"
 CASE_ROOT="$case_root" python3 - <<'PY'
 import os
 from pathlib import Path
+import re
 
 path = Path(os.environ["CASE_ROOT"]) / ".github/workflows/kernel-matrix.yml"
 source = "run: ./scripts/ci/install-cargo-deny.sh"
@@ -1536,14 +1537,28 @@ replacement = "run: echo inline-parser-sentinel"
 text = path.read_text(encoding="utf-8")
 if text.count(source) != 1:
     raise SystemExit(f"inline run anchor is not unique: {source!r}")
-lint_steps_anchor = (
-    "  lint:\n    name: Lint (pre-commit)\n    runs-on: ubuntu-latest\n"
-    "    timeout-minutes: 10\n    permissions:\n      contents: read\n    steps:\n"
+lint_job_anchor = "  lint:\n    name: Lint (pre-commit)\n    runs-on: ubuntu-latest\n"
+if text.count(lint_job_anchor) != 1:
+    raise SystemExit(f"lint job anchor is not unique: {lint_job_anchor!r}")
+lint_start = text.index(lint_job_anchor)
+next_job = re.search(
+    r"^  [A-Za-z0-9_-]+:\n",
+    text[lint_start + len(lint_job_anchor) :],
+    re.MULTILINE,
 )
-if text.count(lint_steps_anchor) != 1:
-    raise SystemExit(f"lint steps anchor is not unique: {lint_steps_anchor!r}")
-text = text.replace(source, replacement, 1)
-text = text.replace(
+lint_end = (
+    lint_start + len(lint_job_anchor) + next_job.start()
+    if next_job is not None
+    else len(text)
+)
+lint_block = text[lint_start:lint_end]
+lint_steps_anchor = "    steps:\n"
+if lint_block.count(lint_steps_anchor) != 1:
+    raise SystemExit(f"lint steps anchor is not unique in lint job: {lint_steps_anchor!r}")
+if lint_block.count(source) != 1:
+    raise SystemExit(f"inline run anchor is not unique in lint job: {source!r}")
+lint_block = lint_block.replace(source, replacement, 1)
+lint_block = lint_block.replace(
     lint_steps_anchor,
     lint_steps_anchor.replace(
         "    steps:\n",
@@ -1551,6 +1566,7 @@ text = text.replace(
     ),
     1,
 )
+text = text[:lint_start] + lint_block + text[lint_end:]
 path.write_text(text, encoding="utf-8")
 PY
 inner_probe_count_path="$case_root/inner-structural-probe-count"

--- a/scripts/ci/test-kernel-matrix-job-timeouts-contract.sh
+++ b/scripts/ci/test-kernel-matrix-job-timeouts-contract.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Pins the bounded lint timeout and fail-closed summary in kernel-matrix.yml (#2760).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${1:-${ROOT}/.github/workflows/kernel-matrix.yml}"
+SELF_TEST_TMP=""
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+validate() {
+  local workflow="$1"
+  [[ -f "${workflow}" ]] || fail "missing workflow ${workflow}"
+
+  ruby -ryaml - "${workflow}" <<'RUBY'
+path = ARGV.fetch(0)
+doc = YAML.safe_load_file(path, aliases: false)
+abort "kernel-matrix.yml must be a mapping" unless doc.is_a?(Hash)
+
+jobs = doc.fetch("jobs")
+abort "kernel-matrix.yml jobs must be a mapping" unless jobs.is_a?(Hash)
+
+lint = jobs.fetch("lint")
+abort "lint job must be a mapping" unless lint.is_a?(Hash)
+timeout = lint["timeout-minutes"]
+abort "lint: timeout-minutes must be the measured 15-minute class, got #{timeout.inspect}" unless timeout == 15
+
+summary = jobs.fetch("summary")
+abort "summary job must be a mapping" unless summary.is_a?(Hash)
+abort "summary must stay fail-closed with if: always()" unless summary["if"] == "always()"
+needs = Array(summary["needs"]).map(&:to_s)
+abort "summary must consume the lint result" unless needs.include?("lint")
+
+steps = summary.fetch("steps")
+abort "summary steps must be an array" unless steps.is_a?(Array)
+report = steps.find { |step| step.is_a?(Hash) && step["name"] == "Report Status" }
+abort "summary must keep the Report Status step" unless report
+env = report.fetch("env")
+abort "Report Status env must be a mapping" unless env.is_a?(Hash)
+expected_lint_result = "${{ needs.lint.result }}"
+abort "Report Status must read needs.lint.result" unless env["LINT_RESULT"] == expected_lint_result
+run = report.fetch("run")
+abort "Report Status run must be a string" unless run.is_a?(String)
+guard = 'if [ "${LINT_RESULT}" != "success" ]; then'
+abort "Report Status must fail closed when lint is not successful" unless run.include?(guard)
+
+puts "kernel-matrix timeout contract=passed (lint=15m; summary fail-closed)"
+RUBY
+}
+
+self_test() {
+  validate "${WORKFLOW}" >/dev/null
+  SELF_TEST_TMP="$(mktemp -d)"
+  trap 'rm -rf -- "${SELF_TEST_TMP:?}"' EXIT
+
+  run_mutation() {
+    local name="$1"
+    local mutation="$2"
+    local candidate="${SELF_TEST_TMP}/${name}.yml"
+    cp "${WORKFLOW}" "${candidate}"
+    ruby -ryaml - "${candidate}" "${mutation}" <<'RUBY'
+path, mutation = ARGV
+doc = YAML.safe_load_file(path, aliases: false)
+jobs = doc.fetch("jobs")
+lint = jobs.fetch("lint")
+summary = jobs.fetch("summary")
+report = summary.fetch("steps").find { |step| step["name"] == "Report Status" }
+
+case mutation
+when "missing-timeout"
+  lint.delete("timeout-minutes")
+when "short-timeout"
+  lint["timeout-minutes"] = 10
+when "wrong-timeout-class"
+  lint["timeout-minutes"] = 20
+when "summary-not-always"
+  summary["if"] = "success()"
+when "summary-drops-lint"
+  summary["needs"] = Array(summary["needs"]).reject { |need| need.to_s == "lint" }
+when "summary-reads-wrong-result"
+  report.fetch("env")["LINT_RESULT"] = "${{ needs.check-ebpf-changes.result }}"
+when "summary-drops-lint-guard"
+  report["run"] = report.fetch("run").sub(
+    /\n\s*if \[ "\$\{LINT_RESULT\}" != "success" \]; then\n\s*echo "Lint did not complete successfully: \$\{LINT_RESULT\}"\n\s*exit 1\n\s*fi\n/,
+    "\n"
+  )
+else
+  abort "unknown mutation #{mutation}"
+end
+
+File.write(path, YAML.dump(doc))
+RUBY
+    if validate "${candidate}" >/dev/null 2>&1; then
+      echo "mutation did not bite: ${name}" >&2
+      exit 1
+    fi
+    echo "ok    ${name}"
+  }
+
+  run_mutation missing-timeout missing-timeout
+  run_mutation short-timeout short-timeout
+  run_mutation wrong-timeout-class wrong-timeout-class
+  run_mutation summary-not-always summary-not-always
+  run_mutation summary-drops-lint summary-drops-lint
+  run_mutation summary-reads-wrong-result summary-reads-wrong-result
+  run_mutation summary-drops-lint-guard summary-drops-lint-guard
+  echo "kernel-matrix timeout contract self-test=passed"
+}
+
+if [[ "${2:-}" == "--self-test" || "${1:-}" == "--self-test" ]]; then
+  [[ "${1:-}" == "--self-test" ]] && WORKFLOW="${ROOT}/.github/workflows/kernel-matrix.yml"
+  self_test
+else
+  validate "${WORKFLOW}"
+fi


### PR DESCRIPTION
Fixes #2760.

## Contract

The `kernel-matrix.yml` lint job uses a bounded 15-minute timeout class. Measured warm runs reached 9m13s, while cold cargo-deny setup added about two minutes; the previous 10-minute class cancelled both cold and slow-warm healthy runs. `Kernel Matrix Summary` remains fail-closed for cancelled, timed-out, or failed lint.

A dedicated contract owns the timeout and the summary wiring together. It rejects a missing, short, or unmeasured timeout class; loss of `if: always()`; loss of the lint dependency/result; and loss of the non-success guard.

## RED to GREEN

- RED on `origin/main`: `lint: timeout-minutes must be the measured 15-minute class, got 10`.
- GREEN: `bash scripts/ci/test-kernel-matrix-job-timeouts-contract.sh --self-test`.
- Seven mutations bite: missing timeout, 10 minutes, 20 minutes, non-always summary, dropped lint need, wrong result source, and dropped fail-closed guard.

## Verification

- Full matching pre-commit catalogue: passed in-band, twice (explicit run and commit hook).
- `actionlint`, `shellcheck`, `cargo fmt --check`: passed.
- `bash scripts/ci/test-ci-programme-truth.sh`: passed.
- `bash scripts/ci/test-ci-job-timeouts-contract.sh --self-test`: passed.
- `git diff --check`: passed.

The first full pre-push run exposed one stale test-fixture anchor that embedded
the old 10-minute value. The follow-up commit bounds that structural mutation to
the lint job without owning the timeout value itself. Its hardening suite passes
110 cases and 23 structural probes, and the final full pre-push catalogue passed.

Hosted proof on exact head `5859c6aae85c553c268acb87a60eae163c771ae9`:
`Lint (pre-commit)` passed in 10m55s, including 7m53s in the all-files step. The
old 10-minute job ceiling would have cancelled this healthy run before completion.
An unrelated pre-existing Codex host-proof `EPIPE` race failed once and passed on
one bounded rerun; it is tracked separately in #2762 rather than folded into this
timeout-only change.

## Non-claims

- This does not identify or remove a failing hook.
- It does not cache or relocate cargo-deny.
- It does not weaken, skip, or make lint continue-on-error.
- A green hosted run is supporting evidence; it does not prove every future run fits the bound.
