### PR TITLE
fix(ci): fail-closed when Codex host-proof stdin closes before elicitation

### DIFF
--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -659,7 +659,8 @@ export async function runProof(options) {
         childAlive &&
         child.stdin &&
         !child.stdin.destroyed &&
-        child.stdin.writable,
+        child.stdin.writable &&
+        !child.stdin.writableEnded,
     );
 
   let stdinFailureNoted = false;
@@ -687,20 +688,54 @@ export async function runProof(options) {
     child.stdin.on("error", onChildStdinError);
   }
 
-  const writeChildStdin = (payload) => {
+  const dropClientWrite = (id) => {
+    if (id != null) {
+      pending.delete(id);
+    }
+    for (let i = events.length - 1; i >= 0; i -= 1) {
+      const event = events[i];
+      if (event.direction !== "client") {
+        continue;
+      }
+      if (id != null ? event.id !== id : event.method !== "initialized") {
+        continue;
+      }
+      const encoded = Buffer.byteLength(JSON.stringify(event), "utf8");
+      events.splice(i, 1);
+      retainedBytes = Math.max(0, retainedBytes - encoded);
+      break;
+    }
+  };
+
+  let inFlightWrites = 0;
+  const writeChildStdin = (payload, onFailed) => {
     if (!childStdinIsWritable()) {
-      return noteStdinFailure("child stdin is not writable");
-    }
-    try {
-      child.stdin.write(encode(payload));
-    } catch {
-      return noteStdinFailure("child stdin write failed");
-    }
-    if (stdinFailureNoted) {
+      noteStdinFailure("child stdin is not writable");
+      onFailed?.();
       return false;
     }
-    if (!child.stdin || child.stdin.destroyed || !child.stdin.writable) {
-      return noteStdinFailure("child stdin is not writable");
+    let encoded;
+    try {
+      encoded = encode(payload);
+    } catch {
+      noteStdinFailure("child stdin write failed");
+      onFailed?.();
+      return false;
+    }
+    inFlightWrites += 1;
+    try {
+      child.stdin.write(encoded, (err) => {
+        inFlightWrites = Math.max(0, inFlightWrites - 1);
+        if (err) {
+          noteStdinFailure("child stdin error");
+          onFailed?.();
+        }
+      });
+    } catch {
+      inFlightWrites = Math.max(0, inFlightWrites - 1);
+      noteStdinFailure("child stdin write failed");
+      onFailed?.();
+      return false;
     }
     return true;
   };
@@ -769,7 +804,7 @@ export async function runProof(options) {
             content: {},
           },
         };
-        if (writeChildStdin(reply)) {
+        if (writeChildStdin(reply, () => dropClientWrite(message.id))) {
           if (accepted) {
             acceptedElicitations += 1;
           }
@@ -833,11 +868,11 @@ export async function runProof(options) {
   const send = (method, params) => {
     const id = nextId;
     nextId += 1;
-    if (!writeChildStdin({ id, method, params })) {
-      return id;
-    }
     pending.set(id, method);
     retainEvent(projectRetainedEvent({ direction: "client", method, id, params }));
+    if (!writeChildStdin({ id, method, params }, () => dropClientWrite(id))) {
+      dropClientWrite(id);
+    }
     return id;
   };
 
@@ -884,7 +919,7 @@ export async function runProof(options) {
     });
     await waitFor(1);
     const initialized = { method: "initialized", params: {} };
-    if (writeChildStdin(initialized)) {
+    if (writeChildStdin(initialized, () => dropClientWrite())) {
       retainEvent(projectRetainedEvent({ direction: "client", ...initialized }));
     }
     send("skills/list", { forceReload: true, cwds: [options.projectRoot] });
@@ -986,6 +1021,12 @@ export async function runProof(options) {
   }, 1000);
   childExit = await childClosed;
   clearTimeout(killer);
+  while (inFlightWrites > 0 && Date.now() < runDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  if (inFlightWrites > 0) {
+    noteStdinFailure("child stdin write incomplete");
+  }
 
   return writeProofFiles(options, {
     events,

--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -662,8 +662,26 @@ export async function runProof(options) {
         child.stdin.writable,
     );
 
-  const onChildStdinError = () => {
+  let stdinFailureNoted = false;
+  const noteStdinFailure = (message) => {
+    if (stdinFailureNoted) {
+      return false;
+    }
+    stdinFailureNoted = true;
+    streamUnavailable = true;
+    retainEvent(
+      projectRetainedEvent({
+        direction: "driver",
+        method: "error",
+        params: { message },
+      }),
+    );
     stopChild();
+    return false;
+  };
+
+  const onChildStdinError = () => {
+    noteStdinFailure("child stdin error");
   };
   if (child.stdin) {
     child.stdin.on("error", onChildStdinError);
@@ -671,9 +689,20 @@ export async function runProof(options) {
 
   const writeChildStdin = (payload) => {
     if (!childStdinIsWritable()) {
+      return noteStdinFailure("child stdin is not writable");
+    }
+    try {
+      child.stdin.write(encode(payload));
+    } catch {
+      return noteStdinFailure("child stdin write failed");
+    }
+    if (stdinFailureNoted) {
       return false;
     }
-    return child.stdin.write(encode(payload));
+    if (!child.stdin || child.stdin.destroyed || !child.stdin.writable) {
+      return noteStdinFailure("child stdin is not writable");
+    }
+    return true;
   };
 
   let buffer = "";
@@ -733,9 +762,6 @@ export async function runProof(options) {
         const turnId = turnReply?.result?.turn?.id;
         const accepted =
           elicitationAcceptable(message.params, threadId, turnId) && acceptedElicitations === 0;
-        if (accepted) {
-          acceptedElicitations += 1;
-        }
         const reply = {
           id: message.id,
           result: {
@@ -743,15 +769,19 @@ export async function runProof(options) {
             content: {},
           },
         };
-        writeChildStdin(reply);
-        retainEvent(
-          projectRetainedEvent({
-            direction: "client",
-            method: message.method,
-            id: message.id,
-            result: reply.result,
-          }),
-        );
+        if (writeChildStdin(reply)) {
+          if (accepted) {
+            acceptedElicitations += 1;
+          }
+          retainEvent(
+            projectRetainedEvent({
+              direction: "client",
+              method: message.method,
+              id: message.id,
+              result: reply.result,
+            }),
+          );
+        }
       }
     }
   };
@@ -803,9 +833,11 @@ export async function runProof(options) {
   const send = (method, params) => {
     const id = nextId;
     nextId += 1;
+    if (!writeChildStdin({ id, method, params })) {
+      return id;
+    }
     pending.set(id, method);
     retainEvent(projectRetainedEvent({ direction: "client", method, id, params }));
-    writeChildStdin({ id, method, params });
     return id;
   };
 
@@ -852,8 +884,9 @@ export async function runProof(options) {
     });
     await waitFor(1);
     const initialized = { method: "initialized", params: {} };
-    retainEvent(projectRetainedEvent({ direction: "client", ...initialized }));
-    writeChildStdin(initialized);
+    if (writeChildStdin(initialized)) {
+      retainEvent(projectRetainedEvent({ direction: "client", ...initialized }));
+    }
     send("skills/list", { forceReload: true, cwds: [options.projectRoot] });
     await waitFor(2);
 

--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -653,6 +653,29 @@ export async function runProof(options) {
     stopChild();
   });
 
+  const childStdinIsWritable = () =>
+    Boolean(
+      !stopped &&
+        childAlive &&
+        child.stdin &&
+        !child.stdin.destroyed &&
+        child.stdin.writable,
+    );
+
+  const onChildStdinError = () => {
+    stopChild();
+  };
+  if (child.stdin) {
+    child.stdin.on("error", onChildStdinError);
+  }
+
+  const writeChildStdin = (payload) => {
+    if (!childStdinIsWritable()) {
+      return false;
+    }
+    return child.stdin.write(encode(payload));
+  };
+
   let buffer = "";
   const onLine = (line) => {
     frames += 1;
@@ -720,7 +743,7 @@ export async function runProof(options) {
             content: {},
           },
         };
-        child.stdin.write(encode(reply));
+        writeChildStdin(reply);
         retainEvent(
           projectRetainedEvent({
             direction: "client",
@@ -782,9 +805,7 @@ export async function runProof(options) {
     nextId += 1;
     pending.set(id, method);
     retainEvent(projectRetainedEvent({ direction: "client", method, id, params }));
-    if (!stopped) {
-      child.stdin.write(encode({ id, method, params }));
-    }
+    writeChildStdin({ id, method, params });
     return id;
   };
 
@@ -832,9 +853,7 @@ export async function runProof(options) {
     await waitFor(1);
     const initialized = { method: "initialized", params: {} };
     retainEvent(projectRetainedEvent({ direction: "client", ...initialized }));
-    if (!stopped) {
-      child.stdin.write(encode(initialized));
-    }
+    writeChildStdin(initialized);
     send("skills/list", { forceReload: true, cwds: [options.projectRoot] });
     await waitFor(2);
 

--- a/scripts/ci/fixtures/codex-host-proof/fake-app-server.mjs
+++ b/scripts/ci/fixtures/codex-host-proof/fake-app-server.mjs
@@ -3,6 +3,7 @@
  * Fake Codex app-server stdio child. Protocol-shaped replies only. Never a model.
  */
 import readline from "node:readline";
+import fs from "node:fs";
 import path from "node:path";
 import { DECIDE_INPUT } from "../../codex_host_proof_validator.mjs";
 
@@ -23,6 +24,9 @@ function argValue(flag, fallback) {
 }
 
 const scenario = argValue("--scenario", "valid");
+if (scenario === "close-stdin-then-elicit-exit-0") {
+  process.on("SIGTERM", () => {});
+}
 const projectRoot = argValue("--project-root", process.env.HOME || "/tmp/assay-fake-project");
 const threads = new Map();
 let threadSeq = 0;
@@ -289,6 +293,9 @@ function handle(message) {
         requestedSchema: { type: "object", properties: {} },
       };
     };
+    if (scenario === "close-stdin-then-elicit-exit-0") {
+      fs.closeSync(0);
+    }
     write({
       id: "elicit-1",
       method: "mcpServer/elicitation/request",
@@ -376,6 +383,9 @@ function handle(message) {
       return;
     }
     emitTool();
+    if (scenario === "close-stdin-then-elicit-exit-0") {
+      setImmediate(() => process.exit(0));
+    }
     return;
   }
 }

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -7,11 +7,9 @@
  */
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
-import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { PassThrough } from "node:stream";
 import test from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
@@ -23,9 +21,7 @@ import {
   CELLS,
   DECIDE_INPUT,
   DECIDE_TOOL,
-  EXPECTED_ELICITATION,
   EXPECTED_TOOLS,
-  FAKE_USER_AGENT,
   HARD_MAX_SNAPSHOT_BYTES,
   HOST_SUBJECTS,
   classifyRecord,
@@ -72,237 +68,17 @@ function spawnFakeChild(childArgv, projectRoot) {
   });
 }
 
-function epipeError() {
-  return Object.assign(new Error("write EPIPE"), {
-    errno: -32,
-    code: "EPIPE",
-    syscall: "write",
-  });
-}
-
-function encodeLine(message) {
-  return `${JSON.stringify(message)}\n`;
-}
-
-function statusTools() {
-  return Object.fromEntries(EXPECTED_TOOLS.map((name) => [name, { name, inputSchema: {} }]));
-}
-
-function assayStatusRow(thread) {
-  if (thread.kind === "missing" || thread.kind === "invalid") {
-    return {
-      name: "assay",
-      authStatus: "unsupported",
-      resourceTemplates: [],
-      resources: [],
-      runtimeStatus: "failed",
-      tools: {},
-    };
-  }
-  return {
-    name: "assay",
-    authStatus: "unsupported",
-    resourceTemplates: [],
-    resources: [],
-    runtimeStatus: "connected",
-    tools: statusTools(),
-  };
-}
-
-function canonicalToolItem() {
-  return {
-    type: "mcpToolCall",
-    id: "call-1",
-    server: "assay",
-    tool: DECIDE_TOOL,
-    arguments: { ...DECIDE_INPUT },
-    status: "completed",
-    result: {
-      content: [{ type: "text", text: JSON.stringify({ allowed: true, reason: "Allowed by policy" }) }],
-      structuredContent: null,
-    },
-  };
-}
-
-function elicitAfterCloseChild(mode) {
+function wrapSpawnedStdinWrites(child) {
   const writesAfterClose = { count: 0 };
-  const stdin = new PassThrough();
-  const stdout = new PassThrough();
-  const stderr = new PassThrough();
-  const child = new EventEmitter();
-  child.stdin = stdin;
-  child.stdout = stdout;
-  child.stderr = stderr;
-  let closed = false;
-  let stdinClosed = false;
+  const stdin = child.stdin;
   const nativeWrite = stdin.write.bind(stdin);
   stdin.write = function writeAfterClose(chunk, encoding, cb) {
-    if (stdinClosed) {
+    if (!stdin.writable || stdin.destroyed) {
       writesAfterClose.count += 1;
-      const err = epipeError();
-      queueMicrotask(() => stdin.emit("error", err));
-      if (typeof encoding === "function") {
-        encoding(err);
-      } else if (typeof cb === "function") {
-        cb(err);
-      }
-      return false;
     }
     return nativeWrite(chunk, encoding, cb);
   };
-  const closeStdin = () => {
-    stdinClosed = true;
-    if (mode === "destroy") {
-      stdin.destroy();
-    }
-  };
-  const finish = (code) => {
-    if (closed) {
-      return;
-    }
-    closed = true;
-    child.emit("close", code, null);
-  };
-  child.kill = () => finish(1);
-  const threads = new Map();
-  let threadSeq = 0;
-  const emit = (message) => {
-    stdout.write(encodeLine(message));
-  };
-  const handle = (message) => {
-    const { id, method, params } = message;
-    if (method === "initialize") {
-      emit({
-        id,
-        result: {
-          userAgent: FAKE_USER_AGENT,
-          platformFamily: "unix",
-          platformOs: "linux",
-          codexHome: path.join(process.env.HOME || "/tmp", ".codex-home"),
-        },
-      });
-      return;
-    }
-    if (method === "initialized") {
-      return;
-    }
-    if (method === "skills/list") {
-      const projectRoot = params?.cwds?.[0] ?? "";
-      emit({
-        id,
-        result: {
-          data: [
-            {
-              cwd: projectRoot,
-              errors: [],
-              skills: [
-                {
-                  name: "assay-golden-path",
-                  description: "golden path",
-                  enabled: true,
-                  path: path.join(projectRoot, ".agents/skills/assay-golden-path/SKILL.md"),
-                  scope: "repo",
-                },
-              ],
-            },
-          ],
-        },
-      });
-      return;
-    }
-    if (method === "thread/start") {
-      threadSeq += 1;
-      const threadId = `thread-${threadSeq}`;
-      const assay = params?.config?.mcp_servers?.assay;
-      const command = assay?.command ?? "";
-      const args = assay?.args ?? [];
-      let kind = "primary";
-      if (String(command).includes("missing-assay-mcp-server")) {
-        kind = "missing";
-      } else if (args.some((value) => String(value).includes("missing-policy-root"))) {
-        kind = "invalid";
-      }
-      threads.set(threadId, { kind, cwd: params?.cwd ?? "" });
-      emit({
-        id,
-        result: {
-          cwd: params?.cwd ?? "",
-          approvalPolicy: "on-request",
-          approvalsReviewer: "user",
-          model: "none",
-          modelProvider: "none",
-          sandbox: { type: "readOnly" },
-          thread: {
-            id: threadId,
-            cwd: params?.cwd ?? "",
-            cliVersion: "fake",
-            createdAt: 0,
-            ephemeral: true,
-            modelProvider: "none",
-            preview: "",
-            projectId: null,
-            sessionId: "session-1",
-            source: "appServer",
-            status: { type: "idle" },
-            turns: [],
-            updatedAt: 0,
-          },
-        },
-      });
-      return;
-    }
-    if (method === "mcpServerStatus/list") {
-      const thread = threads.get(params?.threadId);
-      emit({ id, result: { data: [assayStatusRow(thread ?? { kind: "missing" })] } });
-      return;
-    }
-    if (method === "turn/start") {
-      const threadId = params?.threadId;
-      emit({
-        id,
-        result: { turn: { id: "turn-1", items: [], status: "inProgress" } },
-      });
-      closeStdin();
-      const item = canonicalToolItem();
-      emit({
-        id: "elicit-1",
-        method: "mcpServer/elicitation/request",
-        params: {
-          serverName: EXPECTED_ELICITATION.serverName,
-          threadId,
-          turnId: "turn-1",
-          message: EXPECTED_ELICITATION.message,
-          mode: EXPECTED_ELICITATION.mode,
-          requestedSchema: { type: "object", properties: {} },
-        },
-      });
-      emit({
-        method: "item/completed",
-        params: {
-          completedAtMs: 1,
-          threadId,
-          turnId: "turn-1",
-          item,
-        },
-      });
-      emit({
-        method: "turn/completed",
-        params: {
-          threadId,
-          turn: { id: "turn-1", items: [item], status: "completed" },
-        },
-      });
-      queueMicrotask(() => finish(1));
-    }
-  };
-  stdin.on("data", (chunk) => {
-    for (const line of String(chunk).split("\n")) {
-      if (line.trim()) {
-        handle(JSON.parse(line));
-      }
-    }
-  });
-  return { child, writesAfterClose };
+  return writesAfterClose;
 }
 
 function writeMutatedDriver(mutate) {
@@ -315,26 +91,8 @@ function writeMutatedDriver(mutate) {
   return path.join(dir, "codex_host_proof.mjs");
 }
 
-async function runClosedStdinElicit(run, mode) {
-  const projectRoot = seedProject();
-  const proofRoot = scratch();
-  const { child, writesAfterClose } = elicitAfterCloseChild(mode);
-  const result = await run({
-    captureMode: "synthetic-fixture",
-    timeoutMs: 4000,
-    maxBytes: 1_048_576,
-    journey: "tool",
-    allowLiveTurn: false,
-    testOnlyChild: child,
-    proofRoot,
-    projectRoot,
-    assayMcpBin: path.join(projectRoot, "install/bin/assay-mcp-server"),
-  });
-  return { ...result, proofRoot, projectRoot, writesAfterClose };
-}
-
-
-async function drive(scenario, journey = "tool") {
+async function drive(scenario, journey = "tool", options = {}) {
+  const run = options.run ?? runProof;
   const projectRoot = scratch();
   const proofRoot = scratch();
   fs.mkdirSync(path.join(projectRoot, ".agents/skills/assay-golden-path"), {
@@ -345,18 +103,20 @@ async function drive(scenario, journey = "tool") {
     "# disposable canary\n",
   );
   const childArgv = ["node", FAKE, "--scenario", scenario, "--project-root", projectRoot];
-  const result = await runProof({
+  const child = spawnFakeChild(childArgv, projectRoot);
+  const writesAfterClose = options.wrapStdin ? wrapSpawnedStdinWrites(child) : undefined;
+  const result = await run({
     captureMode: "synthetic-fixture",
     timeoutMs: 4000,
     maxBytes: 1_048_576,
     journey,
     allowLiveTurn: false,
-    testOnlyChild: spawnFakeChild(childArgv, projectRoot),
+    testOnlyChild: child,
     proofRoot,
     projectRoot,
     assayMcpBin: path.join(projectRoot, "install/bin/assay-mcp-server"),
   });
-  return { ...result, proofRoot, projectRoot };
+  return { ...result, proofRoot, projectRoot, writesAfterClose };
 }
 
 function seedProject() {
@@ -547,14 +307,25 @@ test("successful tool output plus nonzero child exit: CLI process is nonzero", a
 });
 
 test("closed stdin then elicitation reply is fail-closed, not uncaught EPIPE", async () => {
-  const { classified, manifest, childExitCode, driverOutcome, writesAfterClose } =
-    await runClosedStdinElicit(runProof, "destroy");
-  assert.equal(writesAfterClose.count, 0, "guard must not write a destroyed stdin");
-  assert.equal(childExitCode, 1);
+  const { classified, manifest, events, childExitCode, driverOutcome } = await drive(
+    "close-stdin-then-elicit-exit-0",
+  );
+  assert.equal(
+    clientParams(events, "mcpServer/elicitation/request").length,
+    0,
+    "must not retain a client elicitation reply that was not written",
+  );
+  assert.equal(manifest.streamUnavailable, true);
+  assert.equal(driverOutcome.status, "unavailable");
   assert.notEqual(driverOutcome.exitCode, 0);
-  assert.equal(manifest.childExitCode, 1);
-  assert.notEqual(manifest.driverOutcome.exitCode, 0);
-  assert.equal(classified.cells.oneToolInvoked.status, "pass");
+  assert.notEqual(driverOutcome.status, "pass");
+  assert.equal(childExitCode, 0, "child exit 0 must remain visible so the I/O break is not a kill-fail");
+  assert.notEqual(
+    driverOutcome.status,
+    "pass",
+    "childExitCode 0 must never make the driver pass when stdin closed before elicitation",
+  );
+  assert.notEqual(classified.cells.oneToolInvoked.status, "pass");
   assert.notEqual(classified.externalAttestation, "pass");
 });
 
@@ -572,12 +343,54 @@ test("mutation: removing the child-stdin write guard writes the closed pipe", as
     return src.replace(guardNeedle, "const childStdinIsWritable = () => true;");
   });
   const { runProof: runMutated } = await import(pathToFileURL(mutatedPath).href);
-  const { writesAfterClose, childExitCode, driverOutcome, classified } =
-    await runClosedStdinElicit(runMutated, "destroy");
+  const projectRoot = seedProject();
+  const proofRoot = scratch();
+  const child = spawnFakeChild(
+    ["node", FAKE, "--scenario", "valid", "--project-root", projectRoot],
+    projectRoot,
+  );
+  const writesAfterClose = wrapSpawnedStdinWrites(child);
+  child.stdin.destroy();
+  const result = await runMutated({
+    captureMode: "synthetic-fixture",
+    timeoutMs: 4000,
+    maxBytes: 1_048_576,
+    journey: "discovery",
+    allowLiveTurn: false,
+    testOnlyChild: child,
+    proofRoot,
+    projectRoot,
+    assayMcpBin: path.join(projectRoot, "install/bin/assay-mcp-server"),
+  });
   assert.ok(writesAfterClose.count > 0, "unguarded write must hit closed stdin");
-  assert.equal(childExitCode, 1);
-  assert.notEqual(driverOutcome.exitCode, 0);
-  assert.equal(classified.cells.oneToolInvoked.status, "pass");
+  assert.notEqual(result.driverOutcome.exitCode, 0);
+});
+
+test("mutation: retaining a client elicitation reply after a failed stdin write invents a sent event", async () => {
+  const replyNeedle = "if (writeChildStdin(reply)) {";
+  const mutatedPath = writeMutatedDriver((src) => {
+    assert.match(src, /if \(writeChildStdin\(reply\)\) \{/);
+    return src.replace(replyNeedle, "if (writeChildStdin(reply) || true) {");
+  });
+  const { runProof: runMutated } = await import(pathToFileURL(mutatedPath).href);
+  const { events } = await drive("close-stdin-then-elicit-exit-0", "tool", { run: runMutated });
+  assert.ok(
+    clientParams(events, "mcpServer/elicitation/request").length > 0,
+    "retaining a client elicitation after writeChildStdin false must invent a sent event",
+  );
+});
+
+test("mutation: omitting streamUnavailable on stdin failure hides the I/O break", async () => {
+  const noteNeedle = `    stdinFailureNoted = true;
+    streamUnavailable = true;`;
+  const mutatedPath = writeMutatedDriver((src) => {
+    assert.match(src, /stdinFailureNoted = true;\n    streamUnavailable = true;/);
+    return src.replace(noteNeedle, "    stdinFailureNoted = true;");
+  });
+  const { runProof: runMutated } = await import(pathToFileURL(mutatedPath).href);
+  const { manifest, driverOutcome } = await drive("close-stdin-then-elicit-exit-0", "tool", { run: runMutated });
+  assert.notEqual(manifest.streamUnavailable, true);
+  assert.notEqual(driverOutcome.status, "unavailable");
 });
 
 test("mutation: removing the stdin error handler leaves EPIPE uncaught", () => {

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -336,7 +336,8 @@ test("mutation: removing the child-stdin write guard writes the closed pipe", as
         childAlive &&
         child.stdin &&
         !child.stdin.destroyed &&
-        child.stdin.writable,
+        child.stdin.writable &&
+        !child.stdin.writableEnded,
     );`;
   const mutatedPath = writeMutatedDriver((src) => {
     assert.match(src, /const childStdinIsWritable = \(\) =>/);
@@ -367,10 +368,10 @@ test("mutation: removing the child-stdin write guard writes the closed pipe", as
 });
 
 test("mutation: retaining a client elicitation reply after a failed stdin write invents a sent event", async () => {
-  const replyNeedle = "if (writeChildStdin(reply)) {";
+  const replyNeedle = "if (writeChildStdin(reply, () => dropClientWrite(message.id))) {";
   const mutatedPath = writeMutatedDriver((src) => {
-    assert.match(src, /if \(writeChildStdin\(reply\)\) \{/);
-    return src.replace(replyNeedle, "if (writeChildStdin(reply) || true) {");
+    assert.match(src, /if \(writeChildStdin\(reply, \(\) => dropClientWrite\(message\.id\)\)\) \{/);
+    return src.replace(replyNeedle, "if (writeChildStdin(reply, () => {}) || true) {");
   });
   const { runProof: runMutated } = await import(pathToFileURL(mutatedPath).href);
   const { events } = await drive("close-stdin-then-elicit-exit-0", "tool", { run: runMutated });
@@ -447,6 +448,137 @@ await runProof({
   const result = spawnSync(process.execPath, [script], { encoding: "utf8", timeout: 15_000 });
   assert.notEqual(result.status, 0, "removing the stdin error handler must fail the process");
   assert.match(`${result.stderr}\n${result.stdout}`, /EPIPE/);
+});
+
+test("delayed async EPIPE after elicitation-accept stdin write does not retain a client accept", async () => {
+  const projectRoot = seedProject();
+  const proofRoot = scratch();
+  const child = spawnFakeChild(
+    ["node", FAKE, "--scenario", "valid", "--project-root", projectRoot],
+    projectRoot,
+  );
+  const stdin = child.stdin;
+  const nativeWrite = stdin.write.bind(stdin);
+  stdin.write = function delayedEpipeOnAccept(chunk, encoding, cb) {
+    const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+    let parsed = null;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = null;
+    }
+    const isAccept =
+      parsed &&
+      parsed.method == null &&
+      parsed.result &&
+      parsed.result.action === "accept";
+    if (!isAccept) {
+      return nativeWrite(chunk, encoding, cb);
+    }
+    const err = Object.assign(new Error("write EPIPE"), {
+      errno: -32,
+      code: "EPIPE",
+      syscall: "write",
+    });
+    const callback = typeof encoding === "function" ? encoding : cb;
+    queueMicrotask(() => {
+      if (typeof callback === "function") {
+        callback(err);
+      }
+      stdin.emit("error", err);
+    });
+    return true;
+  };
+  const result = await runProof({
+    captureMode: "synthetic-fixture",
+    timeoutMs: 4000,
+    maxBytes: 1_048_576,
+    journey: "tool",
+    allowLiveTurn: false,
+    testOnlyChild: child,
+    proofRoot,
+    projectRoot,
+    assayMcpBin: path.join(projectRoot, "install/bin/assay-mcp-server"),
+  });
+  assert.equal(
+    clientParams(result.events, "mcpServer/elicitation/request").length,
+    0,
+    "must not retain a client elicitation accept whose write later EPIPE'd",
+  );
+  assert.equal(result.manifest.streamUnavailable, true);
+  assert.equal(result.driverOutcome.status, "unavailable");
+  assert.notEqual(result.driverOutcome.exitCode, 0);
+  const driverErrors = result.events.filter(
+    (event) => event.direction === "driver" && event.method === "error",
+  );
+  assert.equal(driverErrors.length, 1, "callback-error and stdin error must share one idempotent sink");
+});
+
+test("stdin write() returning false (backpressure) is not unavailable", async () => {
+  const { EventEmitter } = await import("node:events");
+  const { PassThrough } = await import("node:stream");
+  const projectRoot = seedProject();
+  const proofRoot = scratch();
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const child = new EventEmitter();
+  child.stdin = stdin;
+  child.stdout = stdout;
+  child.stderr = stderr;
+  let closed = false;
+  const closeChild = () => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    child.emit("close", 0, null);
+  };
+  child.kill = () => closeChild();
+  stdin.on("finish", closeChild);
+  stdin.write = function backpressureWrite(chunk, encoding, cb) {
+    const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+    for (const line of text.split("\n")) {
+      if (!line.trim()) {
+        continue;
+      }
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (message.method === "initialize") {
+        stdout.write(
+          `${JSON.stringify({ id: message.id, result: { userAgent: "backpressure-test" } })}\n`,
+        );
+      } else if (message.method === "skills/list") {
+        stdout.write(`${JSON.stringify({ id: message.id, result: { data: [] } })}\n`);
+      }
+    }
+    const callback = typeof encoding === "function" ? encoding : cb;
+    if (typeof callback === "function") {
+      queueMicrotask(() => callback());
+    }
+    return false;
+  };
+  const result = await runProof({
+    captureMode: "synthetic-fixture",
+    timeoutMs: 4000,
+    maxBytes: 1_048_576,
+    journey: "discovery",
+    allowLiveTurn: false,
+    testOnlyChild: child,
+    proofRoot,
+    projectRoot,
+    assayMcpBin: path.join(projectRoot, "install/bin/assay-mcp-server"),
+  });
+  assert.notEqual(result.manifest.streamUnavailable, true);
+  assert.equal(
+    result.events.some((event) => event.direction === "driver" && event.method === "error"),
+    false,
+    "write() returning false must not invent a stdin-failure driver error",
+  );
 });
 
 test("synthetic events never validate as actual-host proof", async () => {

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -7,11 +7,13 @@
  */
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   parseArgs,
   resolveHostIdentity as resolveHostIdentityProduction,
@@ -21,7 +23,9 @@ import {
   CELLS,
   DECIDE_INPUT,
   DECIDE_TOOL,
+  EXPECTED_ELICITATION,
   EXPECTED_TOOLS,
+  FAKE_USER_AGENT,
   HARD_MAX_SNAPSHOT_BYTES,
   HOST_SUBJECTS,
   classifyRecord,
@@ -67,6 +71,268 @@ function spawnFakeChild(childArgv, projectRoot) {
     },
   });
 }
+
+function epipeError() {
+  return Object.assign(new Error("write EPIPE"), {
+    errno: -32,
+    code: "EPIPE",
+    syscall: "write",
+  });
+}
+
+function encodeLine(message) {
+  return `${JSON.stringify(message)}\n`;
+}
+
+function statusTools() {
+  return Object.fromEntries(EXPECTED_TOOLS.map((name) => [name, { name, inputSchema: {} }]));
+}
+
+function assayStatusRow(thread) {
+  if (thread.kind === "missing" || thread.kind === "invalid") {
+    return {
+      name: "assay",
+      authStatus: "unsupported",
+      resourceTemplates: [],
+      resources: [],
+      runtimeStatus: "failed",
+      tools: {},
+    };
+  }
+  return {
+    name: "assay",
+    authStatus: "unsupported",
+    resourceTemplates: [],
+    resources: [],
+    runtimeStatus: "connected",
+    tools: statusTools(),
+  };
+}
+
+function canonicalToolItem() {
+  return {
+    type: "mcpToolCall",
+    id: "call-1",
+    server: "assay",
+    tool: DECIDE_TOOL,
+    arguments: { ...DECIDE_INPUT },
+    status: "completed",
+    result: {
+      content: [{ type: "text", text: JSON.stringify({ allowed: true, reason: "Allowed by policy" }) }],
+      structuredContent: null,
+    },
+  };
+}
+
+function elicitAfterCloseChild(mode) {
+  const writesAfterClose = { count: 0 };
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const child = new EventEmitter();
+  child.stdin = stdin;
+  child.stdout = stdout;
+  child.stderr = stderr;
+  let closed = false;
+  let stdinClosed = false;
+  const nativeWrite = stdin.write.bind(stdin);
+  stdin.write = function writeAfterClose(chunk, encoding, cb) {
+    if (stdinClosed) {
+      writesAfterClose.count += 1;
+      const err = epipeError();
+      queueMicrotask(() => stdin.emit("error", err));
+      if (typeof encoding === "function") {
+        encoding(err);
+      } else if (typeof cb === "function") {
+        cb(err);
+      }
+      return false;
+    }
+    return nativeWrite(chunk, encoding, cb);
+  };
+  const closeStdin = () => {
+    stdinClosed = true;
+    if (mode === "destroy") {
+      stdin.destroy();
+    }
+  };
+  const finish = (code) => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    child.emit("close", code, null);
+  };
+  child.kill = () => finish(1);
+  const threads = new Map();
+  let threadSeq = 0;
+  const emit = (message) => {
+    stdout.write(encodeLine(message));
+  };
+  const handle = (message) => {
+    const { id, method, params } = message;
+    if (method === "initialize") {
+      emit({
+        id,
+        result: {
+          userAgent: FAKE_USER_AGENT,
+          platformFamily: "unix",
+          platformOs: "linux",
+          codexHome: path.join(process.env.HOME || "/tmp", ".codex-home"),
+        },
+      });
+      return;
+    }
+    if (method === "initialized") {
+      return;
+    }
+    if (method === "skills/list") {
+      const projectRoot = params?.cwds?.[0] ?? "";
+      emit({
+        id,
+        result: {
+          data: [
+            {
+              cwd: projectRoot,
+              errors: [],
+              skills: [
+                {
+                  name: "assay-golden-path",
+                  description: "golden path",
+                  enabled: true,
+                  path: path.join(projectRoot, ".agents/skills/assay-golden-path/SKILL.md"),
+                  scope: "repo",
+                },
+              ],
+            },
+          ],
+        },
+      });
+      return;
+    }
+    if (method === "thread/start") {
+      threadSeq += 1;
+      const threadId = `thread-${threadSeq}`;
+      const assay = params?.config?.mcp_servers?.assay;
+      const command = assay?.command ?? "";
+      const args = assay?.args ?? [];
+      let kind = "primary";
+      if (String(command).includes("missing-assay-mcp-server")) {
+        kind = "missing";
+      } else if (args.some((value) => String(value).includes("missing-policy-root"))) {
+        kind = "invalid";
+      }
+      threads.set(threadId, { kind, cwd: params?.cwd ?? "" });
+      emit({
+        id,
+        result: {
+          cwd: params?.cwd ?? "",
+          approvalPolicy: "on-request",
+          approvalsReviewer: "user",
+          model: "none",
+          modelProvider: "none",
+          sandbox: { type: "readOnly" },
+          thread: {
+            id: threadId,
+            cwd: params?.cwd ?? "",
+            cliVersion: "fake",
+            createdAt: 0,
+            ephemeral: true,
+            modelProvider: "none",
+            preview: "",
+            projectId: null,
+            sessionId: "session-1",
+            source: "appServer",
+            status: { type: "idle" },
+            turns: [],
+            updatedAt: 0,
+          },
+        },
+      });
+      return;
+    }
+    if (method === "mcpServerStatus/list") {
+      const thread = threads.get(params?.threadId);
+      emit({ id, result: { data: [assayStatusRow(thread ?? { kind: "missing" })] } });
+      return;
+    }
+    if (method === "turn/start") {
+      const threadId = params?.threadId;
+      emit({
+        id,
+        result: { turn: { id: "turn-1", items: [], status: "inProgress" } },
+      });
+      closeStdin();
+      const item = canonicalToolItem();
+      emit({
+        id: "elicit-1",
+        method: "mcpServer/elicitation/request",
+        params: {
+          serverName: EXPECTED_ELICITATION.serverName,
+          threadId,
+          turnId: "turn-1",
+          message: EXPECTED_ELICITATION.message,
+          mode: EXPECTED_ELICITATION.mode,
+          requestedSchema: { type: "object", properties: {} },
+        },
+      });
+      emit({
+        method: "item/completed",
+        params: {
+          completedAtMs: 1,
+          threadId,
+          turnId: "turn-1",
+          item,
+        },
+      });
+      emit({
+        method: "turn/completed",
+        params: {
+          threadId,
+          turn: { id: "turn-1", items: [item], status: "completed" },
+        },
+      });
+      queueMicrotask(() => finish(1));
+    }
+  };
+  stdin.on("data", (chunk) => {
+    for (const line of String(chunk).split("\n")) {
+      if (line.trim()) {
+        handle(JSON.parse(line));
+      }
+    }
+  });
+  return { child, writesAfterClose };
+}
+
+function writeMutatedDriver(mutate) {
+  const dir = scratch();
+  fs.writeFileSync(path.join(dir, "codex_host_proof.mjs"), mutate(DRIVER_SRC));
+  fs.copyFileSync(
+    path.join(HERE, "codex_host_proof_validator.mjs"),
+    path.join(dir, "codex_host_proof_validator.mjs"),
+  );
+  return path.join(dir, "codex_host_proof.mjs");
+}
+
+async function runClosedStdinElicit(run, mode) {
+  const projectRoot = seedProject();
+  const proofRoot = scratch();
+  const { child, writesAfterClose } = elicitAfterCloseChild(mode);
+  const result = await run({
+    captureMode: "synthetic-fixture",
+    timeoutMs: 4000,
+    maxBytes: 1_048_576,
+    journey: "tool",
+    allowLiveTurn: false,
+    testOnlyChild: child,
+    proofRoot,
+    projectRoot,
+    assayMcpBin: path.join(projectRoot, "install/bin/assay-mcp-server"),
+  });
+  return { ...result, proofRoot, projectRoot, writesAfterClose };
+}
+
 
 async function drive(scenario, journey = "tool") {
   const projectRoot = scratch();
@@ -278,6 +544,96 @@ test("successful tool output plus nonzero child exit: CLI process is nonzero", a
   const cli = driveCli("exit-1-after-success");
   assert.notEqual(cli.status, 0, "driver CLI must not exit 0 when the child exits 1");
   assert.match(cli.stdout, /"exitCode":1/);
+});
+
+test("closed stdin then elicitation reply is fail-closed, not uncaught EPIPE", async () => {
+  const { classified, manifest, childExitCode, driverOutcome, writesAfterClose } =
+    await runClosedStdinElicit(runProof, "destroy");
+  assert.equal(writesAfterClose.count, 0, "guard must not write a destroyed stdin");
+  assert.equal(childExitCode, 1);
+  assert.notEqual(driverOutcome.exitCode, 0);
+  assert.equal(manifest.childExitCode, 1);
+  assert.notEqual(manifest.driverOutcome.exitCode, 0);
+  assert.equal(classified.cells.oneToolInvoked.status, "pass");
+  assert.notEqual(classified.externalAttestation, "pass");
+});
+
+test("mutation: removing the child-stdin write guard writes the closed pipe", async () => {
+  const guardNeedle = `const childStdinIsWritable = () =>
+    Boolean(
+      !stopped &&
+        childAlive &&
+        child.stdin &&
+        !child.stdin.destroyed &&
+        child.stdin.writable,
+    );`;
+  const mutatedPath = writeMutatedDriver((src) => {
+    assert.match(src, /const childStdinIsWritable = \(\) =>/);
+    return src.replace(guardNeedle, "const childStdinIsWritable = () => true;");
+  });
+  const { runProof: runMutated } = await import(pathToFileURL(mutatedPath).href);
+  const { writesAfterClose, childExitCode, driverOutcome, classified } =
+    await runClosedStdinElicit(runMutated, "destroy");
+  assert.ok(writesAfterClose.count > 0, "unguarded write must hit closed stdin");
+  assert.equal(childExitCode, 1);
+  assert.notEqual(driverOutcome.exitCode, 0);
+  assert.equal(classified.cells.oneToolInvoked.status, "pass");
+});
+
+test("mutation: removing the stdin error handler leaves EPIPE uncaught", () => {
+  const handlerNeedle = `  if (child.stdin) {
+    child.stdin.on("error", onChildStdinError);
+  }
+`;
+  const mutatedPath = writeMutatedDriver((src) => {
+    assert.match(src, /child\.stdin\.on\("error", onChildStdinError\)/);
+    return src.replace(handlerNeedle, "");
+  });
+  const script = path.join(scratch(), "run-handler-mutation.mjs");
+  fs.writeFileSync(
+    script,
+    `import { runProof } from ${JSON.stringify(pathToFileURL(mutatedPath).href)};
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+
+const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "assay-2684-"));
+fs.mkdirSync(path.join(projectRoot, ".agents/skills/assay-golden-path"), { recursive: true });
+fs.writeFileSync(path.join(projectRoot, ".agents/skills/assay-golden-path/SKILL.md"), "# disposable canary\\n");
+const proofRoot = fs.mkdtempSync(path.join(os.tmpdir(), "assay-2684-"));
+const stdin = new PassThrough();
+const stdout = new PassThrough();
+const stderr = new PassThrough();
+const child = new EventEmitter();
+child.stdin = stdin;
+child.stdout = stdout;
+child.stderr = stderr;
+child.kill = () => child.emit("close", 1, null);
+stdin.write = (_chunk, encoding, cb) => {
+  const err = Object.assign(new Error("write EPIPE"), { errno: -32, code: "EPIPE", syscall: "write" });
+  queueMicrotask(() => stdin.emit("error", err));
+  if (typeof encoding === "function") encoding(err);
+  else if (typeof cb === "function") cb(err);
+  return false;
+};
+await runProof({
+  captureMode: "synthetic-fixture",
+  timeoutMs: 4000,
+  maxBytes: 1048576,
+  journey: "discovery",
+  allowLiveTurn: false,
+  testOnlyChild: child,
+  proofRoot,
+  projectRoot,
+  assayMcpBin: path.join(projectRoot, "install/bin/assay-mcp-server"),
+});
+`,
+  );
+  const result = spawnSync(process.execPath, [script], { encoding: "utf8", timeout: 15_000 });
+  assert.notEqual(result.status, 0, "removing the stdin error handler must fail the process");
+  assert.match(`${result.stderr}\n${result.stdout}`, /EPIPE/);
 });
 
 test("synthetic events never validate as actual-host proof", async () => {


### PR DESCRIPTION
Fixes #2762.

Wait-gate: `origin/main` `287d7f19c426fc65dca173d4b6485b31dbe39ab5` (merge #2759). Head `5a0eb953c50626ddcd668946ce1cdc87e22293e1` on `ruley/2762-codex-host-proof-epipe`. Worktree `/tmp/assay-ruley-2762-wt`. Still draft; do not ready or merge.

## Change

Node Writable write-contract for Codex host-proof stdin:

- `write(chunk, cb)` only. The `write()` boolean is ignored forever (backpressure is not EPIPE / unavailable).
- Post-write `!writable` check is gone; `childStdinIsWritable` now includes `writableEnded`.
- `pending.set` + `retainEvent` happen before `send()` write; `dropClientWrite` splices the retained client event and pending id on precheck / sync throw / callback error.
- Elicitation accept and `initialized` retain only if `writeChildStdin` returns true; callback `onFailed` drops a buffered-then-EPIPE accept so it cannot validate as sent.
- One idempotent `noteStdinFailure` (`stdinFailureNoted`) for write-callback error and stdin `'error'`: sets `streamUnavailable`, one driver error, `stopChild`.
- After `childClosed`, wait bounded on `inFlightWrites === 0` (or `runDeadline`) before `writeProofFiles`. No delivery schema field.

Fixture `scripts/ci/fixtures/codex-host-proof/fake-app-server.mjs` already has `close-stdin-then-elicit-exit-0` (`fs.closeSync(0)`, ignore `SIGTERM`, `process.exit(0)` after `turn/completed`). Unchanged in this commit.

## Evidence

RED (delayed async EPIPE, not `PassThrough.destroy()`): wrap `valid` child so only the elicitation-accept `write` returns true, then `queueMicrotask` fires write-callback error + stdin `'error'` EPIPE. Must not retain a client `mcpServer/elicitation/request`; `streamUnavailable` true; `driverOutcome.status` unavailable; `exitCode !== 0`; exactly one driver error.

GREEN close-stdin (sync state-flip): `drive("close-stdin-then-elicit-exit-0")` — no client elicitation reply, `streamUnavailable` true, driver unavailable, `childExitCode` 0 never pass.

GREEN backpressure: PassThrough `write()` returning false, never errors, writable stays true — `streamUnavailable !== true`, no driver stdin-failure.

`node --test --test-reporter spec scripts/ci/test_codex_host_proof.mjs` — 110 tests, 110 pass, 0 fail, 0 skipped (27.8s, Codex local).

Mutations still bite:

1. force `childStdinIsWritable` true → wrap `stdin.write`, `writesAfterClose.count > 0`
2. retain client elicitation even on failed write / skip `dropClientWrite` → invented sent accept
3. omit `streamUnavailable = true` in `noteStdinFailure` → hides the I/O break
4. remove stdin `'error'` handler → uncaught EPIPE

`node --check` on both files; `git diff --check` clean; `pre-commit run --files` on both files passed, including Codex host-proof Node contract.

## Non-claims

- Not a kernel-lint / #2760 / #2761 defect.
- Not a live-host proof or #2684 result.
- Still draft; not ready; not merged.
- #112 hold unchanged; other writer worktrees untouched.
