### PR TITLE
ci: retry one transient Assay Action YAML parser timeout

### DIFF
--- a/scripts/ci/check-assay-action-pin.sh
+++ b/scripts/ci/check-assay-action-pin.sh
@@ -158,18 +158,21 @@ def parse_provenance(text: str) -> tuple[str, str]:
 
 
 def load_yaml(text: str, *, source: str, required: bool = True):
-    try:
-        proc = subprocess.run(
-            ["ruby", "-EUTF-8:UTF-8", "-e", RUBY_SAFE_LOAD],
-            input=text,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-    except FileNotFoundError:
-        fail("ruby is required to parse GitHub Actions YAML")
-    except subprocess.TimeoutExpired:
-        fail(f"{source}: YAML parse timed out")
+    for attempt in range(2):
+        try:
+            proc = subprocess.run(
+                ["ruby", "-EUTF-8:UTF-8", "-e", RUBY_SAFE_LOAD],
+                input=text,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            break
+        except FileNotFoundError:
+            fail("ruby is required to parse GitHub Actions YAML")
+        except subprocess.TimeoutExpired:
+            if attempt == 1:
+                fail(f"{source}: YAML parse timed out")
     if proc.returncode != 0:
         if not required:
             return None

--- a/scripts/ci/test-check-assay-action-pin.sh
+++ b/scripts/ci/test-check-assay-action-pin.sh
@@ -110,6 +110,74 @@ expect_ok() {
   echo "ok    ${name}"
 }
 
+prepare_yaml_timeout_tree() {
+  local dest="$1"
+  copy_into "${dest}"
+  mkdir -p "${dest}/scripts/ci" "${dest}/fake-bin"
+  cp "${CHECKER}" "${dest}/scripts/ci/check-assay-action-pin.sh"
+  cp "${READER}" "${dest}/scripts/ci/read-assay-action-pin.sh"
+  python3 - "${dest}/scripts/ci/check-assay-action-pin.sh" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+needle = "            timeout=30,"
+if text.count(needle) != 1:
+    raise SystemExit("expected exactly one YAML parser timeout")
+path.write_text(
+    text.replace(
+        needle,
+        '            timeout=5 if source == "pinned action.yml" else 30,',
+    ),
+    encoding="utf-8",
+)
+PY
+  cat >"${dest}/fake-bin/ruby" <<'PY'
+#!/usr/bin/env python3
+import os
+from pathlib import Path
+import sys
+import time
+
+state = Path(os.environ["ASSAY_FAKE_RUBY_STATE"])
+attempt = int(state.read_text(encoding="utf-8")) + 1 if state.exists() else 1
+state.write_text(str(attempt), encoding="utf-8")
+mode = os.environ["ASSAY_FAKE_RUBY_MODE"]
+if mode == "persistent-timeout" or (mode == "transient-timeout" and attempt == 1):
+    time.sleep(6)
+elif mode == "parser-failure":
+    print("synthetic parser failure", file=sys.stderr)
+    raise SystemExit(2)
+os.execv(os.environ["ASSAY_REAL_RUBY"], [os.environ["ASSAY_REAL_RUBY"], *sys.argv[1:]])
+PY
+  chmod +x "${dest}/fake-bin/ruby"
+}
+
+run_yaml_timeout_checker() {
+  local tree="$1" mode="$2" state="$3"
+  PATH="${tree}/fake-bin:${PATH}" \
+    ASSAY_REAL_RUBY="${REAL_RUBY}" \
+    ASSAY_FAKE_RUBY_MODE="${mode}" \
+    ASSAY_FAKE_RUBY_STATE="${state}" \
+    ASSAY_ACTION_TREE="${tree}" \
+    ASSAY_ACTION_PIN_FILE="${tree}/.github/assay-action-pin" \
+    ASSAY_ACTION_FIXTURE_FILE="${tree}/scripts/ci/fixtures/assay-action-pin/action.yml" \
+    ASSAY_ACTION_PROVENANCE_FILE="${tree}/scripts/ci/fixtures/assay-action-pin/PROVENANCE" \
+    "${tree}/scripts/ci/check-assay-action-pin.sh"
+}
+
+expect_attempts() {
+  local name="$1" state="$2" expected="$3"
+  local actual
+  actual="$(cat "${state}")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "FAIL: ${name} made ${actual} parser attempts; expected ${expected}" >&2
+    exit 1
+  fi
+  echo "ok    ${name} (${actual} parser attempt(s))"
+}
+
 mutate_once() {
   local path="$1" old="$2" new="$3"
   python3 - "$path" "$old" "$new" <<'PY'
@@ -189,6 +257,11 @@ require_exists "${CHANGELOG}"
 require_exists "${DEPENDABOT}"
 require_exists "${CI_YML}"
 require_exists "${PRECOMMIT}"
+REAL_RUBY="$(command -v ruby)"
+if [[ -z "${REAL_RUBY}" ]]; then
+  echo "ruby is required to test YAML parser retries" >&2
+  exit 1
+fi
 
 check_consumer_compat() {
   python3 - "$1" "$2" "$3" <<'PY'
@@ -253,6 +326,46 @@ if [[ ! "${PIN}" =~ ^[0-9a-f]{40}$ ]]; then
   exit 1
 fi
 EXPECTED_USES="Rul1an/assay-action@${PIN}"
+
+echo "== bounded YAML parser timeout retry =="
+timeout_tree="${scratch}/yaml-timeout-tree"
+prepare_yaml_timeout_tree "${timeout_tree}"
+
+transient_state="${scratch}/transient-timeout-attempts"
+expect_ok "one transient timeout is retried" \
+  run_yaml_timeout_checker "${timeout_tree}" "transient-timeout" "${transient_state}"
+transient_attempts="$(cat "${transient_state}")"
+if (( transient_attempts < 2 )); then
+  echo "FAIL: transient timeout made ${transient_attempts} parser attempt(s); expected at least 2" >&2
+  exit 1
+fi
+echo "ok    transient timeout was retried"
+
+persistent_state="${scratch}/persistent-timeout-attempts"
+if run_yaml_timeout_checker "${timeout_tree}" "persistent-timeout" "${persistent_state}" \
+  >"${scratch}/out" 2>"${scratch}/err"; then
+  echo "FAIL: persistent YAML parser timeout stayed green" >&2
+  exit 1
+fi
+if ! grep -Fq -- "YAML parse timed out" "${scratch}/err"; then
+  echo "FAIL: persistent timeout lost the fail-closed diagnostic:" >&2
+  cat "${scratch}/err" >&2
+  exit 1
+fi
+expect_attempts "persistent timeout retry bound" "${persistent_state}" 2
+
+failure_state="${scratch}/parser-failure-attempts"
+if run_yaml_timeout_checker "${timeout_tree}" "parser-failure" "${failure_state}" \
+  >"${scratch}/out" 2>"${scratch}/err"; then
+  echo "FAIL: ordinary YAML parser failure stayed green" >&2
+  exit 1
+fi
+if ! grep -Fq -- "YAML parse failed: synthetic parser failure" "${scratch}/err"; then
+  echo "FAIL: ordinary parser failure lost its diagnostic:" >&2
+  cat "${scratch}/err" >&2
+  exit 1
+fi
+expect_attempts "ordinary parser failures are not retried" "${failure_state}" 1
 
 echo "== no-op control =="
 expect_ok "control-is-green" "${CHECKER}"


### PR DESCRIPTION
## Summary

Retry the Ruby GitHub Actions YAML parser exactly once after `subprocess.TimeoutExpired` so one transient process-start stall cannot fail every Assay PR. All non-timeout failures remain single-attempt and fail closed.

Fixes #2767
Parent programme: #2764

## Scope

- `scripts/ci/check-assay-action-pin.sh`
- `scripts/ci/test-check-assay-action-pin.sh`

## Contract

- Keep the production parser deadline at 30 seconds per attempt.
- Retry only `subprocess.TimeoutExpired`, at most once.
- A second timeout preserves the existing `YAML parse timed out` failure.
- Missing Ruby, parser non-zero exit, invalid parser JSON, and invalid YAML are not retried.
- Do not change Action pins, workflow ownership, YAML acceptance, published-byte checks, or network behavior.

## Evidence

RED before the production change:

```text
== bounded YAML parser timeout retry ==
FAIL: one transient timeout is retried exited non-zero:
pinned action.yml: YAML parse timed out
```

GREEN on final local head:

- bounded timeout matrix: transient timeout recovered; persistent timeout failed after exactly 2 attempts; ordinary parser failure failed after exactly 1 attempt;
- `bash scripts/ci/test-check-assay-action-pin.sh`: PASS, including the existing mutation battery;
- `bash scripts/ci/check-assay-action-pin.sh`: PASS;
- normal hooked commit: PASS;
- `shellcheck -x -e SC2016 scripts/ci/check-assay-action-pin.sh scripts/ci/test-check-assay-action-pin.sh`: PASS;
- `git diff --check`: PASS.

Mutation: changing `for attempt in range(2)` back to `range(1)` makes `one transient timeout is retried` fail before semantic evaluation. The scratch control remained on the unmodified tree.

## Non-claims

- This does not make the parser tolerant of invalid YAML.
- This does not increase or remove the 30-second per-attempt resource bound.
- This does not prove the host is healthy or eliminate all scheduler stalls.
- No Rust product behavior, release asset, install pin, or ADR-048 decision table changes here.
- Merge and release claims remain contingent on final-head review and required GitHub checks.


## Exact candidate

Head: `d93db3aef690c614819ea9c2dc43f240d2c24d42`
