### PR TITLE
feat(claim): ADR-048 6B — one claim vocabulary in assay-common, four public paths kept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,18 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Open the Assay 6.0 source line for the two bounded, already accepted breaking changes in
-  ADR-047 and ADR-048. Published installation instructions and the install pin remain on verified
-  `v5.5.2` until `v6.0.0` exists and its release artifacts have been verified (#2764).
+- Open the Assay 6.0 source line for one bounded, already accepted breaking change: ADR-048.
+  ADR-047's next-major step was already paid in `v5.0.0` (#2139) and is not part of 6.0. Published
+  installation instructions and the install pin remain on verified `v5.5.2` until `v6.0.0` exists
+  and its release artifacts have been verified (#2764).
+- ADR-048: the claim-gate vocabulary `ClaimDecision { allowed, degraded, blocked }` and
+  `ClaimKind { positive_existence, exhaustive_set, bounded_negative }` now lives once, in
+  `assay_common::claim`. `assay_runner_schema::{ClaimGateDecision, CoverageClaimKind}` and
+  `assay_evidence::{CodingAgentGateDecision, CodingAgentClaimKind}` are re-exports of those types
+  under their former names, so existing imports keep resolving and the serialised spelling is
+  unchanged and now pinned by tests. `assay-runner-schema` gains a normal dependency on
+  `assay-common` (`default-features = false`). The decision tables stay in their crates. Code that
+  bridged the two former enums with a `From` impl no longer compiles, because they are one type.
 
 ## [5.5.2] - 2026-08-31
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,21 +125,25 @@ assay-registry -> assay-common
 assay-adapter-api -> assay-evidence
 assay-adapter-{a2a,acp,ucp} -> assay-adapter-api, assay-evidence
 assay-runner-core -> assay-common, assay-monitor, assay-runner-schema
+assay-runner-schema -> assay-common
 assay-sim -> assay-core, assay-evidence
 assay-ebpf -> assay-common
 ```
 
-Leaf crates (no internal dependencies): `assay-common`, `assay-canonical`, `assay-policy`, `assay-runner-schema`, `assay-runner-linux`, `gateway-evidence-replay`, `assay-xtask`.
+Leaf crates (no internal dependencies): `assay-common`, `assay-canonical`, `assay-policy`, `assay-runner-linux`, `gateway-evidence-replay`, `assay-xtask`.
 
 No circular dependencies. All dependencies flow in one direction.
 
 The one dev-only edge is marked as such above and is deliberately not a production dependency.
-`assay-evidence`'s claim gate re-states, over a different vocabulary, the occurrence-versus-absence rule
-`assay-runner-schema::RunnerClaimGate` has enforced since 2026-06-01, so the two are pinned against each
-other by `tests/claim_gate_parity.rs` rather than left to drift. Per one-rule-one-function a parity test
-is the sanctioned fallback when one rule cannot simply call the other; promoting it to a real dependency
-is an ADR question, not a test fixture. Note `docs/generated/crate-deps.mermaid` draws dependency edges
-without distinguishing kind, so that edge appears there as if it were architectural.
+ADR-048 moved the shared claim vocabulary — `ClaimDecision` and `ClaimKind` — into
+`assay_common::claim`, which is why `assay-runner-schema` is no longer a leaf; the four former
+public paths re-export the shared types under their old names. The decision tables did not move:
+`assay-evidence`'s gate and `assay-runner-schema`'s descriptor table are domain readings of one
+lattice, and `tests/claim_gate_parity.rs` still pins their overlapping outputs. Two gaps stay open
+and are recorded in the ADR: nothing pins `RunnerClaimGate::for_verdict` against the evidence gate,
+and the parity test's complete-coverage leg is dead. Note `docs/generated/crate-deps.mermaid` draws
+dependency edges without distinguishing kind, so the dev-only edge appears there as if it were
+architectural.
 
 `assay-evidence -> assay-common` carries two shared primitives, and the test for admitting one
 is the same in both cases: a mechanism whose second implementation would silently mean something

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
 name = "assay-runner-schema"
 version = "6.0.0"
 dependencies = [
+ "assay-common",
  "serde",
  "serde_json",
  "thiserror 2.0.20",

--- a/crates/assay-common/src/claim.rs
+++ b/crates/assay-common/src/claim.rs
@@ -1,0 +1,47 @@
+//! Shared vocabulary for coverage-aware claim gates (ADR-048).
+//!
+//! Only the vocabulary lives here. The decision tables that consume it stay in their domain
+//! crates — `RunnerClaimGate::for_verdict` and `CoverageDescriptor::claim_decision_for` in
+//! `assay-runner-schema`, `coding_agent_claim_decision` in `assay-evidence` — because each is a
+//! domain reading of the same lattice and a shared table would merge those readings into one word.
+//! What moved is the construction: two crates spelling the same three members twice would let one
+//! of them silently mean something different, and the first evidence-side draft did exactly that.
+//!
+//! Neither enum derives `Ord`. The one comparison the tree makes between decisions is
+//! `assay_runner_schema::permissiveness`, a free function next to the invariant that needs it; an
+//! ordering on the public type would invite arithmetic on it. Neither enum is `#[non_exhaustive]`:
+//! a fourth member changes what every table means and must cost a major, not be absorbed.
+
+use serde::{Deserialize, Serialize};
+
+/// What a consumer may conclude, once a claim kind has been checked against how a run was
+/// observed. The tables that write this are meant to keep an absence claim no more permissive
+/// than an occurrence claim. That is pinned for `RunnerClaimGate::for_verdict`
+/// (`claim_support_parity.rs`) and for the descriptor/evidence pair on corresponding inputs
+/// (`claim_gate_parity.rs`). It is not pinned for `CoverageDescriptor::claim_decision_for_effect`,
+/// which can degrade a positive claim for an effect class the descriptor does not observe while
+/// the same complete descriptor still allows the absence claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimDecision {
+    /// The observation supports the claim as made.
+    Allowed,
+    /// The claim may be made, but on a weaker footing than the consumer asked for — records were
+    /// dropped, the account is the subject's own, coverage is partial, or the effect class was not
+    /// observed. Which of those applies is the table's reading, carried in its `rule` and reason.
+    Degraded,
+    /// The observation cannot support the claim; no rung or basis applies.
+    Blocked,
+}
+
+/// What kind of claim a consumer wants to make about one dimension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimKind {
+    /// "this effect happened" — seeing part of a run is enough to say what was seen.
+    PositiveExistence,
+    /// "these are all of them" — needs coverage of the whole dimension.
+    ExhaustiveSet,
+    /// "this did not happen" — the claim a blind spot silently destroys.
+    BoundedNegative,
+}

--- a/crates/assay-common/src/lib.rs
+++ b/crates/assay-common/src/lib.rs
@@ -21,6 +21,9 @@ pub mod dsse;
 /// a `&str` method and nothing allocates.
 pub mod tool_pattern;
 
+/// Claim-gate lattice and claim-kind vocabulary. The domain-specific decision tables stay home.
+pub mod claim;
+
 /// Monitor object ABI digest (`KEY_*` descriptor); shared by eBPF bake + monitor verify.
 mod object_abi;
 pub use object_abi::{

--- a/crates/assay-common/tests/claim.rs
+++ b/crates/assay-common/tests/claim.rs
@@ -1,0 +1,37 @@
+//! Wire contract of the shared claim vocabulary (ADR-048, decision 2).
+//!
+//! The two enums moved here from `assay-runner-schema` and `assay-evidence`, where each carried
+//! `#[serde(rename_all = "snake_case")]`. Every artifact that already serialised one of the four
+//! former paths must read back unchanged, so the spelling is pinned member by member rather than
+//! left to the derive.
+
+use assay_common::claim::{ClaimDecision, ClaimKind};
+
+#[test]
+fn shared_claim_vocabulary_keeps_its_wire_spelling() {
+    for (value, wire) in [
+        (ClaimDecision::Allowed, "\"allowed\""),
+        (ClaimDecision::Degraded, "\"degraded\""),
+        (ClaimDecision::Blocked, "\"blocked\""),
+    ] {
+        assert_eq!(serde_json::to_string(&value).unwrap(), wire);
+        assert_eq!(serde_json::from_str::<ClaimDecision>(wire).unwrap(), value);
+    }
+
+    for (value, wire) in [
+        (ClaimKind::PositiveExistence, "\"positive_existence\""),
+        (ClaimKind::ExhaustiveSet, "\"exhaustive_set\""),
+        (ClaimKind::BoundedNegative, "\"bounded_negative\""),
+    ] {
+        assert_eq!(serde_json::to_string(&value).unwrap(), wire);
+        assert_eq!(serde_json::from_str::<ClaimKind>(wire).unwrap(), value);
+    }
+}
+
+/// A fourth member would change what every decision table means (ADR-048, decision 6), so an
+/// unknown spelling must be a deserialisation error, never a silent default.
+#[test]
+fn unknown_members_are_rejected_not_defaulted() {
+    assert!(serde_json::from_str::<ClaimDecision>("\"unknown\"").is_err());
+    assert!(serde_json::from_str::<ClaimKind>("\"unknown\"").is_err());
+}

--- a/crates/assay-evidence/Cargo.toml
+++ b/crates/assay-evidence/Cargo.toml
@@ -55,12 +55,13 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
-# DEV-ONLY, and deliberately not a production edge. `assay-runner-schema` is a leaf (serde +
-# thiserror), so this cannot cycle. It exists for tests/claim_gate_parity.rs: the runner substrate has
-# gated claims by kind since 2026-06-01 and this crate re-states the same rule over a different
-# vocabulary, so the two are pinned against each other rather than left to drift. Per
-# [[one-rule-one-function]] a parity test is the sanctioned fallback when one rule cannot simply call
-# the other; promoting this to a real dependency is an ADR question, not a test fixture.
+# DEV-ONLY, and deliberately not a production edge. It cannot cycle: `assay-runner-schema` and this
+# crate both depend toward `assay-common`, which depends on neither (ADR-048 gave the schema crate its
+# one normal edge, `assay-common` with `default-features = false`). It exists for
+# tests/claim_gate_parity.rs, which compares two distinct domain tables — the runner's descriptor
+# gate and this crate's coding-agent gate — that now consume the one shared ADR-048 vocabulary,
+# `assay_common::claim`. Per [[one-rule-one-function]] a parity test is the sanctioned fallback when
+# one table cannot simply call the other; the tables stay apart by decision, not by omission.
 assay-runner-schema = { workspace = true }
 getrandom = { version = "0.4", features = ["sys_rng"] }
 jsonschema.workspace = true

--- a/crates/assay-evidence/src/coding_agent.rs
+++ b/crates/assay-evidence/src/coding_agent.rs
@@ -10,6 +10,13 @@ use crate::types::EvidenceEvent;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
+/// The claim vocabulary is shared with the runner substrate (ADR-048): these are re-exports of
+/// `assay_common::claim`, kept under their former names so existing paths keep resolving. The
+/// decision table that consumes them, [`coding_agent_claim_decision`], stays in this crate.
+pub use assay_common::claim::{
+    ClaimDecision as CodingAgentGateDecision, ClaimKind as CodingAgentClaimKind,
+};
+
 /// Event type for the v0 coding-agent evidence pack payload.
 pub const CODING_AGENT_EVIDENCE_EVENT_TYPE: &str = "assay.coding_agent.evidence_pack.v0";
 
@@ -107,34 +114,6 @@ pub enum CodingAgentClaimCeiling {
     ObservedAtReceiver,
     ObservedInPath,
     IndependentlyConfirmed,
-}
-
-/// What kind of claim a consumer wants to make about one dimension.
-///
-/// Mirrors `assay_runner_schema::CoverageClaimKind` deliberately. The runner substrate has gated
-/// claims by kind since 2026-06-01 (`RunnerClaimGate`) and by coverage descriptor since 2026-06-04.
-/// The first draft of this module ignored the kind entirely, which made it **contradict** that rule
-/// rather than merely duplicate it: a positive claim under partial coverage is `Allowed` there and
-/// was `Incomplete` here. Keeping the vocabularies parallel is what lets
-/// `tests/claim_gate_parity.rs` assert the two agree.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum CodingAgentClaimKind {
-    /// "this effect happened" — seeing part of a run is enough to say what was seen.
-    PositiveExistence,
-    /// "these are all of them" — needs coverage of the whole dimension.
-    ExhaustiveSet,
-    /// "this did not happen" — the claim a blind spot silently destroys.
-    BoundedNegative,
-}
-
-/// Mirrors `assay_runner_schema::ClaimGateDecision`.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum CodingAgentGateDecision {
-    Allowed,
-    Degraded,
-    Blocked,
 }
 
 /// What a consumer may conclude about one dimension, for one kind of claim.

--- a/crates/assay-evidence/src/types/tests.rs
+++ b/crates/assay-evidence/src/types/tests.rs
@@ -237,10 +237,9 @@ fn sandbox_degraded_payload_serde_shape_is_stable() {
 
 /// The record parses as a typed struct, and `Unknown` is not the fallback it looks like.
 ///
-/// `PayloadSessionFinding` ships without a `Payload` variant: adding one to that exhaustive public
-/// enum is a semver major (`cargo semver-checks`: `enum_variant_added`), which ADR-047 records as
-/// deferred to the next major together with `#[non_exhaustive]`, so the break is paid once for
-/// every kind that follows rather than once per kind.
+/// `Payload::SessionFinding` and `#[non_exhaustive]` shipped together in `v5.0.0` (#2139), the
+/// next-major step ADR-047 planned, so later event kinds cost no major. What this test pins is the
+/// no-fallback behaviour below, not the variant's presence.
 ///
 /// The control is what makes this worth pinning: **there is no fallback member at all**, so an
 /// unregistered kind is a deserialisation error and not an untyped landing. `Unknown(Value)` used

--- a/crates/assay-evidence/tests/claim_gate_parity.rs
+++ b/crates/assay-evidence/tests/claim_gate_parity.rs
@@ -1,20 +1,22 @@
-//! Parity between this crate's claim gate and the runner substrate's.
+//! Parity between this crate's claim gate and the runner substrate's (ADR-048, decision 5).
 //!
-//! Two implementations of one rule always drift. `assay-runner-schema` has gated claims by kind
-//! since 2026-06-01 (`RunnerClaimGate`) and by coverage descriptor since 2026-06-04
-//! (`CoverageDescriptor::claim_decision`); `assay-evidence` re-states the same rule over a different
-//! vocabulary because its inputs are different (a per-dimension coverage state and a source class,
-//! rather than a runner fidelity verdict and a descriptor).
+//! ADR-048 moved the two shared enums into `assay_common::claim`, so the vocabulary can no longer
+//! drift and the enum-equality half of this file is retired: both sides now consume one type. The
+//! tables did not move. `CoverageDescriptor::claim_decision_for` (runner) and
+//! `coding_agent_claim_decision` (evidence) answer from different inputs — a coverage descriptor
+//! there, a per-dimension coverage state and a source class here — and this file keeps their
+//! overlapping readings from drifting, which a shared type cannot do on its own.
 //!
-//! Ideally one would call the other. It cannot today: the runner substrate is documented as
-//! internal and API-unstable, and its inputs are runner-domain vocabulary that an evidence pack does
-//! not have. Promoting the shared mechanism into `assay-common` is a real ADR question — the
-//! CLAUDE.md admission test ("a mechanism whose second implementation would silently mean something
-//! different") is arguably met, and this file is the evidence that it is met, since the first draft
-//! of the evidence-side rule *did* silently mean something different.
+//! Two gaps are known and deliberately left open, recorded in ADR-048 rather than fixed here:
 //!
-//! Until that decision is taken, this is the sanctioned fallback: run both over the states that
-//! correspond and require the same decision. `assay-runner-schema` is a dev-dependency only.
+//! * The fidelity table, `RunnerClaimGate::for_verdict`, is **not** pinned against the evidence
+//!   gate by this file or any other. `claim_support_parity.rs` pins it only to its own crate's
+//!   `claim_support` projection.
+//! * The complete-coverage leg below is dead: no shipped descriptor constructor satisfies the
+//!   runner's completeness rule, so that test prints a notice and skips.
+//!
+//! `assay-runner-schema` is a dev-dependency only; the production edge ADR-048 admitted runs the
+//! other way, `assay-runner-schema -> assay-common`.
 
 use assay_evidence::{
     coding_agent_claim_decision, CodingAgentClaimKind, CodingAgentCoverageState,
@@ -22,21 +24,12 @@ use assay_evidence::{
 };
 use assay_runner_schema::{ClaimGateDecision, CoverageClaimKind, CoverageDescriptor};
 
-/// The two claim-kind vocabularies, paired.
-fn kinds() -> Vec<(CodingAgentClaimKind, CoverageClaimKind)> {
+/// One vocabulary since ADR-048; `CoverageClaimKind` is the same type under the runner's name.
+fn kinds() -> Vec<CodingAgentClaimKind> {
     vec![
-        (
-            CodingAgentClaimKind::PositiveExistence,
-            CoverageClaimKind::PositiveExistence,
-        ),
-        (
-            CodingAgentClaimKind::ExhaustiveSet,
-            CoverageClaimKind::ExhaustiveSet,
-        ),
-        (
-            CodingAgentClaimKind::BoundedNegative,
-            CoverageClaimKind::BoundedNegative,
-        ),
+        CodingAgentClaimKind::PositiveExistence,
+        CodingAgentClaimKind::ExhaustiveSet,
+        CodingAgentClaimKind::BoundedNegative,
     ]
 }
 
@@ -48,18 +41,6 @@ fn allows_absence(descriptor: &CoverageDescriptor) -> bool {
         == ClaimGateDecision::Allowed
 }
 
-fn same(ours: CodingAgentGateDecision, theirs: ClaimGateDecision) -> bool {
-    matches!(
-        (ours, theirs),
-        (CodingAgentGateDecision::Allowed, ClaimGateDecision::Allowed)
-            | (
-                CodingAgentGateDecision::Degraded,
-                ClaimGateDecision::Degraded
-            )
-            | (CodingAgentGateDecision::Blocked, ClaimGateDecision::Blocked)
-    )
-}
-
 /// Nothing watched here, and no descriptor there: both must block every claim kind.
 #[test]
 fn no_observation_matches_missing_descriptor() {
@@ -67,17 +48,17 @@ fn no_observation_matches_missing_descriptor() {
         CodingAgentCoverageState::Absent,
         CodingAgentCoverageState::Unavailable,
     ] {
-        for (ours_kind, their_kind) in kinds() {
+        for kind in kinds() {
             let ours = coding_agent_claim_decision(
                 // The strongest source class, so any disagreement is about coverage and not vantage.
                 CodingAgentSourceClass::IndependentlyObserved,
                 coverage,
-                ours_kind,
+                kind,
             );
-            let theirs = CoverageDescriptor::claim_decision_for(None, their_kind);
+            let theirs = CoverageDescriptor::claim_decision_for(None, kind);
             assert!(
-                same(ours.decision, theirs.decision),
-                "{coverage:?}/{ours_kind:?}: evidence says {:?}, runner says {:?} ({})",
+                ours.decision == theirs.decision,
+                "{coverage:?}/{kind:?}: evidence says {:?}, runner says {:?} ({})",
                 ours.decision,
                 theirs.decision,
                 theirs.rule
@@ -100,16 +81,16 @@ fn partial_coverage_matches_partial_completeness() {
         "fixture must actually be partial, or this test proves nothing"
     );
 
-    for (ours_kind, their_kind) in kinds() {
+    for kind in kinds() {
         let ours = coding_agent_claim_decision(
             CodingAgentSourceClass::BoundaryObserved,
             CodingAgentCoverageState::Partial,
-            ours_kind,
+            kind,
         );
-        let theirs = descriptor.claim_decision(their_kind);
+        let theirs = descriptor.claim_decision(kind);
         assert!(
-            same(ours.decision, theirs.decision),
-            "partial/{ours_kind:?}: evidence says {:?}, runner says {:?} ({})",
+            ours.decision == theirs.decision,
+            "partial/{kind:?}: evidence says {:?}, runner says {:?} ({})",
             ours.decision,
             theirs.decision,
             theirs.rule
@@ -127,16 +108,16 @@ fn full_coverage_matches_complete_descriptor() {
         eprintln!("no shipped descriptor reports complete coverage; leg skipped deliberately");
         return;
     }
-    for (ours_kind, their_kind) in kinds() {
+    for kind in kinds() {
         let ours = coding_agent_claim_decision(
             CodingAgentSourceClass::BoundaryObserved,
             CodingAgentCoverageState::Observed,
-            ours_kind,
+            kind,
         );
-        let theirs = complete.claim_decision(their_kind);
+        let theirs = complete.claim_decision(kind);
         assert!(
-            same(ours.decision, theirs.decision),
-            "observed/{ours_kind:?}: evidence says {:?}, runner says {:?} ({})",
+            ours.decision == theirs.decision,
+            "observed/{kind:?}: evidence says {:?}, runner says {:?} ({})",
             ours.decision,
             theirs.decision,
             theirs.rule
@@ -195,4 +176,48 @@ fn self_reported_is_documented_as_out_of_parity_scope() {
     );
     assert_eq!(ours.decision, CodingAgentGateDecision::Degraded);
     assert_eq!(ours.rule, "self_reported_degrades_positive_claim");
+}
+
+/// The four public paths are re-exports of one shared type (ADR-048, decision 6): a value read
+/// through any of them is assignable through any other without conversion. Before the move this
+/// did not compile, which is the whole point of the move.
+#[test]
+fn public_claim_vocabulary_paths_are_reexports_of_one_type() {
+    let decision: assay_runner_schema::ClaimGateDecision =
+        assay_common::claim::ClaimDecision::Degraded;
+    let same_decision: assay_evidence::CodingAgentGateDecision = decision;
+    assert_eq!(same_decision, assay_common::claim::ClaimDecision::Degraded);
+
+    let kind: assay_runner_schema::CoverageClaimKind =
+        assay_common::claim::ClaimKind::BoundedNegative;
+    let same_kind: assay_evidence::CodingAgentClaimKind = kind;
+    assert_eq!(same_kind, assay_common::claim::ClaimKind::BoundedNegative);
+}
+
+/// Type identity, not just assignability: every former public path names the one shared type.
+/// This is the intentional ADR-048 break stated positively — a downstream `From` bridge or two
+/// local trait impls across the former pair now overlap, because there is no pair.
+#[test]
+fn every_former_path_is_the_same_type_id() {
+    use std::any::TypeId;
+    let decision = TypeId::of::<assay_common::claim::ClaimDecision>();
+    assert_eq!(
+        decision,
+        TypeId::of::<assay_runner_schema::ClaimGateDecision>()
+    );
+    assert_eq!(
+        decision,
+        TypeId::of::<assay_evidence::CodingAgentGateDecision>()
+    );
+    assert_eq!(
+        decision,
+        TypeId::of::<assay_evidence::coding_agent::CodingAgentGateDecision>()
+    );
+    let kind = TypeId::of::<assay_common::claim::ClaimKind>();
+    assert_eq!(kind, TypeId::of::<assay_runner_schema::CoverageClaimKind>());
+    assert_eq!(kind, TypeId::of::<assay_evidence::CodingAgentClaimKind>());
+    assert_eq!(
+        kind,
+        TypeId::of::<assay_evidence::coding_agent::CodingAgentClaimKind>()
+    );
 }

--- a/crates/assay-evidence/tests/claim_vocabulary_wire.rs
+++ b/crates/assay-evidence/tests/claim_vocabulary_wire.rs
@@ -1,0 +1,78 @@
+//! The four public claim-vocabulary paths keep their wire spelling across ADR-048's move.
+//!
+//! This test names only paths that exist on both sides of the migration, so it is green before
+//! the move and must stay green after it: it pins behaviour, not structure.
+
+use assay_evidence::{CodingAgentClaimKind, CodingAgentGateDecision};
+use assay_runner_schema::{ClaimGateDecision, CoverageClaimKind};
+
+#[test]
+fn every_public_path_keeps_the_snake_case_wire_spelling() {
+    let runner_decisions = [
+        (ClaimGateDecision::Allowed, "\"allowed\""),
+        (ClaimGateDecision::Degraded, "\"degraded\""),
+        (ClaimGateDecision::Blocked, "\"blocked\""),
+    ];
+    let evidence_decisions = [
+        (CodingAgentGateDecision::Allowed, "\"allowed\""),
+        (CodingAgentGateDecision::Degraded, "\"degraded\""),
+        (CodingAgentGateDecision::Blocked, "\"blocked\""),
+    ];
+    for (value, wire) in runner_decisions {
+        assert_eq!(serde_json::to_string(&value).unwrap(), wire);
+        assert_eq!(
+            serde_json::from_str::<ClaimGateDecision>(wire).unwrap(),
+            value
+        );
+    }
+    for (value, wire) in evidence_decisions {
+        assert_eq!(serde_json::to_string(&value).unwrap(), wire);
+        assert_eq!(
+            serde_json::from_str::<CodingAgentGateDecision>(wire).unwrap(),
+            value
+        );
+    }
+
+    let runner_kinds = [
+        (
+            CoverageClaimKind::PositiveExistence,
+            "\"positive_existence\"",
+        ),
+        (CoverageClaimKind::ExhaustiveSet, "\"exhaustive_set\""),
+        (CoverageClaimKind::BoundedNegative, "\"bounded_negative\""),
+    ];
+    let evidence_kinds = [
+        (
+            CodingAgentClaimKind::PositiveExistence,
+            "\"positive_existence\"",
+        ),
+        (CodingAgentClaimKind::ExhaustiveSet, "\"exhaustive_set\""),
+        (
+            CodingAgentClaimKind::BoundedNegative,
+            "\"bounded_negative\"",
+        ),
+    ];
+    for (value, wire) in runner_kinds {
+        assert_eq!(serde_json::to_string(&value).unwrap(), wire);
+        assert_eq!(
+            serde_json::from_str::<CoverageClaimKind>(wire).unwrap(),
+            value
+        );
+    }
+    for (value, wire) in evidence_kinds {
+        assert_eq!(serde_json::to_string(&value).unwrap(), wire);
+        assert_eq!(
+            serde_json::from_str::<CodingAgentClaimKind>(wire).unwrap(),
+            value
+        );
+    }
+
+    // The module path is public too, and `cargo semver-checks` reports it as its own item.
+    let via_module = assay_evidence::coding_agent::CodingAgentGateDecision::Blocked;
+    assert_eq!(serde_json::to_string(&via_module).unwrap(), "\"blocked\"");
+    let via_module_kind = assay_evidence::coding_agent::CodingAgentClaimKind::ExhaustiveSet;
+    assert_eq!(
+        serde_json::to_string(&via_module_kind).unwrap(),
+        "\"exhaustive_set\""
+    );
+}

--- a/crates/assay-runner-schema/Cargo.toml
+++ b/crates/assay-runner-schema/Cargo.toml
@@ -10,6 +10,7 @@ description = "Internal/experimental substrate for Assay measured-run workflows.
 readme.workspace = true
 
 [dependencies]
+assay-common = { workspace = true, default-features = false }
 serde = { workspace = true, features = ["derive", "std"] }
 thiserror = { workspace = true }
 

--- a/crates/assay-runner-schema/src/coverage.rs
+++ b/crates/assay-runner-schema/src/coverage.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{ClaimGateDecision, NetworkProtocolCoverageStatus};
+use crate::{ClaimGateDecision, CoverageClaimKind, NetworkProtocolCoverageStatus};
 
 pub const COVERAGE_DESCRIPTOR_SCHEMA: &str = "assay.runner.coverage_descriptor.v0";
 
@@ -21,14 +21,6 @@ pub enum CoverageCompleteness {
     DatagramPeerObserved,
     ConnectAndDatagramPeerObserved,
     ExecOnly,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CoverageClaimKind {
-    PositiveExistence,
-    ExhaustiveSet,
-    BoundedNegative,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/assay-runner-schema/src/fidelity.rs
+++ b/crates/assay-runner-schema/src/fidelity.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    CgroupCorrelationStatus, KernelLayerStatus, ObservationHealth, ObservationHealthError,
-    OBSERVATION_HEALTH_SCHEMA,
+    CgroupCorrelationStatus, ClaimGateDecision, KernelLayerStatus, ObservationHealth,
+    ObservationHealthError, OBSERVATION_HEALTH_SCHEMA,
 };
 
 pub const RUNNER_FIDELITY_VERDICT_SCHEMA: &str = "assay.runner.fidelity_verdict.v0";
@@ -27,14 +27,6 @@ pub enum RunnerFidelityVerdict {
     CorrelationPartial,
     Failed,
     NotApplicable,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ClaimGateDecision {
-    Allowed,
-    Degraded,
-    Blocked,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/assay-runner-schema/src/lib.rs
+++ b/crates/assay-runner-schema/src/lib.rs
@@ -29,6 +29,11 @@ mod health;
 mod sdk_event;
 mod surface;
 
+/// Shared claim vocabulary (ADR-048), re-exported under this crate's former names so
+/// `assay_runner_schema::ClaimGateDecision` and `assay_runner_schema::CoverageClaimKind` keep
+/// resolving. The tables that consume them stay in this crate.
+pub use assay_common::claim::{ClaimDecision as ClaimGateDecision, ClaimKind as CoverageClaimKind};
+
 pub use archive_manifest::{
     ArchiveFile, ArchiveManifest, ARCHIVE_MANIFEST_SCHEMA, CAPABILITY_SURFACE_PATH,
     CORRELATION_REPORT_PATH, EVENTS_PATH, KERNEL_LAYER_PATH, MANIFEST_PATH,
@@ -44,14 +49,13 @@ pub use correlation::{
     CorrelationStatus, CORRELATION_REPORT_SCHEMA,
 };
 pub use coverage::{
-    CoverageClaimDecision, CoverageClaimKind, CoverageCompleteness, CoverageDescriptor,
-    EffectDimension, COVERAGE_DESCRIPTOR_SCHEMA,
+    CoverageClaimDecision, CoverageCompleteness, CoverageDescriptor, EffectDimension,
+    COVERAGE_DESCRIPTOR_SCHEMA,
 };
 pub use fidelity::{
-    ClaimGateDecision, RunnerClaimGate, RunnerFidelityReason, RunnerFidelityVerdict,
-    RunnerFidelityVerdictReport, PROJECTION_CLAIM_LEVEL_INCONCLUSIVE,
-    PROJECTION_CLAIM_LEVEL_PROJECTED_EQUIVALENT, PROJECTION_CLAIM_LEVEL_RAW_OBSERVED,
-    RUNNER_FIDELITY_VERDICT_SCHEMA,
+    RunnerClaimGate, RunnerFidelityReason, RunnerFidelityVerdict, RunnerFidelityVerdictReport,
+    PROJECTION_CLAIM_LEVEL_INCONCLUSIVE, PROJECTION_CLAIM_LEVEL_PROJECTED_EQUIVALENT,
+    PROJECTION_CLAIM_LEVEL_RAW_OBSERVED, RUNNER_FIDELITY_VERDICT_SCHEMA,
 };
 pub use health::{
     CaptureOrigin, CgroupCorrelationStatus, KernelLayerStatus, NetworkEndpointClaimScope,

--- a/crates/assay-runner-schema/tests/claim_support_parity.rs
+++ b/crates/assay-runner-schema/tests/claim_support_parity.rs
@@ -1,9 +1,11 @@
 //! The health half of the claim-support rule, held to its own contract.
 //!
-//! `assay-evidence`'s `tests/claim_gate_parity.rs` pins two Rust vocabularies against each other.
-//! This file pins one vocabulary against the thing it claims to be: a table that *derives* from
-//! `RunnerClaimGate` rather than restating it, is total over both enums, and carries the asymmetry
-//! that makes the rule worth having.
+//! `assay-evidence`'s `tests/claim_gate_parity.rs` pins the runner's descriptor table against the
+//! evidence gate. This file pins the fidelity table against the thing it claims to be: a
+//! `claim_support` projection that *derives* from `RunnerClaimGate` rather than restating it, is
+//! total over both enums, and carries the asymmetry that makes the rule worth having. Both enums
+//! are `assay_common::claim` re-exports since ADR-048; that ADR records, and this file does not
+//! close, the gap that nothing pins `RunnerClaimGate::for_verdict` against the evidence gate.
 //!
 //! The one substantive assertion here is `absence_is_never_more_permissive_than_occurrence`. It is
 //! true today by construction, and it was never checked. A gate that lets an absence claim through

--- a/docs/AIcontext/architecture-diagrams.md
+++ b/docs/AIcontext/architecture-diagrams.md
@@ -891,6 +891,7 @@ flowchart TB
     assay_runner_core --> assay_common
     assay_runner_core --> assay_monitor
     assay_runner_core --> assay_runner_schema
+    assay_runner_schema --> assay_common
     assay_sim --> assay_adapter_api
     assay_sim --> assay_core
     assay_sim --> assay_evidence

--- a/docs/architecture/ADR-047-session-scope-findings-are-events.md
+++ b/docs/architecture/ADR-047-session-scope-findings-are-events.md
@@ -43,6 +43,12 @@ unaffected — `EvidenceEvent::payload` is a raw `Value`, a consumer parses `Pay
 from it directly, and the enum was already documented as a convenience view rather than the
 contract.
 
+> Implementation note, 2026-09-03: the planned next-major step was taken in
+> [PR #2139](https://github.com/Rul1an/assay/pull/2139) (`c00b46bf7`, merged 2026-08-08) and
+> shipped in `v5.0.0`: `Payload` gained `SessionFinding(PayloadSessionFinding)` and
+> `#[non_exhaustive]` together. The two-step reasoning above is kept as written; it describes why
+> the break was paid once. Nothing about this kind is pending in a later major.
+
 **Why a distinct kind rather than a field on `assay.tool.decision`.** The defining property of this
 record is that it *spans* calls. A per-call payload has no honest place to put a span: whichever
 call carried it would be claiming a verdict it did not alone produce. `RuleEvaluation`
@@ -168,10 +174,10 @@ work that took one predicate.
 
 ## Consequences
 
-- `PayloadSessionFinding` is additive; `Payload` is unchanged until the next major, when it gains
-  the variant and `#[non_exhaustive]` together. Nothing in the workspace matches `Payload`
-  exhaustively today anyway — the one existing match is in a test and has a wildcard arm — and
-  `Unknown` never absorbed this class, as Decision 1 records.
+- `PayloadSessionFinding` was additive at this ADR's date; since `v5.0.0` (#2139) `Payload` carries
+  the `SessionFinding` variant and is `#[non_exhaustive]`, so later kinds cost no major. Nothing in
+  the workspace matched `Payload` exhaustively at the time — the one existing match was in a test
+  and had a wildcard arm — and `Unknown` never absorbed this class, as Decision 1 records.
 - Findings enter `run_root`, so they are covered by bundle verification with no new file and no
   change to `ALLOWED_FILES`.
 - The span is expressed as `u64` indices into the evaluated call sequence, which is what the

--- a/docs/generated/crate-deps.mermaid
+++ b/docs/generated/crate-deps.mermaid
@@ -63,6 +63,7 @@ flowchart TB
     assay_runner_core --> assay_common
     assay_runner_core --> assay_monitor
     assay_runner_core --> assay_runner_schema
+    assay_runner_schema --> assay_common
     assay_sim --> assay_adapter_api
     assay_sim --> assay_core
     assay_sim --> assay_evidence


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: [issue #2764](https://github.com/Rul1an/assay/issues/2764), the bounded Assay 6.0 programme
- Slice: 6B — ADR-048 decisions 2, 5, 6 (claim vocabulary moves to `assay-common`; four public paths kept as re-exports)
- Builder: Claude (sole writer lease on `claude/adr-048-core-enum-migration`, worktree `~/.claude/worktrees/assay-adr048-6b`)
- Reviewer: Ruley, independent non-building final-head review: READY at `8a89d98439e842fc5a0fbe545b439045ce1a4d4f` ([review](https://github.com/Rul1an/assay/pull/2769#issuecomment-5529136550), [carrier](https://github.com/Rul1an/assay/pull/2769#issuecomment-5529136774))
- Final head SHA: 8a89d98439e842fc5a0fbe545b439045ce1a4d4f — base `b3869814a25dd49d4bfbf10077b11d04d71058de`. Head history: `804b3b2aa331d396503f8caec5023b3d638bebd5` (6B; every measurement below ran on it) → `8a89d98439e842fc5a0fbe545b439045ce1a4d4f` (B1 follow-up: one comment in `crates/assay-evidence/Cargo.toml`, no dependency, code or test change; measurements were not rerun and carry over because the tree differs only in that comment); toolchain from `rust-toolchain.toml` (`rustc 1.96.0`), `cargo-semver-checks 0.50.0`, macOS host
- ADR invariants affected: ADR-048 D2 (what moves), D5 (parity tests and their named gaps), D6 (public names preserved, type identity merged). ADR-042/043 boundaries untouched.

## Behavior

`assay_common::claim::{ClaimDecision, ClaimKind}` is the single spelling of the claim-gate lattice and claim-kind vocabulary. `assay_runner_schema::{ClaimGateDecision, CoverageClaimKind}` and `assay_evidence::{CodingAgentGateDecision, CodingAgentClaimKind}` (also `assay_evidence::coding_agent::…`) resolve as re-exports of those types under their former names. Every decision table, fold and runtime reading stays in its crate and is unchanged; the parity tests still pass unmodified in what they assert. Serialised spelling is byte-identical (`snake_case`) and pinned. `assay-runner-schema` gains one normal dependency, `assay-common` with `default-features = false`.

Intentional source break, paid in 6.0: the former pair is one type, so a downstream `From` bridge or two local trait impls across them fail to compile (E0119). No wire change. No runtime behaviour change.

Documentation truth repairs carried in this slice: the 6A `[Unreleased]` line now says ADR-048 is the 6.0 break and ADR-047's next-major step was already paid in `v5.0.0` (#2139, `c00b46bf7`); ADR-047 gains a dated implementation note and a present-tense Consequences line (historical reasoning preserved); `crates/assay-evidence/src/types/tests.rs` no longer calls the `Payload` variant deferred; `claim.rs` states the pinned scope of the occurrence/absence invariant and excludes `claim_decision_for_effect`.

B1 follow-up (review finding): the `crates/assay-evidence/Cargo.toml` dev-dependency comment retired three claims 6B falsified (schema crate is a leaf; different vocabularies; sharing is an open ADR question). It now states the dev-only edge is non-production and cannot cycle because both crates depend toward `assay-common`, which depends on neither, and that the parity test compares two distinct domain tables consuming one shared vocabulary. `conformance/UNGUARDED-CLAIMS.md` is deliberately untouched: its table is a 2026-08-19 measurement pinned to `9382ff831`, when CLAUDE.md really listed seven leaves.

Conflict resolution on rehydration: one conflict in `CHANGELOG.md` (6A's line vs the ADR-048 item); resolved by keeping 6A's line, then correcting it as above, with the ADR-048 item beneath it under the same `### Changed`. Nothing was taken wholesale from either side.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim
- No ADR-047 implementation (already shipped in `v5.0.0`), no policy/trace basis, no MCP emission right, no fourth `ClaimDecision` member, no behavioural change to any table, no AGENTS.md change.
- No release, tag or publish from this PR. Delegated proof status: run https://github.com/Rul1an/assay/actions/runs/33775814363 (gate `all`) completed and was accepted for SHA `804b3b2aa331d396503f8caec5023b3d638bebd5`; it binds to that head only and is **stale for `8a89d98439e842fc5a0fbe545b439045ce1a4d4f`**. Fresh exact-head dispatch run `33778357004` completed successfully on `8a89d98439e842fc5a0fbe545b439045ce1a4d4f` and `lane-check/proof` accepted it via run `33779919662`; it was dispatched by the owner/coordinator, not the builder.

## Test Evidence

### RED

On base `287d7f19c` (before the production change), measured in the earlier worktree:
- `cargo test -p assay-common --test claim` → `error[E0432]: unresolved import assay_common::claim` (exit 101)
- `cargo test -p assay-evidence --test claim_gate_parity` → `error[E0433]: cannot find claim in assay_common` ×4 (exit 101)
- `cargo test -p assay-evidence --test claim_vocabulary_wire` → green (names only pre-existing public paths; pins behaviour, not structure)

### GREEN

Measured on `804b3b2aa331d396503f8caec5023b3d638bebd5` in worktree `~/.claude/worktrees/assay-adr048-6b`, one Cargo lane at a time; not rerun on `8a89d98439e842fc5a0fbe545b439045ce1a4d4f`, which changes one comment in `crates/assay-evidence/Cargo.toml` only:
- `cargo check -p assay-common --no-default-features` → exit 0 (no_std still compiles with the new module)
- `cargo test -p assay-common -p assay-runner-schema -p assay-evidence` → exit 0; 53 suites, 748 passed, 0 failed, 4 ignored. New/pinned: `shared_claim_vocabulary_keeps_its_wire_spelling`, `unknown_members_are_rejected_not_defaulted`, `public_claim_vocabulary_paths_are_reexports_of_one_type`, `every_former_path_is_the_same_type_id`, `every_public_path_keeps_the_snake_case_wire_spelling` (now also pins `assay_evidence::coding_agent::…`). `claim_gate_parity` and `claim_support_parity` pass unmodified in what they assert.
- `cargo clippy -p assay-common -p assay-runner-schema -p assay-evidence -p assay-cli --all-targets -- -D warnings` → exit 0
- `cargo fmt --all --check` → exit 0
- `bash scripts/ci/check-docs-generated-drift.sh` → exit 0, "generated artifacts reproduce from their generators (20 files)" (the generated crate-deps diagram is regenerated and byte-checked; CLAUDE.md is hand-maintained and its dependency paragraph was edited by hand)
- `cargo semver-checks check-release --baseline-rev v5.5.2`, one crate per run, workspace toolchain: 
  - Declared-major mode (what CI runs; the 6.0.0 manifest against baseline `v5.5.2` makes the tool skip every lint, so this is *not* evidence of compatibility, only that the declared bump is sufficient): `assay-common --default-features` → exit 0, "0 checks: 0 pass, 254 skip, no semver update required"; `assay-runner-schema` → exit 0, same; `assay-evidence` → exit 0, same. Note: `assay-common` without `--default-features` fails at the baseline `cargo doc` step on macOS because the eBPF feature pulls `aya`'s Linux-only netlink imports; that is a host limitation of the baseline build, not a semver finding.
  - Forced minor mode (`--release-type minor`, which runs the 196 lints and names what the major pays for): `assay-common` → exit 0, 196 pass, "no semver update required" (the new module is additive); `assay-runner-schema` → exit 100, 195 pass, **1 fail: `enum_missing`** for `assay_runner_schema::CoverageClaimKind` and `assay_runner_schema::ClaimGateDecision`; `assay-evidence` → exit 100, 195 pass, **1 fail: `enum_missing`** for `assay_evidence::CodingAgentGateDecision`, `assay_evidence::CodingAgentClaimKind` and both `assay_evidence::coding_agent::…` paths. Nothing else fails. Those paths still resolve (re-exports) and round-trip byte-identically; the lint is the type-identity change ADR-048 D6 pays for in 6.0, and there is no other break in either crate.
- Public-string audit of every added line in the 18 owned paths: no private repository, private file, strategy term, local path or recovery path.

### Mutations (each reverted after measurement)

Focused suites `claim`, `claim_vocabulary_wire`, `claim_gate_parity`, `claim_support_parity` across the three crates:
- M1 `#[serde(rename_all = "camelCase")]` on both enums → exit 101; `shared_claim_vocabulary_keeps_its_wire_spelling` panics (`"positiveExistence"` ≠ `"positive_existence"`), evidence wire test fails to compile against the changed spelling.
- M2 remove the `assay-runner-schema` compatibility `pub use` → exit 101; 4× `E0432 unresolved imports crate::ClaimGateDecision, crate::CoverageClaimKind`.
- M3 rename member `Degraded` → `Reduced` → exit 101; 11× `E0599 no variant … Degraded`.
Tree restored byte-identical after each (`cmp` against saved originals; `git status` shows only the 18 staged paths).

### Review/feature-tree checks (not mutations)

- `cargo tree -e features -i assay-common -p assay-runner-schema` → `assay-common v6.0.0 └── assay-runner-schema v6.0.0 └── assay-runner-schema feature "default"`: no `std` or other feature of `assay-common` is pulled through this edge, so `default-features = false` is honoured.
- `#[non_exhaustive]` is deliberately absent on both enums (ADR-048 D6); not a mutation target because no in-tree signal distinguishes it — reviewer check.
- Decision tables unchanged: `coverage.rs`, `fidelity.rs`, `coding_agent.rs` diffs touch only the enum definitions/imports; no match arm or return value changed.

## Review Quorum

- [x] One non-building agent review (Ruley) — READY at `8a89d98439e842fc5a0fbe545b439045ce1a4d4f` ([review](https://github.com/Rul1an/assay/pull/2769#issuecomment-5529136550), [carrier](https://github.com/Rul1an/assay/pull/2769#issuecomment-5529136774)); the prior BLOCKED review remains stale for this head
- [x] Every actionable finding is fixed or has a technical disposition — B1 and B3 retired; B2 retracted as historical; final-head findings are empty
- [x] Delegated proof for this exact head — replacement run `33778357004` (gate `all`) completed successfully on `8a89d98439e842fc5a0fbe545b439045ce1a4d4f` and `lane-check/proof` accepted it via run `33779919662`; prior run `33775814363` remains stale for this head

Optional automated reviews can add evidence, but do not count toward or block quorum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




