### PR TITLE
fix(ci): classify attestation API refusal as infra

### DIFF
--- a/scripts/ci/test-verify-release.sh
+++ b/scripts/ci/test-verify-release.sh
@@ -208,6 +208,117 @@ for name in \
     || fail "expected-absent attestation was not classified green: $name"
 done
 expect_status 1 "$ORACLE" --unit-classify-attestation assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz 404
+for status in 401 403 429 500; do
+  expect_status 2 "$ORACLE" --unit-classify-attestation \
+    assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz "$status"
+done
+
+# Attestation lookup must use the authenticated GitHub client while preserving
+# the HTTP status needed to distinguish expected absence from infrastructure.
+attestation_gh="$tmp/attestation-gh"
+attestation_gh_log="$tmp/attestation-gh.log"
+cat >"$attestation_gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$FAKE_GH_LOG"
+[[ "${1:-}" == api && "${2:-}" == --include ]] || exit 64
+shift 2
+[[ " $* " == *" -H Accept: application/vnd.github+json "* ]] || exit 65
+[[ " $* " == *" -H X-GitHub-Api-Version: 2022-11-28 "* ]] || exit 66
+[[ "${*: -1}" == repos/Rul1an/assay/attestations/sha256:* ]] || exit 67
+[[ "${FAKE_HTTP_STATUS:-}" != transport ]] || exit 68
+if [[ "${FAKE_HTTP_STATUS:-}" == timeout ]]; then
+  sleep 30
+fi
+if [[ "${FAKE_HTTP_STATUS:-}" == oversize ]]; then
+  printf 'HTTP/2.0 200 Fixture\r\nContent-Type: application/json\r\n\r\n'
+  python3 - <<'PY'
+import sys
+sys.stdout.write("x" * (1024 * 1024 + 1))
+PY
+  sleep 30
+fi
+printf 'HTTP/2.0 %s Fixture\r\nContent-Type: application/json\r\n\r\n' "$FAKE_HTTP_STATUS"
+if [[ -v FAKE_HTTP_BODY ]]; then
+  printf '%s\n' "$FAKE_HTTP_BODY"
+else
+  printf '%s\n' '{}'
+fi
+[[ "$FAKE_HTTP_STATUS" == 200 ]] || exit 1
+SH
+chmod +x "$attestation_gh"
+
+dummy_digest="sha256:$(printf 'a%.0s' {1..64})"
+attestation_response="$tmp/attestation-response.json"
+valid_attestation='{"attestations":[{"bundle":{"dsseEnvelope":{"payloadType":"application/vnd.in-toto+json"}}}]}'
+
+expect_status 0 env FAKE_GH_LOG="$attestation_gh_log" FAKE_HTTP_STATUS=200 \
+  FAKE_HTTP_BODY="$valid_attestation" GH="$attestation_gh" \
+  "$ORACLE" --unit-check-attestation \
+  assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz "$dummy_digest" "$attestation_response"
+[[ "$(cat "$attestation_response")" == "$valid_attestation" ]] \
+  || fail "authenticated attestation query did not retain the response body"
+
+expect_status 0 env FAKE_GH_LOG="$attestation_gh_log" FAKE_HTTP_STATUS=404 \
+  GH="$attestation_gh" "$ORACLE" --unit-check-attestation \
+  assay-v5.3.0-release-proof-kit.tar.gz "$dummy_digest" "$attestation_response"
+expect_status 1 env FAKE_GH_LOG="$attestation_gh_log" FAKE_HTTP_STATUS=404 \
+  GH="$attestation_gh" "$ORACLE" --unit-check-attestation \
+  assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz "$dummy_digest" "$attestation_response"
+for status in 401 403 429; do
+  expect_status 2 env FAKE_GH_LOG="$attestation_gh_log" FAKE_HTTP_STATUS="$status" \
+    GH="$attestation_gh" "$ORACLE" --unit-check-attestation \
+    assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz "$dummy_digest" "$attestation_response"
+done
+
+attestation_stderr="$tmp/attestation-refusal.stderr"
+status=0
+env FAKE_GH_LOG="$attestation_gh_log" FAKE_HTTP_STATUS=403 GH="$attestation_gh" \
+  "$ORACLE" --unit-check-attestation \
+  assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz "$dummy_digest" "$attestation_response" \
+  >/dev/null 2>"$attestation_stderr" || status=$?
+[[ "$status" -eq 2 ]] || fail "attestation refusal was not infrastructure (got $status)"
+grep -q '^INFRA:' "$attestation_stderr" \
+  || fail "attestation refusal diagnostic is not infrastructure"
+if grep -q '^FINDING:' "$attestation_stderr"; then
+  fail "attestation refusal was mislabeled as a finding"
+fi
+
+expect_status 2 env FAKE_GH_LOG="$attestation_gh_log" FAKE_HTTP_STATUS=transport \
+  GH="$attestation_gh" "$ORACLE" --unit-check-attestation \
+  assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz "$dummy_digest" "$attestation_response"
+
+expect_status 1 env FAKE_GH_LOG="$attestation_gh_log" FAKE_HTTP_STATUS=200 \
+  FAKE_HTTP_BODY='{}' GH="$attestation_gh" "$ORACLE" --unit-check-attestation \
+  assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz "$dummy_digest" "$attestation_response"
+
+attestation_stderr="$tmp/attestation-timeout.stderr"
+status=0
+env FAKE_GH_LOG="$attestation_gh_log" FAKE_HTTP_STATUS=timeout \
+  ASSAY_RELEASE_GH_TIMEOUT_SECONDS=0.2 GH="$attestation_gh" \
+  "$ORACLE" --unit-check-attestation \
+  assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz "$dummy_digest" "$attestation_response" \
+  >/dev/null 2>"$attestation_stderr" || status=$?
+[[ "$status" -eq 2 ]] || fail "attestation timeout was not infrastructure (got $status)"
+grep -q 'deadline' "$attestation_stderr" \
+  || fail "attestation timeout diagnostic does not name the deadline"
+
+attestation_stderr="$tmp/attestation-oversize.stderr"
+status=0
+env FAKE_GH_LOG="$attestation_gh_log" FAKE_HTTP_STATUS=oversize \
+  ASSAY_RELEASE_GH_TIMEOUT_SECONDS=2 GH="$attestation_gh" \
+  "$ORACLE" --unit-check-attestation \
+  assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz "$dummy_digest" "$attestation_response" \
+  >/dev/null 2>"$attestation_stderr" || status=$?
+[[ "$status" -eq 2 ]] || fail "oversize attestation response was not infrastructure (got $status)"
+grep -q 'combined stdout+stderr' "$attestation_stderr" \
+  || fail "oversize attestation diagnostic does not name the byte ceiling"
+
+grep -Fq 'api --include' "$attestation_gh_log" \
+  || fail "attestation lookup did not use authenticated gh api"
+if grep -Eqi 'authorization|bearer|token' "$attestation_gh_log"; then
+  fail "attestation lookup exposed credential material in process arguments"
+fi
 
 # GitHub wraps the in-toto statement in a Sigstore bundle. The required
 # application/vnd.in-toto+json value belongs to dsseEnvelope.payloadType.
@@ -220,20 +331,44 @@ expect_status 0 "$ORACLE" --unit-verify-attestation-json "$attestation"
 
 # Mutation proof: treating expected 404s as failures must make the targeted
 # assertion red. This checks behavior through a copied oracle, not a mock.
-mutant="$tmp/verify-release.sh"
-cp "$ORACLE" "$mutant"
+mutant_dir="$tmp/expected-absent-mutant"
+mkdir -p "$mutant_dir"
+cp "$ORACLE" "$ASSET_CONTRACT" "$mutant_dir/"
+mutant="$mutant_dir/verify-release.sh"
 python3 - "$mutant" <<'PY'
 import pathlib
 import sys
 
 path = pathlib.Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
-needle = 'printf \'%s\\n\' "expected-absent"\n    return 0'
+needle = 'printf \'%s\\n\' "expected-absent"\n      else'
 if needle not in text:
     raise SystemExit("expected-absent implementation anchor moved")
-path.write_text(text.replace(needle, 'printf \'%s\\n\' "expected-absent"\n    return 1', 1), encoding="utf-8")
+path.write_text(text.replace(needle, 'return 1\n      else', 1), encoding="utf-8")
 PY
-expect_status 1 "$mutant" --unit-classify-attestation assay-v5.3.0-release-proof-kit.tar.gz 404
+expect_status 1 env FAKE_GH_LOG="$attestation_gh_log" FAKE_HTTP_STATUS=404 \
+  GH="$attestation_gh" "$mutant" --unit-check-attestation \
+  assay-v5.3.0-release-proof-kit.tar.gz "$dummy_digest" "$attestation_response"
+
+# Mutation proof: API refusal is infrastructure, never a release finding.
+infra_mutant_dir="$tmp/infra-mutant"
+mkdir -p "$infra_mutant_dir"
+cp "$ORACLE" "$ASSET_CONTRACT" "$infra_mutant_dir/"
+infra_mutant="$infra_mutant_dir/verify-release.sh"
+python3 - "$infra_mutant" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+needle = '    *) return 2 ;;'
+if text.count(needle) != 1:
+    raise SystemExit("attestation infrastructure classification anchor moved")
+path.write_text(text.replace(needle, '    *) return 1 ;;', 1), encoding="utf-8")
+PY
+expect_status 1 env FAKE_GH_LOG="$attestation_gh_log" FAKE_HTTP_STATUS=403 \
+  GH="$attestation_gh" "$infra_mutant" --unit-check-attestation \
+  assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz "$dummy_digest" "$attestation_response"
 
 # A heredoc supplies Python's stdin itself, so piping JSON into one silently
 # loses the JSON. Release and provenance JSON must be parsed from a path.

--- a/scripts/ci/verify-release.sh
+++ b/scripts/ci/verify-release.sh
@@ -35,19 +35,24 @@ expected_absent_attestation() {
 
 classify_attestation() {
   local name="$1" status="$2"
-  if [[ "$status" == 404 ]] && expected_absent_attestation "$name"; then
-    printf '%s\n' "expected-absent"
-    return 0
-  fi
-  [[ "$status" == 200 ]] || return 1
-  printf '%s\n' "present"
+  case "$status" in
+    200) printf '%s\n' "present" ;;
+    404)
+      if expected_absent_attestation "$name"; then
+        printf '%s\n' "expected-absent"
+      else
+        return 1
+      fi
+      ;;
+    *) return 2 ;;
+  esac
 }
 
-# Capture command stdout before it is materialized as JSON; stderr remains visible.
-bounded_capture() {
-  local output="$1"
-  shift
-  "$PYTHON" - "$output" "$@" <<'PY'
+# Capture command output and its status under one deadline and byte ceiling.
+bounded_capture_with_status() {
+  local output="$1" status_output="$2"
+  shift 2
+  "$PYTHON" - "$output" "$status_output" "$@" <<'PY'
 import math
 import os
 import pathlib
@@ -57,7 +62,9 @@ import subprocess
 import sys
 import time
 
-output, command = pathlib.Path(sys.argv[1]), sys.argv[2:]
+output = pathlib.Path(sys.argv[1])
+status_output = pathlib.Path(sys.argv[2])
+command = sys.argv[3:]
 limit = 1024 * 1024
 raw_timeout = os.environ.get("ASSAY_RELEASE_GH_TIMEOUT_SECONDS", "60")
 try:
@@ -163,10 +170,87 @@ finally:
         if not pipe.closed:
             pipe.close()
 
-if process.returncode:
-    raise SystemExit(f"{command[0]} exited {process.returncode}")
 output.write_bytes(stdout)
+status_output.write_text(f"{process.returncode}\n", encoding="ascii")
 PY
+}
+
+# Most GitHub calls require exit zero. Attestation lookup is the exception: its
+# authenticated 404 is part of the release contract and must remain observable.
+bounded_capture() {
+  local output="$1" command_name
+  shift
+  command_name="${1:-command}"
+  local status_output="$WORK/bounded-capture-status" command_status
+  bounded_capture_with_status "$output" "$status_output" "$@" || return
+  IFS= read -r command_status <"$status_output"
+  if [[ "$command_status" -ne 0 ]]; then
+    printf '%s exited %s\n' "$command_name" "$command_status" >&2
+    return 1
+  fi
+}
+
+parse_gh_api_response() {
+  local envelope="$1" response="$2"
+  "$PYTHON" - "$envelope" "$response" <<'PY'
+import pathlib
+import re
+import sys
+
+raw = pathlib.Path(sys.argv[1]).read_bytes()
+separator = b"\r\n\r\n" if b"\r\n\r\n" in raw else b"\n\n"
+if separator not in raw:
+    raise SystemExit("GitHub API response has no header boundary")
+headers, body = raw.split(separator, 1)
+status_line = headers.splitlines()[0] if headers else b""
+match = re.fullmatch(rb"HTTP/(?:1\.[01]|2(?:\.0)?) ([0-9]{3})(?: .*)?", status_line)
+if not match:
+    raise SystemExit("GitHub API response has no valid HTTP status line")
+pathlib.Path(sys.argv[2]).write_bytes(body)
+print(match.group(1).decode("ascii"))
+PY
+}
+
+query_attestation() {
+  local name="$1" digest="$2" response="$3"
+  local envelope="${response}.envelope" status_output="${response}.command-status"
+  local command_status http_status classification
+
+  # The current verifier consumes the inline bundle retained by this API version;
+  # 2026-03-10 replaces it with a separately encoded bundle_url.
+  bounded_capture_with_status "$envelope" "$status_output" \
+    "$GH" api --include \
+      -H 'Accept: application/vnd.github+json' \
+      -H 'X-GitHub-Api-Version: 2022-11-28' \
+      "repos/$REPO/attestations/$digest" || return 2
+  IFS= read -r command_status <"$status_output"
+  http_status="$(parse_gh_api_response "$envelope" "$response")" || return 2
+
+  if [[ "$http_status" == 200 ]]; then
+    [[ "$command_status" -eq 0 ]] || return 2
+  else
+    [[ "$command_status" -ne 0 ]] || return 2
+  fi
+
+  classification="$(classify_attestation "$name" "$http_status")" || return $?
+  printf '%s\n' "$classification"
+}
+
+check_asset_attestation() {
+  local name="$1" digest="$2" response="$3"
+  local classification query_status=0
+  classification="$(query_attestation "$name" "$digest" "$response")" || query_status=$?
+  case "$query_status" in
+    0) ;;
+    1) finding "required attestation is absent: $name" ;;
+    2) infra "could not query attestation: $name" ;;
+    *) infra "attestation query returned an unknown status: $name" ;;
+  esac
+  case "$classification" in
+    present) verify_attestation_json "$response" || finding "invalid attestation: $name" ;;
+    expected-absent) ;;
+    *) infra "attestation query returned an unknown classification: $name" ;;
+  esac
 }
 
 require_tools() {
@@ -348,12 +432,8 @@ post_publish() {
       actual="sha256:$(hash_file "$WORK/assets/$name")"
       [[ "$actual" == "$digest" ]] || finding "server.json bytes differ from API digest"
     fi
-    local response="$WORK/attestation-${name}.json" status
-    status="$("$CURL" --silent --show-error --location --max-time 60 --output "$response" --write-out '%{http_code}' \
-      -H 'Accept: application/vnd.github+json' \
-      "https://api.github.com/repos/$REPO/attestations/$digest")" || infra "could not query attestation: $name"
-    classify_attestation "$name" "$status" >/dev/null || finding "unexpected attestation status $status: $name"
-    [[ "$status" == 404 ]] || verify_attestation_json "$response" || finding "invalid attestation: $name"
+    local response="$WORK/attestation-${name}.json"
+    check_asset_attestation "$name" "$digest" "$response"
   done <"$WORK/assets.tsv"
 
   local crate response newest
@@ -418,6 +498,13 @@ case "${1:-}" in
     [[ $# -eq 3 && "$2" =~ v([0-9]+\.[0-9]+\.[0-9]+) ]] || usage
     VERSION="${BASH_REMATCH[1]}"
     classify_attestation "$2" "$3"
+    exit $?
+    ;;
+  --unit-check-attestation)
+    [[ $# -eq 4 && "$2" =~ v([0-9]+\.[0-9]+\.[0-9]+) ]] || usage
+    VERSION="${BASH_REMATCH[1]}"
+    [[ "$3" =~ ^sha256:[0-9a-f]{64}$ ]] || usage
+    check_asset_attestation "$2" "$3" "$4"
     exit $?
     ;;
   --pre-tag) MODE="pre-tag"; if [[ $# -eq 2 ]]; then PIN_SHA="$2"; elif [[ $# -ne 1 ]]; then usage; fi ;;


### PR DESCRIPTION
Closes #2773.

## Change

- query release-asset attestations through authenticated `gh api --include` access;
- retain the HTTP status under the existing 1 MiB combined-output ceiling and deadline;
- classify required `404` as a finding and `401`/`403`/`429`/transport/timeout as infrastructure;
- keep the current inline-bundle verifier on API version `2022-11-28` rather than silently adding the separate Snappy `bundle_url` migration from `2026-03-10`.

## Verification

- RED first: `401` was classified as exit 1 before the implementation.
- `bash scripts/ci/test-verify-release.sh` -> PASS.
- `pre-commit run verify-release-oracle-self-test --files scripts/ci/verify-release.sh scripts/ci/test-verify-release.sh` -> Passed.
- All commit hooks passed, including shellcheck, cargo fmt, release-oracle and installer-contract hooks.
- `git diff --check` -> clean.
- Live, read-only `v6.0.0` checks through the new route:
  - required `assay-v6.0.0-x86_64-unknown-linux-gnu.tar.gz` attestation -> exit 0, inline bundle parsed;
  - expected-absent `assay-v6.0.0-release-proof-kit.tar.gz.sha256` attestation -> authenticated 404, exit 0.

## Mutation proof

- expected-absent `404` changed to finding -> targeted product-path test fails;
- API-refusal catch-all changed from infra to finding -> targeted product-path test fails;
- both mutant fixtures include the sourced release contract, so an import failure cannot satisfy them.

## Non-claims

No release asset, signer policy, existing v6.0.0 verdict, retry behavior, or attestation requirement changes. This PR does not implement the `2026-03-10` `bundle_url`/Snappy response migration.

## Exact head

- Candidate head: `68f2b9cd6127a8cba045d4a38c65f1741f685e58`
