### PR TITLE
fix(mcp): typed tools/call envelope protocol faults (#2776 Slice B)

### DIFF
--- a/crates/assay-mcp-server/src/modern_adapter.rs
+++ b/crates/assay-mcp-server/src/modern_adapter.rs
@@ -80,7 +80,13 @@ pub async fn serve(request: &Value, ctx: Option<&ToolContext>) -> Value {
         Some("server/discover") => ok_response(id, discover_result()),
         Some("tools/list") => ok_response(id, list_tools_result()),
         Some("tools/call") => match ctx {
-            Some(ctx) => ok_response(id, call_tool(request, ctx).await),
+            Some(ctx) => match tools::classify_call_tool_params(request.get("params")) {
+                Ok(dispatch) => ok_response(
+                    id,
+                    execute_known_tool(ctx, &dispatch.name, &dispatch.arguments).await,
+                ),
+                Err(fault) => error_response(id, fault.code(), fault.message(), Some(fault.data())),
+            },
             None => error_response(id, ERROR_INVALID_PARAMS, "Invalid params", None),
         },
         _ => error_response(id, ERROR_METHOD_NOT_FOUND, "Method not found", None),
@@ -137,11 +143,7 @@ fn list_tools_result() -> Value {
     result
 }
 
-async fn call_tool(request: &Value, ctx: &ToolContext) -> Value {
-    let params = request.get("params").cloned().unwrap_or_else(|| json!({}));
-    let name = params.get("name").and_then(Value::as_str).unwrap_or("");
-    let default_args = json!({});
-    let args = params.get("arguments").unwrap_or(&default_args);
+async fn execute_known_tool(ctx: &ToolContext, name: &str, args: &Value) -> Value {
     let payload = match tools::handle_call(ctx, name, args).await {
         Ok(value) => value,
         Err(_) => json!({

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -361,126 +361,137 @@ impl Server {
                     )
                 }
                 "tools/call" => {
-                    if let Some(params) = req.params {
-                        let name = params.get("name").and_then(|s| s.as_str()).unwrap_or("");
-                        let default_args = serde_json::json!({});
-                        let args = params.get("arguments").unwrap_or(&default_args);
+                    match tools::classify_call_tool_params(req.params.as_ref()) {
+                        Err(fault) => JsonRpcResponse::error_with_data(
+                            req.id.clone(),
+                            fault.code(),
+                            fault.message().to_string(),
+                            fault.data(),
+                        ),
+                        Ok(dispatch) => {
+                            let name = dispatch.name.as_str();
+                            let args = &dispatch.arguments;
 
-                        let bytes_in = line.len();
-                        let args_bytes = serde_json::to_vec(args).map(|b| b.len()).unwrap_or(0);
+                            let bytes_in = line.len();
+                            let args_bytes = serde_json::to_vec(args).map(|b| b.len()).unwrap_or(0);
 
-                        let start = std::time::Instant::now();
+                            let start = std::time::Instant::now();
 
-                        tracing::info!(
-                           event="tool_call_start",
-                           rid=%rid,
-                           rpc_id=?req.id,
-                           bytes_in=bytes_in,
-                           args_bytes=args_bytes,
-                        );
+                            tracing::info!(
+                               event="tool_call_start",
+                               rid=%rid,
+                               rpc_id=?req.id,
+                               bytes_in=bytes_in,
+                               args_bytes=args_bytes,
+                            );
 
-                        // Metered billing telemetry
-                        assay_metrics::usage::log_usage_event("policy_check", 1);
+                            // Metered billing telemetry
+                            assay_metrics::usage::log_usage_event("policy_check", 1);
 
-                        // Execute with timeout
-                        let fut = tools::handle_call(&ctx, name, args);
-                        let result = match timeout(Duration::from_millis(cfg.timeout_ms), fut).await
-                        {
-                            Ok(Ok(value)) => value,
-                            Ok(Err(_error)) => {
-                                tracing::error!(
-                                    event = "tool_execution_error",
+                            // Execute with timeout
+                            let fut = tools::handle_call(&ctx, name, args);
+                            let result = match timeout(Duration::from_millis(cfg.timeout_ms), fut)
+                                .await
+                            {
+                                Ok(Ok(value)) => value,
+                                Ok(Err(_error)) => {
+                                    tracing::error!(
+                                        event = "tool_execution_error",
+                                        rid = %rid,
+                                        rpc_id = ?req.id,
+                                        duration_ms = start.elapsed().as_millis() as u64,
+                                        code = "E_INTERNAL"
+                                    );
+                                    fail_closed_tool_result("E_INTERNAL", TOOL_EXECUTION_FAILED)?
+                                }
+                                Err(_) => {
+                                    let dur = start.elapsed().as_millis() as u64;
+                                    tracing::warn!(
+                                       event="tool_call_timeout",
+                                       rid=%rid,
+                                       rpc_id=?req.id,
+                                       duration_ms=dur,
+                                       code="E_TIMEOUT"
+                                    );
+                                    fail_closed_tool_result("E_TIMEOUT", TOOL_EXECUTION_TIMED_OUT)?
+                                }
+                            };
+
+                            let dur = start.elapsed().as_millis() as u64;
+                            // Log outcome
+                            let (allowed, is_error) = classify_tool_result(&result);
+                            if let Some(err) = result.get("error") {
+                                let code = err.get("code").and_then(|v| v.as_str()).unwrap_or("");
+                                tracing::info!(
+                                  event="tool_call_done",
+                                  rid=%rid,
+                                  rpc_id=?req.id,
+                                  duration_ms=dur,
+                                  outcome="app_error",
+                                  allowed=allowed,
+                                  code=code
+                                );
+                            } else {
+                                tracing::info!(
+                                  event="tool_call_done",
+                                  rid=%rid,
+                                  rpc_id=?req.id,
+                                  duration_ms=dur,
+                                  outcome="ok",
+                                  allowed=allowed
+                                );
+                            }
+
+                            // P57b: emit the observed tool decision (assay.tool_decision_surface.v0) as
+                            // its own structured event. Redaction and the asserted-vs-verified rule are
+                            // enforced inside build_decision; this site never has SaaS-verified evidence.
+                            {
+                                use crate::tool_decision::{build_decision, Effect, ObservedCall};
+                                let (effect, status) = if let Some(code) = result
+                                    .get("error")
+                                    .and_then(|e| e.get("code"))
+                                    .and_then(|v| v.as_str())
+                                {
+                                    (Effect::Error, code.to_string())
+                                } else if allowed {
+                                    (Effect::Allow, "success".to_string())
+                                } else {
+                                    (Effect::Deny, "blocked".to_string())
+                                };
+                                let decision = build_decision(&ObservedCall {
+                                    server_id: "mcp",
+                                    tool_name: name,
+                                    // Inspected transiently by the classifier to project named target
+                                    // fields (hashed); never copied into the record verbatim.
+                                    args,
+                                    effect,
+                                    status: &status,
+                                    rule_id: None,
+                                    // SEP-414 (MCP 2026-07-28): trace context travels in `_meta`.
+                                    // Validation and basis typing happen inside build_decision.
+                                    traceparent: crate::tool_decision::traceparent_from_params(
+                                        req.params
+                                            .as_ref()
+                                            .expect("classify_call_tool_params accepted params"),
+                                    ),
+                                });
+                                tracing::info!(
+                                    event = "tool_decision",
                                     rid = %rid,
                                     rpc_id = ?req.id,
-                                    duration_ms = start.elapsed().as_millis() as u64,
-                                    code = "E_INTERNAL"
+                                    decision = %serde_json::to_string(&decision).unwrap_or_default(),
                                 );
-                                fail_closed_tool_result("E_INTERNAL", TOOL_EXECUTION_FAILED)?
                             }
-                            Err(_) => {
-                                let dur = start.elapsed().as_millis() as u64;
-                                tracing::warn!(
-                                   event="tool_call_timeout",
-                                   rid=%rid,
-                                   rpc_id=?req.id,
-                                   duration_ms=dur,
-                                   code="E_TIMEOUT"
-                                );
-                                fail_closed_tool_result("E_TIMEOUT", TOOL_EXECUTION_TIMED_OUT)?
-                            }
-                        };
 
-                        let dur = start.elapsed().as_millis() as u64;
-                        // Log outcome
-                        let (allowed, is_error) = classify_tool_result(&result);
-                        if let Some(err) = result.get("error") {
-                            let code = err.get("code").and_then(|v| v.as_str()).unwrap_or("");
-                            tracing::info!(
-                              event="tool_call_done",
-                              rid=%rid,
-                              rpc_id=?req.id,
-                              duration_ms=dur,
-                              outcome="app_error",
-                              allowed=allowed,
-                              code=code
-                            );
-                        } else {
-                            tracing::info!(
-                              event="tool_call_done",
-                              rid=%rid,
-                              rpc_id=?req.id,
-                              duration_ms=dur,
-                              outcome="ok",
-                              allowed=allowed
-                            );
-                        }
-
-                        // P57b: emit the observed tool decision (assay.tool_decision_surface.v0) as
-                        // its own structured event. Redaction and the asserted-vs-verified rule are
-                        // enforced inside build_decision; this site never has SaaS-verified evidence.
-                        {
-                            use crate::tool_decision::{build_decision, Effect, ObservedCall};
-                            let (effect, status) = if let Some(code) = result
-                                .get("error")
-                                .and_then(|e| e.get("code"))
-                                .and_then(|v| v.as_str())
-                            {
-                                (Effect::Error, code.to_string())
-                            } else if allowed {
-                                (Effect::Allow, "success".to_string())
-                            } else {
-                                (Effect::Deny, "blocked".to_string())
-                            };
-                            let decision = build_decision(&ObservedCall {
-                                server_id: "mcp",
-                                tool_name: name,
-                                // Inspected transiently by the classifier to project named target
-                                // fields (hashed); never copied into the record verbatim.
-                                args,
-                                effect,
-                                status: &status,
-                                rule_id: None,
-                                // SEP-414 (MCP 2026-07-28): trace context travels in `_meta`.
-                                // Validation and basis typing happen inside build_decision.
-                                traceparent: crate::tool_decision::traceparent_from_params(&params),
+                            // MCP Compliance: wrap every tool outcome in CallToolResult.
+                            let json_text =
+                                serde_json::to_string_pretty(&result).unwrap_or_default();
+                            let mcp_result = serde_json::json!({
+                                "content": [{"type": "text", "text": json_text}],
+                                "isError": is_error
                             });
-                            tracing::info!(
-                                event = "tool_decision",
-                                rid = %rid,
-                                rpc_id = ?req.id,
-                                decision = %serde_json::to_string(&decision).unwrap_or_default(),
-                            );
+                            JsonRpcResponse::ok(req.id.clone(), mcp_result)
                         }
-
-                        // MCP Compliance: wrap every tool outcome in CallToolResult.
-                        let json_text = serde_json::to_string_pretty(&result).unwrap_or_default();
-                        let mcp_result = serde_json::json!({
-                            "content": [{"type": "text", "text": json_text}],
-                            "isError": is_error
-                        });
-                        JsonRpcResponse::ok(req.id.clone(), mcp_result)
-                    } else {
-                        JsonRpcResponse::error(req.id.clone(), -32602, "Missing params".to_string())
                     }
                 }
                 _ => JsonRpcResponse::error(

--- a/crates/assay-mcp-server/src/tools/call_tool_request.rs
+++ b/crates/assay-mcp-server/src/tools/call_tool_request.rs
@@ -1,0 +1,165 @@
+//! Classify a parsed `tools/call` params envelope before tool execution.
+//!
+//! Protocol faults stay value-free: fixed messages and complete `data` objects with only
+//! a stable `kind`. Hostile tool names and argument bodies never enter the public error.
+
+use serde_json::{json, Value};
+
+/// JSON-RPC invalid params. Used for both unknown-tool and malformed CallToolRequest.
+pub const ERROR_INVALID_PARAMS: i32 = -32602;
+
+/// Request-envelope failure for `tools/call` after JSON-RPC parse succeeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallToolProtocolFault {
+    /// Params missing, non-object, or fail CallToolRequest shape (name/arguments).
+    MalformedCall,
+    /// `name` is a string but not a tool this server exposes.
+    UnknownTool,
+}
+
+impl CallToolProtocolFault {
+    pub const fn code(self) -> i32 {
+        ERROR_INVALID_PARAMS
+    }
+
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::MalformedCall => "Invalid params",
+            Self::UnknownTool => "Unknown tool",
+        }
+    }
+
+    /// Complete public `error.data` object. Equality-sensitive: no extra fields.
+    pub fn data(self) -> Value {
+        match self {
+            Self::MalformedCall => json!({ "kind": "malformed_call" }),
+            Self::UnknownTool => json!({ "kind": "unknown_tool" }),
+        }
+    }
+}
+
+/// Known tool + arguments ready for execution.
+#[derive(Debug)]
+pub struct CallToolDispatch {
+    pub name: String,
+    pub arguments: Value,
+}
+
+/// True iff `name` is a tool this process will execute.
+///
+/// Single membership rule for protocol classification and dispatch.
+pub fn is_known_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "assay_check_args"
+            | "assay_check_sequence"
+            | "assay_policy_decide"
+            | "assay_check_coverage"
+            | "assay_explain_trace"
+    ) || {
+        #[cfg(feature = "test-outbound")]
+        {
+            name == "assay_test_outbound"
+        }
+        #[cfg(not(feature = "test-outbound"))]
+        {
+            false
+        }
+    }
+}
+
+/// Classify `tools/call` params after the JSON-RPC request object is parsed.
+///
+/// Does not reflect `name` or argument contents into the fault.
+pub fn classify_call_tool_params(
+    params: Option<&Value>,
+) -> Result<CallToolDispatch, CallToolProtocolFault> {
+    let Some(params) = params else {
+        return Err(CallToolProtocolFault::MalformedCall);
+    };
+    let Some(obj) = params.as_object() else {
+        return Err(CallToolProtocolFault::MalformedCall);
+    };
+    let Some(name) = obj.get("name").and_then(Value::as_str) else {
+        return Err(CallToolProtocolFault::MalformedCall);
+    };
+    let arguments = match obj.get("arguments") {
+        None => json!({}),
+        Some(value) if value.is_object() => value.clone(),
+        Some(_) => return Err(CallToolProtocolFault::MalformedCall),
+    };
+    if !is_known_tool(name) {
+        return Err(CallToolProtocolFault::UnknownTool);
+    }
+    Ok(CallToolDispatch {
+        name: name.to_string(),
+        arguments,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn malformed_and_unknown_data_are_complete_and_distinct() {
+        assert_eq!(
+            CallToolProtocolFault::MalformedCall.data(),
+            json!({ "kind": "malformed_call" })
+        );
+        assert_eq!(
+            CallToolProtocolFault::UnknownTool.data(),
+            json!({ "kind": "unknown_tool" })
+        );
+        assert_ne!(
+            CallToolProtocolFault::MalformedCall.data(),
+            CallToolProtocolFault::UnknownTool.data()
+        );
+    }
+
+    #[test]
+    fn classify_rejects_envelope_shapes_without_reflection() {
+        let hostile = format!("HEAD{}TAIL", "x".repeat(100));
+        assert_eq!(
+            classify_call_tool_params(None).unwrap_err(),
+            CallToolProtocolFault::MalformedCall
+        );
+        assert_eq!(
+            classify_call_tool_params(Some(&json!(1))).unwrap_err(),
+            CallToolProtocolFault::MalformedCall
+        );
+        assert_eq!(
+            classify_call_tool_params(Some(&json!({ "arguments": {} }))).unwrap_err(),
+            CallToolProtocolFault::MalformedCall
+        );
+        assert_eq!(
+            classify_call_tool_params(Some(&json!({ "name": 7, "arguments": {} }))).unwrap_err(),
+            CallToolProtocolFault::MalformedCall
+        );
+        assert_eq!(
+            classify_call_tool_params(Some(
+                &json!({ "name": "assay_check_args", "arguments": "nope" })
+            ))
+            .unwrap_err(),
+            CallToolProtocolFault::MalformedCall
+        );
+        let unknown = classify_call_tool_params(Some(&json!({
+            "name": hostile,
+            "arguments": { "leak": hostile }
+        })))
+        .unwrap_err();
+        assert_eq!(unknown, CallToolProtocolFault::UnknownTool);
+        let wire = serde_json::to_string(&unknown.data()).unwrap();
+        assert!(!wire.contains("HEAD"));
+        assert!(!wire.contains("TAIL"));
+        assert_eq!(unknown.message(), "Unknown tool");
+    }
+
+    #[test]
+    fn classify_accepts_known_tool_with_default_arguments() {
+        let dispatch =
+            classify_call_tool_params(Some(&json!({ "name": "assay_check_args" }))).unwrap();
+        assert_eq!(dispatch.name, "assay_check_args");
+        assert_eq!(dispatch.arguments, json!({}));
+    }
+}

--- a/crates/assay-mcp-server/src/tools/call_tool_request.rs
+++ b/crates/assay-mcp-server/src/tools/call_tool_request.rs
@@ -2,11 +2,17 @@
 //!
 //! Protocol faults stay value-free: fixed messages and complete `data` objects with only
 //! a stable `kind`. Hostile tool names and argument bodies never enter the public error.
+//!
+//! Tool membership is not restated here: [`is_known_tool`] reads the names already
+//! advertised by [`super::list_tools`].
 
 use serde_json::{json, Value};
 
 /// JSON-RPC invalid params. Used for both unknown-tool and malformed CallToolRequest.
 pub const ERROR_INVALID_PARAMS: i32 = -32602;
+
+const DATA_KIND_MALFORMED_CALL: &str = "malformed_call";
+const DATA_KIND_UNKNOWN_TOOL: &str = "unknown_tool";
 
 /// Request-envelope failure for `tools/call` after JSON-RPC parse succeeded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -32,8 +38,8 @@ impl CallToolProtocolFault {
     /// Complete public `error.data` object. Equality-sensitive: no extra fields.
     pub fn data(self) -> Value {
         match self {
-            Self::MalformedCall => json!({ "kind": "malformed_call" }),
-            Self::UnknownTool => json!({ "kind": "unknown_tool" }),
+            Self::MalformedCall => json!({ "kind": DATA_KIND_MALFORMED_CALL }),
+            Self::UnknownTool => json!({ "kind": DATA_KIND_UNKNOWN_TOOL }),
         }
     }
 }
@@ -45,27 +51,14 @@ pub struct CallToolDispatch {
     pub arguments: Value,
 }
 
-/// True iff `name` is a tool this process will execute.
+/// True iff `name` is advertised by [`super::list_tools`].
 ///
-/// Single membership rule for protocol classification and dispatch.
+/// This is the membership gate for protocol classification. It must not grow a
+/// second literal tool-name list beside `list_tools`.
 pub fn is_known_tool(name: &str) -> bool {
-    matches!(
-        name,
-        "assay_check_args"
-            | "assay_check_sequence"
-            | "assay_policy_decide"
-            | "assay_check_coverage"
-            | "assay_explain_trace"
-    ) || {
-        #[cfg(feature = "test-outbound")]
-        {
-            name == "assay_test_outbound"
-        }
-        #[cfg(not(feature = "test-outbound"))]
-        {
-            false
-        }
-    }
+    super::list_tools()
+        .iter()
+        .any(|tool| tool.get("name").and_then(Value::as_str) == Some(name))
 }
 
 /// Classify `tools/call` params after the JSON-RPC request object is parsed.
@@ -100,6 +93,7 @@ pub fn classify_call_tool_params(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
 
     #[test]
     fn malformed_and_unknown_data_are_complete_and_distinct() {
@@ -110,6 +104,11 @@ mod tests {
         assert_eq!(
             CallToolProtocolFault::UnknownTool.data(),
             json!({ "kind": "unknown_tool" })
+        );
+        assert_ne!(
+            CallToolProtocolFault::UnknownTool.data().get("kind"),
+            Some(&json!("malformed_call")),
+            "UnknownTool.data must never collapse to malformed_call"
         );
         assert_ne!(
             CallToolProtocolFault::MalformedCall.data(),
@@ -153,6 +152,11 @@ mod tests {
         assert!(!wire.contains("HEAD"));
         assert!(!wire.contains("TAIL"));
         assert_eq!(unknown.message(), "Unknown tool");
+        assert_eq!(
+            unknown.data(),
+            json!({ "kind": "unknown_tool" }),
+            "UnknownTool wire data must stay distinct from malformed_call"
+        );
     }
 
     #[test]
@@ -161,5 +165,82 @@ mod tests {
             classify_call_tool_params(Some(&json!({ "name": "assay_check_args" }))).unwrap();
         assert_eq!(dispatch.name, "assay_check_args");
         assert_eq!(dispatch.arguments, json!({}));
+    }
+
+    #[test]
+    fn classifier_membership_tracks_every_advertised_tool() {
+        let advertised: BTreeSet<String> = super::super::list_tools()
+            .iter()
+            .map(|tool| {
+                tool.get("name")
+                    .and_then(Value::as_str)
+                    .expect("list_tools entry must have a string name")
+                    .to_string()
+            })
+            .collect();
+        assert!(
+            !advertised.is_empty(),
+            "list_tools must advertise at least one tool"
+        );
+
+        for name in &advertised {
+            assert!(
+                is_known_tool(name),
+                "advertised tool {name} missing from classifier membership"
+            );
+            assert!(
+                classify_call_tool_params(Some(&json!({
+                    "name": name,
+                    "arguments": {}
+                })))
+                .is_ok(),
+                "advertised tool {name} must classify as known; dropping it from \
+                 membership (or diverging from list_tools) must fail here"
+            );
+        }
+
+        // Symmetric drift: accepting an unadvertised name must also fail this test.
+        assert!(!advertised.contains("not_an_advertised_tool"));
+        assert!(!is_known_tool("not_an_advertised_tool"));
+        assert_eq!(
+            classify_call_tool_params(Some(&json!({
+                "name": "not_an_advertised_tool",
+                "arguments": {}
+            })))
+            .unwrap_err(),
+            CallToolProtocolFault::UnknownTool
+        );
+    }
+
+    #[test]
+    fn dropping_one_advertised_name_from_membership_is_detectable() {
+        let advertised: Vec<String> = super::super::list_tools()
+            .iter()
+            .filter_map(|tool| tool.get("name").and_then(Value::as_str).map(str::to_string))
+            .collect();
+        assert!(advertised.len() >= 2, "need at least two advertised tools");
+
+        // Simulate a divergent membership list that omits the first advertised tool.
+        let omitted = &advertised[0];
+        let drifted: BTreeSet<&str> = advertised[1..].iter().map(String::as_str).collect();
+        assert!(
+            !drifted.contains(omitted.as_str()),
+            "fixture must omit one advertised name"
+        );
+
+        // Production membership must still accept the omitted name; if is_known_tool
+        // were rebuilt as `drifted.contains(name)`, this assertion is what fails.
+        assert!(
+            is_known_tool(omitted),
+            "production membership dropped advertised tool {omitted}"
+        );
+        assert!(
+            classify_call_tool_params(Some(&json!({
+                "name": omitted,
+                "arguments": {}
+            })))
+            .is_ok(),
+            "classifier must keep accepting every list_tools name; omitted={omitted}"
+        );
     }
 }

--- a/crates/assay-mcp-server/src/tools/mod.rs
+++ b/crates/assay-mcp-server/src/tools/mod.rs
@@ -437,7 +437,7 @@ pub fn list_tools() -> Vec<Value> {
 }
 
 pub async fn handle_call(ctx: &ToolContext, name: &str, args: &Value) -> anyhow::Result<Value> {
-    // Membership is owned by `is_known_tool`; callers that skip
+    // Membership is owned by `list_tools` via `is_known_tool`; callers that skip
     // `classify_call_tool_params` still must not reflect `name`.
     if !is_known_tool(name) {
         return Err(anyhow::anyhow!("unknown tool"));

--- a/crates/assay-mcp-server/src/tools/mod.rs
+++ b/crates/assay-mcp-server/src/tools/mod.rs
@@ -4,6 +4,11 @@ use std::path::PathBuf;
 use crate::cache::PolicyCaches;
 use crate::config::ServerConfig;
 
+pub mod call_tool_request;
+pub use call_tool_request::{
+    classify_call_tool_params, is_known_tool, CallToolDispatch, CallToolProtocolFault,
+};
+
 pub struct ToolContext {
     pub policy_root: PathBuf,
     pub policy_root_canon: PathBuf,
@@ -432,6 +437,11 @@ pub fn list_tools() -> Vec<Value> {
 }
 
 pub async fn handle_call(ctx: &ToolContext, name: &str, args: &Value) -> anyhow::Result<Value> {
+    // Membership is owned by `is_known_tool`; callers that skip
+    // `classify_call_tool_params` still must not reflect `name`.
+    if !is_known_tool(name) {
+        return Err(anyhow::anyhow!("unknown tool"));
+    }
     match name {
         "assay_check_args" => check_args::check_args(ctx, args).await,
         "assay_check_sequence" => check_sequence::check_sequence(ctx, args).await,
@@ -440,7 +450,7 @@ pub async fn handle_call(ctx: &ToolContext, name: &str, args: &Value) -> anyhow:
         "assay_explain_trace" => explain_trace::explain_trace(ctx, args).await,
         #[cfg(feature = "test-outbound")]
         "assay_test_outbound" => test_outbound::test_outbound(args).await,
-        _ => Err(anyhow::anyhow!("Unknown tool: {}", name)),
+        _ => unreachable!("is_known_tool accepted an unhandled name"),
     }
 }
 

--- a/crates/assay-mcp-server/tests/modern_adapter_closed_gate.rs
+++ b/crates/assay-mcp-server/tests/modern_adapter_closed_gate.rs
@@ -379,9 +379,10 @@ async fn adapter_drives_all_five_tools_and_unknown_tool() {
         json!({"name": "not_a_release_tool", "arguments": {}}),
     );
     let response = serve(&unknown, Some(&ctx)).await;
-    assert!(response.get("error").is_none(), "{response}");
-    assert_eq!(response["result"]["isError"], true);
-    assert_eq!(response["result"]["resultType"], "complete");
+    assert_eq!(response["error"]["code"], ERROR_INVALID_PARAMS);
+    assert_eq!(response["error"]["message"], "Unknown tool");
+    assert_eq!(response["error"]["data"], json!({ "kind": "unknown_tool" }));
+    assert!(response.get("result").is_none(), "{response}");
 }
 
 #[tokio::test]

--- a/crates/assay-mcp-server/tests/outer_fallback_contract.rs
+++ b/crates/assay-mcp-server/tests/outer_fallback_contract.rs
@@ -120,6 +120,28 @@ fn caller_cannot_fail_open_handler_errors() {
     assert!(conn.shutdown().success());
 }
 
+fn assert_tools_call_protocol_fault(response: &Value, id: u64, kind: &str, message: &str) {
+    assert!(
+        response.get("result").is_none(),
+        "protocol fault must not use JSON-RPC result: {response}"
+    );
+    assert_eq!(response.get("id"), Some(&Value::from(id)), "{response}");
+    let err = response
+        .get("error")
+        .unwrap_or_else(|| panic!("expected top-level JSON-RPC error: {response}"));
+    assert_eq!(err.get("code"), Some(&Value::from(-32602)), "{response}");
+    assert_eq!(
+        err.get("message").and_then(Value::as_str),
+        Some(message),
+        "{response}"
+    );
+    assert_eq!(
+        err.get("data"),
+        Some(&serde_json::json!({ "kind": kind })),
+        "complete data equality: {response}"
+    );
+}
+
 #[test]
 fn unknown_names_are_value_free() {
     let (mut conn, _root) = spawn_server(None);
@@ -131,17 +153,114 @@ fn unknown_names_are_value_free() {
     );
 
     let unknown_tool = call_tool(&mut conn, &hostile, serde_json::json!({}), 2);
-    assert_fixed_failure(&unknown_tool, "E_INTERNAL", "Tool execution failed");
+    assert_tools_call_protocol_fault(&unknown_tool, 2, "unknown_tool", "Unknown tool");
 
     let unknown_method = conn.request(&hostile, serde_json::json!({}), 3);
     assert_eq!(unknown_method["error"]["code"], -32601);
     assert_eq!(unknown_method["error"]["message"], "Method not found");
+    assert!(
+        unknown_method
+            .get("error")
+            .and_then(|e| e.get("data"))
+            .is_none(),
+        "method-not-found stays data-free: {unknown_method}"
+    );
 
     for response in [&unknown_tool, &unknown_method] {
         let wire = serde_json::to_string(response).unwrap();
         for sentinel in [HEAD, MID, TAIL] {
             assert!(!wire.contains(sentinel), "response reflected {sentinel}");
         }
+        assert!(
+            !wire.contains("E_INTERNAL"),
+            "unknown tool must not collapse to E_INTERNAL: {wire}"
+        );
+    }
+    assert!(conn.shutdown().success());
+}
+
+#[test]
+fn tools_call_envelope_faults_are_distinct_protocol_errors() {
+    let (mut conn, _root) = spawn_server(None);
+    initialize(&mut conn);
+
+    // Missing params object entirely.
+    conn.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "id": 10
+    }));
+    let missing = conn.read_response();
+    assert_tools_call_protocol_fault(&missing, 10, "malformed_call", "Invalid params");
+
+    // Non-object params.
+    conn.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": 1,
+        "id": 11
+    }));
+    let non_object = conn.read_response();
+    assert_tools_call_protocol_fault(&non_object, 11, "malformed_call", "Invalid params");
+
+    // Object params but name missing / wrong type.
+    conn.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": { "arguments": {} },
+        "id": 12
+    }));
+    let missing_name = conn.read_response();
+    assert_tools_call_protocol_fault(&missing_name, 12, "malformed_call", "Invalid params");
+
+    conn.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": { "name": 7, "arguments": {} },
+        "id": 13
+    }));
+    let bad_name_type = conn.read_response();
+    assert_tools_call_protocol_fault(&bad_name_type, 13, "malformed_call", "Invalid params");
+
+    // arguments present but not an object.
+    conn.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": { "name": "assay_check_args", "arguments": "nope" },
+        "id": 14
+    }));
+    let bad_args = conn.read_response();
+    assert_tools_call_protocol_fault(&bad_args, 14, "malformed_call", "Invalid params");
+
+    // Unknown tool stays a distinct kind from malformed_call.
+    let unknown = call_tool(&mut conn, "not_a_real_tool", serde_json::json!({}), 15);
+    assert_tools_call_protocol_fault(&unknown, 15, "unknown_tool", "Unknown tool");
+    assert_ne!(
+        unknown["error"]["data"], missing["error"]["data"],
+        "unknown_tool and malformed_call must remain distinct"
+    );
+
+    // Selected known tool with input-domain failure remains CallToolResult isError.
+    let selected = call_tool(&mut conn, "assay_check_args", serde_json::json!({}), 16);
+    assert_fixed_failure(&selected, "E_INTERNAL", "Tool execution failed");
+
+    for response in [
+        &missing,
+        &non_object,
+        &missing_name,
+        &bad_name_type,
+        &bad_args,
+        &unknown,
+    ] {
+        let wire = serde_json::to_string(response).unwrap();
+        assert!(
+            !wire.contains("E_INTERNAL"),
+            "envelope faults must not use tool E_INTERNAL: {wire}"
+        );
+        assert!(
+            response.pointer("/result/isError").is_none(),
+            "envelope faults must not be CallToolResult: {response}"
+        );
     }
     assert!(conn.shutdown().success());
 }

--- a/crates/assay-mcp-server/tests/resource_limits.rs
+++ b/crates/assay-mcp-server/tests/resource_limits.rs
@@ -90,19 +90,14 @@ fn test_transport_limit_exceeded() -> Result<()> {
         Some("Message too large"),
         "{resp}"
     );
+    // Complete data equality: an added reflected length/body field must not survive.
     assert_eq!(
-        err.pointer("/data/kind").and_then(Value::as_str),
-        Some("transport_limit"),
+        err.get("data"),
+        Some(&serde_json::json!({
+            "kind": "transport_limit",
+            "limit": LIMIT,
+        })),
         "{resp}"
-    );
-    assert_eq!(
-        err.pointer("/data/limit").and_then(Value::as_u64),
-        Some(LIMIT as u64),
-        "{resp}"
-    );
-    assert!(
-        err.get("data").and_then(|d| d.get("content")).is_none(),
-        "must not look like CallToolResult: {resp}"
     );
     assert!(
         !wire.contains(SENTINEL),


### PR DESCRIPTION
## Summary
- **#2776 Slice B**: after a parsed `tools/call` envelope, unknown tool vs malformed/missing/non-object params are distinct top-level JSON-RPC `-32602` protocol errors (`data.kind` = `unknown_tool` | `malformed_call`), value-free messages, no hostile reflection.
- Shared `tools::call_tool_request` classifier/encoder used by stdio `server.rs` and `modern_adapter`.
- Selected known-tool execution/input-domain failures remain `CallToolResult` `isError: true`.
- Carry-forward Slice A hardening: transport-limit test asserts complete `error.data` equality.

Does **not** close #2776 (remaining non-claims below).

## Test plan
- [x] RED: `unknown_names_are_value_free` (E_INTERNAL CallToolResult); `tools_call_envelope_faults_*` (Missing params / wrong shapes)
- [x] GREEN: focused outer_fallback + resource_limits + modern_adapter_closed_gate; `cargo test -p assay-mcp-server`
- [x] fmt / clippy `-D warnings` / `git diff --check`
- [x] Mutations: collapse kinds; route unknown via E_INTERNAL; reflect hostile name; selected-tool→protocol; complete `data` equality catches `bytes_in` (kind-only false-greens)

## Non-claims
- Notification silence / invalid-JSON ignore compatibility
- `structuredContent`, auth/evidence semantics, remote HTTP/OAuth
- Docs / workflows / release files
- Ready / merge / Closes


Made with [Cursor](https://cursor.com)