### PR TITLE
test(ci): separate bounded-process classifier budgets

### DIFF
--- a/scripts/ci/test_run_bounded_stdin.py
+++ b/scripts/ci/test_run_bounded_stdin.py
@@ -385,6 +385,12 @@ class BoundedStdinTests(unittest.TestCase):
             self.test_stdout_over_ceiling_terminates_tree()
         run.assert_called_once_with("flood", b"", timeout_s=CEILING_DEADLINE_S)
 
+    def test_classifier_probe_budgets_are_distinct_from_deadline_budget(self) -> None:
+        self.assertEqual(CEILING_DEADLINE_S, "0.5")
+        self.assertEqual(EXIT_CLASSIFIER_DEADLINE_S, "0.5")
+        self.assertGreater(float(CEILING_DEADLINE_S), float(DEADLINE_S))
+        self.assertGreater(float(EXIT_CLASSIFIER_DEADLINE_S), float(DEADLINE_S))
+
     def test_deadline_reaps_direct_child_and_descendant(self) -> None:
         child_record_path = self.cwd / "child-record.json"
         descendant_record_path = self.cwd / "descendant-record.json"
@@ -488,7 +494,14 @@ class BoundedStdinTests(unittest.TestCase):
             )
             return subprocess.CompletedProcess([], 7, b"", b"err-sentinel\n")
 
-        with patch.object(WORKFLOW_MOD, "run_bounded", side_effect=classified):
+        with (
+            patch.dict(
+                os.environ,
+                {"ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS": "ambient-sentinel"},
+                clear=False,
+            ),
+            patch.object(WORKFLOW_MOD, "run_bounded", side_effect=classified),
+        ):
             self.test_exit_7_allowed_preserves_rc_and_stderr()
         self.assertEqual(observed["timeout"], EXIT_CLASSIFIER_DEADLINE_S)
 

--- a/scripts/ci/test_run_bounded_stdin.py
+++ b/scripts/ci/test_run_bounded_stdin.py
@@ -25,6 +25,8 @@ WORKFLOW = ROOT / "scripts/ci/claude_plugin_install_workflow.py"
 STDIN_256K = b"x" * 262_144
 DEADLINE_S = "0.05"
 SUCCESS_DEADLINE_S = "0.5"
+CEILING_DEADLINE_S = "0.5"
+EXIT_CLASSIFIER_DEADLINE_S = "0.5"
 SLEEP_S = 0.35
 WALL_S = 1.0
 SUBPROCESS_ENV = {**os.environ, "ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS": DEADLINE_S}
@@ -372,10 +374,16 @@ class BoundedStdinTests(unittest.TestCase):
         self.assertEqual(outcome.result.returncode, 0)
 
     def test_stdout_over_ceiling_terminates_tree(self) -> None:
-        outcome = self._run("flood", b"")
+        outcome = self._run("flood", b"", timeout_s=CEILING_DEADLINE_S)
         self.assertEqual(outcome.kind, "err", outcome.reason)
         self.assertIn("ceiling", outcome.reason)
         self.assertIn("stdout", outcome.reason)
+
+    def test_stdout_ceiling_probe_uses_its_classifier_budget(self) -> None:
+        ceiling = Outcome("err", 0.0, reason="stdout exceeded ceiling")
+        with patch.object(self, "_run", return_value=ceiling) as run:
+            self.test_stdout_over_ceiling_terminates_tree()
+        run.assert_called_once_with("flood", b"", timeout_s=CEILING_DEADLINE_S)
 
     def test_deadline_reaps_direct_child_and_descendant(self) -> None:
         child_record_path = self.cwd / "child-record.json"
@@ -427,10 +435,26 @@ class BoundedStdinTests(unittest.TestCase):
         argv = _python(
             "import sys\nsys.stderr.write('err-sentinel\\n')\nraise SystemExit(7)\n"
         )
-        outcome = _invoke(WORKFLOW_MOD.run_bounded, argv, b"", self.cwd, self.pidfile)
+        outcome = _invoke(
+            WORKFLOW_MOD.run_bounded,
+            argv,
+            b"",
+            self.cwd,
+            self.pidfile,
+            timeout_s=EXIT_CLASSIFIER_DEADLINE_S,
+        )
         self.assertEqual(outcome.kind, "err", outcome.reason)
         self.assertIn("exited 7", outcome.reason)
         self.assertIn("err-sentinel", outcome.reason)
+
+    def test_rejected_exit_probe_uses_its_classifier_budget(self) -> None:
+        classified = Outcome("err", 0.0, reason="command exited 7: err-sentinel")
+        with patch(__name__ + "._invoke", return_value=classified) as invoke:
+            self.test_exit_7_rejected_preserves_sentinel()
+        self.assertEqual(
+            invoke.call_args.kwargs.get("timeout_s"),
+            EXIT_CLASSIFIER_DEADLINE_S,
+        )
 
     def test_exit_7_allowed_preserves_rc_and_stderr(self) -> None:
         argv = _python(
@@ -441,7 +465,7 @@ class BoundedStdinTests(unittest.TestCase):
         )
         with patch.dict(
             os.environ,
-            {"ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS": DEADLINE_S},
+            {"ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS": EXIT_CLASSIFIER_DEADLINE_S},
             clear=False,
         ):
             result = WORKFLOW_MOD.run_bounded(
@@ -454,6 +478,19 @@ class BoundedStdinTests(unittest.TestCase):
             )
         self.assertEqual(result.returncode, 7)
         self.assertIn(b"err-sentinel", result.stderr)
+
+    def test_allowed_exit_probe_uses_its_classifier_budget(self) -> None:
+        observed: dict[str, str | None] = {}
+
+        def classified(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+            observed["timeout"] = os.environ.get(
+                "ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS"
+            )
+            return subprocess.CompletedProcess([], 7, b"", b"err-sentinel\n")
+
+        with patch.object(WORKFLOW_MOD, "run_bounded", side_effect=classified):
+            self.test_exit_7_allowed_preserves_rc_and_stderr()
+        self.assertEqual(observed["timeout"], EXIT_CLASSIFIER_DEADLINE_S)
 
     def test_mutation_swallow_exit_7_goes_red(self) -> None:
         argv = _python(


### PR DESCRIPTION
## Summary

- give stdout-ceiling probes their own 0.5s classifier budget
- give accepted and rejected non-zero-exit probes the same bounded classifier budget
- pin each budget at the actual probe call site so a silent fallback to the 0.05s deadline fails deterministically

Fixes #2193

## Why

The shared 0.05s deadline is appropriate for the deadline-reaping tests, but it races the stdout-ceiling and exit-classification assertions under host load. Those tests can therefore report `deadline` before reaching the classifier they claim to guard. This keeps the production timeout unchanged and changes only the test probes that must reach a later failure class.

## RED -> GREEN

Before the change:

- the stdout-ceiling guard observed no explicit classifier budget
- the rejected exit-7 guard observed no explicit classifier budget
- the allowed exit-7 guard observed `0.05` instead of `0.5`

After the change:

- all three probes use their explicit `0.5s` classifier budget
- 20 consecutive repetitions of the stdout-ceiling and both exit-7 cases passed
- full focused suite: 42 tests, 0 failures

## Verification

- `python3 scripts/ci/test_run_bounded_stdin.py`
- `python3 -m py_compile scripts/ci/test_run_bounded_stdin.py`
- `git diff --check HEAD^ HEAD`
- normal pre-commit and pre-push hooks, including workspace clippy and the Linux cross-target compile gate

## Scope and non-claims

- one test file only: `scripts/ci/test_run_bounded_stdin.py`
- no production deadline or subprocess behavior changed
- no claim that every host-load source is removed; this makes the named probes reach the classifier they assert
- independent review on the first head found circular budget guards; the current head independently pins the 0.5 values and seeds an ambient sentinel
- draft until required checks and a fresh independent exact-head review are green
