### PR TITLE
docs(release): bind runbook claims to executable workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,6 +103,12 @@ repos:
         language: system
         pass_filenames: false
         files: ^(scripts/ci/(assay_review_record_check|check-review-record-workflow|test-review-record-workflow)\.py|\.github/workflows/(review-record-check|host-capability-check|ci)\.yml|docs/reference/review-record\.md|\.pre-commit-config\.yaml)$
+      - id: release-runbook-truth
+        name: Release runbook matches executable release.yml
+        entry: python3 scripts/ci/test-release-runbook-truth.py
+        language: system
+        pass_filenames: false
+        files: ^(scripts/ci/(check-release-runbook-truth|test-release-runbook-truth)\.py|docs/reference/release\.md|\.github/workflows/release\.yml|\.pre-commit-config\.yaml)$
       - id: assay-runner-lane-check-self-test
         name: Assay-Runner lane-check self-test
         entry: python3 scripts/ci/assay_runner_lane_check.py --self-test

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -77,8 +77,7 @@ This document outlines the canonical checklist for releasing new versions of Ass
   git push origin vX.Y.Z
   ```
 - [ ] **Watch CI**: Monitor the `release.yml` workflow.
-  - Step: `Publish to Crates.io` (uses `scripts/ci/publish_idempotent.sh`).
-  - Step: `Create GitHub Release` (upload binaries and release assets).
+  The GitHub Release is created before crates publication because `publish-crates` needs `release`.
   - Step: `Build assay-mcp-server MCPB` (produces `release/assay-mcp-server-${VERSION}-linux.mcpb` plus `.sha256`).
   - Step: `Render generated registry metadata` (produces `release/server.json` for later MCP registry submission).
   - Step: `Generate CycloneDX SBOM bundle` (produces `release/assay-${VERSION}-sbom-cyclonedx.tar.gz` plus `.sha256`).
@@ -86,6 +85,7 @@ This document outlines the canonical checklist for releasing new versions of Ass
   - Step: `Build release proof kit` (produces `release/assay-${VERSION}-release-proof-kit.tar.gz` plus `.sha256`).
   - Step: `Check release asset preflight` (fails before publication unless the `release/` directory exactly matches the expected asset contract, every `.sha256` verifies, and `server.json` points at the generated MCPB checksum).
   - Step: `Create GitHub Release` (uploads only the preflighted files from `release/`).
+  - Job: `publish-crates` (`Publish to crates.io`; uses `scripts/ci/publish_idempotent.sh`).
 
 ### Published binary installability
 
@@ -120,7 +120,7 @@ it is not an installer failure.
   "$install_root/bin/assay" --version
   ```
   This exercises the lockfile shipped with the published CLI rather than the workspace lock.
-- [ ] **LSM Smoke Test**: Manually dispatch the `lsm-smoke-test` workflow or run `scripts/verify_lsm_docker.sh --release-tag vX.Y.Z`.
+- [ ] **Optional LSM verification**: Not a stable-release requirement. Dispatch `release.yml` with the optional `workflow_dispatch` input `verify_lsm`, or run the supported local path `scripts/verify_lsm_docker.sh`.
 - [ ] **SBOM Asset Check**: Confirm the GitHub release includes `assay-${VERSION}-sbom-cyclonedx.tar.gz` and `assay-${VERSION}-sbom-cyclonedx.tar.gz.sha256`.
 - [ ] **MCPB Asset Check**: Confirm the GitHub release includes `assay-mcp-server-${VERSION}-linux.mcpb` and `assay-mcp-server-${VERSION}-linux.mcpb.sha256`.
 - [ ] **Registry Metadata Check**: Confirm the GitHub release includes `server.json` generated from the MCPB asset and matching SHA-256.

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -120,7 +120,7 @@ it is not an installer failure.
   "$install_root/bin/assay" --version
   ```
   This exercises the lockfile shipped with the published CLI rather than the workspace lock.
-- [ ] **Optional LSM verification**: Not a stable-release requirement. Dispatch `release.yml` with the optional `workflow_dispatch` input `verify_lsm`, or run the supported local path `scripts/verify_lsm_docker.sh`.
+- [ ] **Optional LSM verification**: Not a stable-release requirement. Dispatch `release.yml` with the optional `workflow_dispatch` input `verify_lsm`, or run the supported local path `scripts/verify_lsm_docker.sh --release-tag vX.Y.Z`.
 - [ ] **SBOM Asset Check**: Confirm the GitHub release includes `assay-${VERSION}-sbom-cyclonedx.tar.gz` and `assay-${VERSION}-sbom-cyclonedx.tar.gz.sha256`.
 - [ ] **MCPB Asset Check**: Confirm the GitHub release includes `assay-mcp-server-${VERSION}-linux.mcpb` and `assay-mcp-server-${VERSION}-linux.mcpb.sha256`.
 - [ ] **Registry Metadata Check**: Confirm the GitHub release includes `server.json` generated from the MCPB asset and matching SHA-256.

--- a/scripts/ci/check-release-runbook-truth.py
+++ b/scripts/ci/check-release-runbook-truth.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Docs/workflow contract: release runbook may name only executable release.yml surfaces."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO / ".github/workflows/release.yml"
+DOCS = REPO / "docs/reference/release.md"
+
+_LSM_SMOKE = "lsm-smoke-test"
+_BEFORE_CLAIM = re.compile(
+    r"GitHub Release is created before crates publication",
+    re.IGNORECASE,
+)
+_REVERSE_CLAIM = re.compile(
+    r"crates publication.{0,80}before.{0,80}GitHub Release",
+    re.IGNORECASE | re.DOTALL,
+)
+_NEEDS_RELEASE_IN_DOCS = re.compile(
+    r"needs `release`|needs:\s*release(?:\s|,|\]|$)",
+)
+_OPTIONAL_LSM = re.compile(r"optional", re.IGNORECASE)
+_NOT_STABLE_REQ = re.compile(
+    r"not a stable-release requirement",
+    re.IGNORECASE,
+)
+
+
+def _mapping_block(text: str, key: str, indent: int) -> str:
+    prefix = " " * indent + key + ":"
+    lines = text.splitlines(keepends=True)
+    starts = [i for i, line in enumerate(lines) if line.rstrip("\r\n") == prefix]
+    if len(starts) != 1:
+        raise AssertionError(
+            f"expected one {key!r} mapping at indent {indent}, found {len(starts)}"
+        )
+    start = starts[0]
+    end = start + 1
+    while end < len(lines):
+        raw = lines[end]
+        if raw.strip() and len(raw) - len(raw.lstrip(" ")) <= indent:
+            break
+        end += 1
+    return "".join(lines[start:end])
+
+
+def _child_entries(block: str) -> dict[str, str]:
+    lines = block.splitlines()
+    if not lines:
+        raise AssertionError("empty mapping block")
+    parent_indent = len(lines[0]) - len(lines[0].lstrip(" "))
+    child_indent = parent_indent + 2
+    entries: dict[str, str] = {}
+    for line in lines[1:]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if indent <= parent_indent:
+            break
+        if indent != child_indent:
+            continue
+        if ":" not in line:
+            continue
+        key, value = line[child_indent:].split(":", 1)
+        key = key.strip()
+        if not key:
+            continue
+        if key in entries:
+            raise AssertionError(f"duplicate mapping key {key!r}")
+        entries[key] = value
+    return entries
+
+
+def _flow_or_scalar_ids(raw: str) -> set[str] | None:
+    text = raw.split(" #", 1)[0].strip()
+    if not text or text in {">", ">-", "|", "|-"}:
+        return None
+    if text.startswith("[") and text.endswith("]"):
+        return {
+            part.strip().strip("'\"")
+            for part in text[1:-1].split(",")
+            if part.strip()
+        }
+    return {text.strip("'\"")}
+
+
+def _job_needs_ids(job: str) -> set[str]:
+    lines = job.splitlines()
+    if not lines:
+        raise AssertionError("empty job mapping")
+    job_indent = len(lines[0]) - len(lines[0].lstrip(" "))
+    needs_indent = job_indent + 2
+    prefix = " " * needs_indent + "needs:"
+    for index, line in enumerate(lines):
+        if not line.startswith(prefix):
+            continue
+        rest = line[len(prefix):]
+        parsed = _flow_or_scalar_ids(rest)
+        if parsed is not None:
+            return parsed
+        values: set[str] = set()
+        for child in lines[index + 1:]:
+            if not child.strip() or child.lstrip().startswith("#"):
+                continue
+            indent = len(child) - len(child.lstrip(" "))
+            if indent <= needs_indent:
+                break
+            stripped = child.strip()
+            if stripped.startswith("- "):
+                values.add(stripped[2:].split(" #", 1)[0].strip().strip("'\""))
+        return values
+    return set()
+
+
+def _has_verify_lsm_dispatch_input(workflow: str) -> bool:
+    on_block = _mapping_block(workflow, "on", 0)
+    dispatch = _mapping_block(on_block, "workflow_dispatch", 2)
+    inputs = _mapping_block(dispatch, "inputs", 4)
+    return "verify_lsm" in _child_entries(inputs)
+
+
+def _publish_crates_needs_release(workflow: str) -> bool:
+    jobs = _mapping_block(workflow, "jobs", 0)
+    job = _mapping_block(jobs, "publish-crates", 2)
+    return "release" in _job_needs_ids(job)
+
+
+def _watch_ci(docs: str) -> str:
+    start = docs.find("**Watch CI**")
+    if start < 0:
+        raise AssertionError("runbook is missing Watch CI")
+    rest = docs[start:]
+    cut = rest.find("\n### ")
+    return rest if cut < 0 else rest[:cut]
+
+
+def _bullet_mentions_github_release(line: str) -> bool:
+    stripped = line.strip()
+    return stripped.startswith("-") and "`Create GitHub Release`" in stripped
+
+
+def _bullet_mentions_crates(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped.startswith("-"):
+        return False
+    return (
+        "`publish-crates`" in stripped
+        or "`Publish to crates.io`" in stripped
+        or "`Publish to Crates.io`" in stripped
+    )
+
+
+def _crates_before_github_in_watch_ci(docs: str) -> bool:
+    section = _watch_ci(docs)
+    github_idx: int | None = None
+    crates_idx: int | None = None
+    for index, line in enumerate(section.splitlines()):
+        if github_idx is None and _bullet_mentions_github_release(line):
+            github_idx = index
+        if crates_idx is None and _bullet_mentions_crates(line):
+            crates_idx = index
+    if crates_idx is None:
+        return False
+    return github_idx is None or crates_idx < github_idx
+
+
+def _workflow_problems(workflow: str) -> list[str]:
+    problems: list[str] = []
+    try:
+        if not _has_verify_lsm_dispatch_input(workflow):
+            problems.append(
+                "release.yml workflow_dispatch inputs do not declare verify_lsm"
+            )
+    except AssertionError as exc:
+        problems.append(
+            f"release.yml workflow_dispatch inputs do not declare verify_lsm ({exc})"
+        )
+    try:
+        if not _publish_crates_needs_release(workflow):
+            problems.append("publish-crates job does not need release")
+    except AssertionError as exc:
+        problems.append(f"publish-crates job does not need release ({exc})")
+    return problems
+
+
+def _docs_problems(docs: str) -> list[str]:
+    problems: list[str] = []
+    if _LSM_SMOKE in docs:
+        problems.append(
+            "runbook names nonexistent workflow lsm-smoke-test"
+        )
+    if not re.search(r"`verify_lsm`", docs):
+        problems.append(
+            "runbook does not name the release.yml workflow_dispatch input verify_lsm"
+        )
+    if "workflow_dispatch" not in docs:
+        problems.append(
+            "runbook does not name verify_lsm as a workflow_dispatch input"
+        )
+    if "scripts/verify_lsm_docker.sh" not in docs:
+        problems.append(
+            "runbook does not name the local scripts/verify_lsm_docker.sh path"
+        )
+    if not _OPTIONAL_LSM.search(docs):
+        problems.append("runbook does not state LSM verification is optional")
+    if not _NOT_STABLE_REQ.search(docs):
+        problems.append(
+            "runbook does not state LSM verification is not a stable-release requirement"
+        )
+    if "publish-crates" not in docs or not _NEEDS_RELEASE_IN_DOCS.search(docs):
+        problems.append(
+            "runbook omits that publish-crates needs release"
+        )
+    if not _BEFORE_CLAIM.search(docs):
+        problems.append(
+            "runbook does not state that the GitHub Release is created before crates publication"
+        )
+    try:
+        reverse_bullets = _crates_before_github_in_watch_ci(docs)
+    except AssertionError as exc:
+        problems.append(str(exc))
+        reverse_bullets = False
+    if reverse_bullets or _REVERSE_CLAIM.search(docs):
+        problems.append(
+            "runbook documents crates publication before GitHub Release"
+        )
+    return problems
+
+
+def contract_problems(workflow: str, docs: str) -> list[str]:
+    return _workflow_problems(workflow) + _docs_problems(docs)
+
+
+def main() -> int:
+    if len(sys.argv) != 1:
+        print("FAIL: this checker accepts no arguments", file=sys.stderr)
+        return 2
+    problems = contract_problems(
+        WORKFLOW.read_text(encoding="utf-8"),
+        DOCS.read_text(encoding="utf-8"),
+    )
+    if problems:
+        for problem in problems:
+            print(f"FAIL: {problem}", file=sys.stderr)
+        return 1
+    print("ok   release runbook matches executable release.yml")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check-release-runbook-truth.py
+++ b/scripts/ci/check-release-runbook-truth.py
@@ -11,6 +11,8 @@ WORKFLOW = REPO / ".github/workflows/release.yml"
 DOCS = REPO / "docs/reference/release.md"
 
 _LSM_SMOKE = "lsm-smoke-test"
+_LSM_ITEM_TITLE = "Optional LSM verification"
+_LOCAL_LSM_CMD = "scripts/verify_lsm_docker.sh --release-tag vX.Y.Z"
 _BEFORE_CLAIM = re.compile(
     r"GitHub Release is created before crates publication",
     re.IGNORECASE,
@@ -21,11 +23,6 @@ _REVERSE_CLAIM = re.compile(
 )
 _NEEDS_RELEASE_IN_DOCS = re.compile(
     r"needs `release`|needs:\s*release(?:\s|,|\]|$)",
-)
-_OPTIONAL_LSM = re.compile(r"optional", re.IGNORECASE)
-_NOT_STABLE_REQ = re.compile(
-    r"not a stable-release requirement",
-    re.IGNORECASE,
 )
 
 
@@ -137,6 +134,29 @@ def _watch_ci(docs: str) -> str:
     return rest if cut < 0 else rest[:cut]
 
 
+def _checklist_item(docs: str, title: str) -> str:
+    heading = f"**{title}**"
+    idx = docs.find(heading)
+    if idx < 0:
+        raise AssertionError(f"runbook is missing {title} checklist item")
+    line_start = docs.rfind("\n", 0, idx)
+    start = 0 if line_start < 0 else line_start + 1
+    prefix = docs[start:idx]
+    if not re.fullmatch(r"- \[[ x]\] ", prefix):
+        raise AssertionError(f"{title} is not a checklist item")
+    lines = docs[start:].splitlines(keepends=True)
+    collected = [lines[0]]
+    for line in lines[1:]:
+        if line.startswith("- ") or line.startswith("#"):
+            break
+        collected.append(line)
+    return "".join(collected)
+
+
+def _optional_lsm_item(docs: str) -> str:
+    return _checklist_item(docs, _LSM_ITEM_TITLE)
+
+
 def _bullet_mentions_github_release(line: str) -> bool:
     stripped = line.strip()
     return stripped.startswith("-") and "`Create GitHub Release`" in stripped
@@ -186,30 +206,39 @@ def _workflow_problems(workflow: str) -> list[str]:
     return problems
 
 
+def _lsm_item_problems(docs: str) -> list[str]:
+    try:
+        item = _optional_lsm_item(docs)
+    except AssertionError as exc:
+        return [str(exc)]
+    problems: list[str] = []
+    if not re.search(r"optional", item, re.IGNORECASE):
+        problems.append(
+            "Optional LSM verification item does not state LSM verification is optional"
+        )
+    if not re.search(r"not a stable-release requirement", item, re.IGNORECASE):
+        problems.append(
+            "Optional LSM verification item does not state LSM verification is not a stable-release requirement"
+        )
+    if "workflow_dispatch" not in item or "`verify_lsm`" not in item:
+        problems.append(
+            "Optional LSM verification item omits the workflow_dispatch verify_lsm alternative"
+        )
+    if _LOCAL_LSM_CMD not in item:
+        problems.append(
+            "Optional LSM verification item omits the local "
+            "scripts/verify_lsm_docker.sh --release-tag vX.Y.Z alternative"
+        )
+    return problems
+
+
 def _docs_problems(docs: str) -> list[str]:
     problems: list[str] = []
     if _LSM_SMOKE in docs:
         problems.append(
             "runbook names nonexistent workflow lsm-smoke-test"
         )
-    if not re.search(r"`verify_lsm`", docs):
-        problems.append(
-            "runbook does not name the release.yml workflow_dispatch input verify_lsm"
-        )
-    if "workflow_dispatch" not in docs:
-        problems.append(
-            "runbook does not name verify_lsm as a workflow_dispatch input"
-        )
-    if "scripts/verify_lsm_docker.sh" not in docs:
-        problems.append(
-            "runbook does not name the local scripts/verify_lsm_docker.sh path"
-        )
-    if not _OPTIONAL_LSM.search(docs):
-        problems.append("runbook does not state LSM verification is optional")
-    if not _NOT_STABLE_REQ.search(docs):
-        problems.append(
-            "runbook does not state LSM verification is not a stable-release requirement"
-        )
+    problems.extend(_lsm_item_problems(docs))
     if "publish-crates" not in docs or not _NEEDS_RELEASE_IN_DOCS.search(docs):
         problems.append(
             "runbook omits that publish-crates needs release"

--- a/scripts/ci/test-release-runbook-truth.py
+++ b/scripts/ci/test-release-runbook-truth.py
@@ -108,6 +108,30 @@ class ReleaseRunbookTruthMutations(unittest.TestCase):
         )
         self.assertTrue(problems)
 
+    def test_docs_omit_release_tag_on_local_lsm_bites(self) -> None:
+        mutated = replace_once(
+            self.docs,
+            "scripts/verify_lsm_docker.sh --release-tag vX.Y.Z",
+            "scripts/verify_lsm_docker.sh",
+        )
+        problems = contract.contract_problems(self.workflow, mutated)
+        self.assertTrue(problems, "mutation survived")
+        self.assertTrue(
+            any("--release-tag" in problem for problem in problems),
+            problems,
+        )
+
+    def test_docs_move_lsm_phrase_outside_item_bites(self) -> None:
+        mutated = replace_once(
+            self.docs,
+            "Not a stable-release requirement. ",
+            "",
+        ) + "\nNot a stable-release requirement.\n"
+        self.assertIn("not a stable-release requirement", mutated.lower())
+        self.assert_mutation_bites(docs=mutated)
+        item = contract._optional_lsm_item(mutated)
+        self.assertNotIn("not a stable-release requirement", item.lower())
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/ci/test-release-runbook-truth.py
+++ b/scripts/ci/test-release-runbook-truth.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Mutation oracle for the release runbook / release.yml contract."""
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CHECKER = REPO / "scripts/ci/check-release-runbook-truth.py"
+
+spec = importlib.util.spec_from_file_location("release_runbook_truth", CHECKER)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"cannot load {CHECKER}")
+contract = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(contract)
+
+
+def replace_once(text: str, old: str, new: str) -> str:
+    if text.count(old) != 1:
+        raise AssertionError(f"mutation anchor count for {old!r}: {text.count(old)}")
+    return text.replace(old, new, 1)
+
+
+class ReleaseRunbookTruthMutations(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = contract.WORKFLOW.read_text(encoding="utf-8")
+        cls.docs = contract.DOCS.read_text(encoding="utf-8")
+        cls.assert_clean(cls.workflow, cls.docs)
+
+    @classmethod
+    def assert_clean(cls, workflow: str, docs: str) -> None:
+        problems = contract.contract_problems(workflow, docs)
+        if problems:
+            raise AssertionError("; ".join(problems))
+
+    def assert_mutation_bites(
+        self, *, workflow: str | None = None, docs: str | None = None,
+    ) -> None:
+        problems = contract.contract_problems(
+            workflow if workflow is not None else self.workflow,
+            docs if docs is not None else self.docs,
+        )
+        self.assertTrue(problems, "mutation survived")
+
+    def test_current_tree_control_stays_green(self) -> None:
+        self.assert_clean(self.workflow, self.docs)
+
+    def test_rename_verify_lsm_input_bites(self) -> None:
+        self.assert_mutation_bites(workflow=replace_once(
+            self.workflow, "      verify_lsm:\n", "      verify_lsm_renamed:\n"))
+
+    def test_remove_publish_crates_needs_release_bites(self) -> None:
+        self.assert_mutation_bites(workflow=replace_once(
+            self.workflow, "    needs: release\n", "    needs: build\n"))
+
+    def test_publish_crates_needs_list_without_release_bites(self) -> None:
+        self.assert_mutation_bites(workflow=replace_once(
+            self.workflow, "    needs: release\n", "    needs: [build]\n"))
+
+    def test_publish_crates_needs_list_including_release_stays_green(self) -> None:
+        self.assert_clean(
+            replace_once(self.workflow, "    needs: release\n", "    needs: [release]\n"),
+            self.docs,
+        )
+
+    def test_docs_reverse_order_bites(self) -> None:
+        mutated = replace_once(
+            self.docs,
+            "The GitHub Release is created before crates publication because `publish-crates` needs `release`.",
+            "crates publication before GitHub Release; omit the needs reason.",
+        )
+        self.assert_mutation_bites(docs=mutated)
+
+    def test_docs_omit_needs_release_reason_bites(self) -> None:
+        mutated = replace_once(
+            self.docs,
+            "because `publish-crates` needs `release`.",
+            "because crates follow the GitHub Release.",
+        )
+        self.assert_mutation_bites(docs=mutated)
+
+    def test_docs_reintroduce_lsm_smoke_test_bites(self) -> None:
+        mutated = self.docs + (
+            "\nManually dispatch the lsm-smoke-test workflow.\n"
+        )
+        problems = contract.contract_problems(self.workflow, mutated)
+        self.assertTrue(problems, "mutation survived")
+        self.assertTrue(
+            any("lsm-smoke-test" in problem for problem in problems),
+            problems,
+        )
+        self.assert_clean(self.workflow, self.docs)
+
+    def test_noop_comment_on_workflow_stays_green(self) -> None:
+        self.assert_clean(self.workflow + "\n# no-op control\n", self.docs)
+
+    def test_noop_comment_on_docs_stays_green(self) -> None:
+        self.assert_clean(self.workflow, self.docs + "\n<!-- no-op control -->\n")
+
+    def test_checker_searches_docs_argument_not_dunder_file(self) -> None:
+        source = Path(contract.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("Path(__file__).read_text()", source)
+        self.assertNotIn("lsm-smoke-test", self.docs)
+        problems = contract.contract_problems(
+            self.workflow, self.docs + "\nlsm-smoke-test\n",
+        )
+        self.assertTrue(problems)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #2772.

## What changed

- correct the release runbook to describe the actual `release` -> `publish-crates` dependency
- replace the nonexistent `lsm-smoke-test` instruction with the real optional `verify_lsm` dispatch input and the supported local `--release-tag` command
- add a workflow/docs contract checker and mutation-sensitive self-test
- wire the focused contract into pre-commit

## Verification

- `python3 scripts/ci/test-release-runbook-truth.py` (13 tests)
- `python3 scripts/ci/check-release-runbook-truth.py`
- `git diff --check`
- full pre-push hook: passed on the pre-merge candidate; the push hook re-runs it on the final merged head

## Non-claims

- no release behavior, tag, asset, registry, install pin, or crate membership changes
- optional LSM verification is not made a stable-release requirement
- this does not retroactively invalidate v6.0.0
