### PR TITLE
docs(agents): add Antigravity writer boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Assay Agent Contract
 
-This file is the shared operating contract for Codex, Claude Code, Cursor, and automated PR
-reviewers. Tool-specific instruction files may add mechanics, but they must not restate or weaken
-this contract.
+This file is the shared operating contract for Codex, Claude Code, Cursor, Antigravity, and
+automated PR reviewers. Tool-specific instruction files may add mechanics, but they must not
+restate or weaken this contract.
 
 ## Canonical State
 
@@ -43,7 +43,8 @@ including its explicit non-claims, or amend the decision through a new ADR.
 
 - One writer owns a branch and worktree. Other agents review the diff without editing that branch.
 - At most two ADR-042/043 implementation branches may be active at once.
-- Use `codex/`, `claude/`, `cursor/`, or `ruley/` branch prefixes matching the writer.
+- Use `codex/`, `claude/`, `cursor/`, `antigravity/`, or `ruley/` branch prefixes matching the
+  writer.
 - Do not implement on `main`.
 - Build in the worktree's own `target/`. Cargo creates one per worktree on first build, so
   worktrees do not share one unless told to, and `/target` is git-ignored so an in-tree build
@@ -164,6 +165,11 @@ so that display and round-trip "can never drift apart".
   plan/read-only mode.
 - Cursor may implement locally in its own worktree. Cursor Background Agents must not mutate auth
   or evidence-boundary code.
+- Antigravity may implement a bounded slice in its own worktree and may use GitHub MCP for its
+  owned branch, PR, and task updates. GitHub write capability is not standing permission to mutate
+  repository state: each write must belong to the concrete assigned lease. It must not inspect,
+  print, copy, or modify credential material, and it must not use commits, comments, or other
+  repository mutations as permission probes.
 - Ruley (GrokBot) may implement a bounded slice in its own worktree and may post issue and PR
   updates. It must not write directly to `main` or use repository mutations as permission probes;
   verify access through read-only API metadata and perform writes only on its owned branch.


### PR DESCRIPTION
## Summary

- add Antigravity to the shared agent contract
- reserve the `antigravity/` branch prefix for its owned worktrees
- permit GitHub MCP writes only within a concrete assigned lease
- prohibit credential inspection and repository mutations used as permission probes

## Verification

- exact base: `f480f6b9254bb379f1955217cd01d13978307c19`
- commit: `a8729f251`
- `git diff --check`
- normal commit and push hooks, including `cargo fmt --check`, workspace clippy with `-D warnings`, and the Linux cross-target compile gate

## Review

Builder: Codex. A fresh non-building exact-head review is required before merge.

## Non-claims

This grants no standing permission to write to GitHub, bypass branch protection, inspect credentials, mutate `main`, or edit another agent's worktree.
