### PR TITLE
test(ci): pin release-surface zero counts, member exclusion and caret compatibility

### DIFF
--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -313,6 +313,26 @@ run_check >"$TMP/noop.out" 2>&1
 mv "$TMP/readme-noop.backup" "$TMP/README.md"
 
 mutation_count=0
+control_count=0
+
+# A negative control: the mutated tree must still be accepted. Deleting the production guard it
+# names turns the acceptance into a rejection, which is how the control bites.
+mutate_and_expect_success() {
+  local name="$1" file="$2" sed_expr="$3"
+  local original="$TMP/$file" backup="$TMP/$file.$name"
+  cp "$original" "$backup"
+  sed -i.bak -e "$sed_expr" "$original"
+  rm -f "$original.bak"
+  if ! run_check >"$TMP/$name.out" 2>&1; then
+    echo "FAIL: control $name must be accepted, but the check reported:" >&2
+    grep '^FAIL' "$TMP/$name.out" >&2 || cat "$TMP/$name.out" >&2
+    exit 1
+  fi
+  mv "$backup" "$original"
+  control_count=$((control_count + 1))
+  echo "PASS: $name (accepted)"
+}
+
 mutate_and_expect_failure() {
   local name="$1" file="$2" sed_expr="$3" diagnostic="$4"
   local original="$TMP/$file" backup="$TMP/$file.$name"
@@ -709,6 +729,38 @@ TOML
 mutate_and_expect_failure root-dep-versionless Cargo.toml \
   's/assay-x = { version = "5.2.0", path = "crates\/assay-x" }/assay-x = { path = "crates\/assay-x" }/' \
   'Cargo.toml: assay-x in [workspace.dependencies] is a path dependency on a workspace member with no version'
+
+# --- #2798: the three residuals from the independent review of #2794 ---
+#
+# Each was reproduced on 6889ba765 by deleting its production guard in an isolated scratch copy and
+# observing the harness stay green at 124. These tests are what make that deletion visible.
+
+# 1. Literal zero counts, reached independently. The pre-existing count tests suppress the line
+# entirely and so exercise the empty-string branch; neither reaches the numeric `-eq 0` branch.
+# Emptying [workspace.dependencies] leaves the crate site untouched, and narrowing members to the
+# one crate that declares nothing leaves the root site untouched.
+mutate_and_expect_failure root-count-literal-zero Cargo.toml \
+  '/^assay-x = { version = "5.2.0", path = "crates\/assay-x" }$/d' \
+  'no internal path dependencies found in [workspace.dependencies]; the enumeration is broken'
+mutate_and_expect_failure crate-count-literal-zero Cargo.toml \
+  's|members = \["crates/assay-x", "crates/assay-y", "crates/assay-p", "sdk-z"\]|members = ["crates/assay-x"]|' \
+  'no crate-level path dependencies on workspace members found; the enumeration is broken'
+
+# 2. A member wildcard that actually selects the excluded crate. The explicit member list never
+# names crates/assay-excluded, so exclusion could stop working unobserved. "crates/*" selects it,
+# and the excluded crate carries a stale 5.0.0 declaration, so accepting this tree is only possible
+# if exclusion is still applied.
+mutate_and_expect_success member-glob-intersects-exclude Cargo.toml \
+  's|members = \["crates/assay-x", "crates/assay-y", "crates/assay-p", "sdk-z"\]|members = ["crates/*", "sdk-z"]|'
+
+# 3. Caret requirements through the shared checker, both directions. A correct caret must be
+# accepted -- that is the branch nothing exercised -- and a caret naming the wrong version must
+# still be reported, so compatibility is not bought by loosening the comparison.
+mutate_and_expect_success caret-correct-requirement crates/assay-y/Cargo.toml \
+  '/^\[dependencies\]/,/^\[build/ s/version = "5.2.0"/version = "^5.2.0"/'
+mutate_and_expect_failure caret-mismatched-requirement crates/assay-y/Cargo.toml \
+  '/^\[dependencies\]/,/^\[build/ s/version = "5.2.0"/version = "^5.0.0"/' \
+  'crates/assay-y/Cargo.toml: assay-x in [dependencies] declares version "^5.0.0", workspace is "5.2.0"'
 
 # --- containment: expansion must not read outside the root either ---
 mutate_and_expect_failure member-glob-through-symlink Cargo.toml \
@@ -1157,8 +1209,13 @@ cargo install --path crates/assay-mcp-server --locked
 ```
 MD
 
-if [ "$mutation_count" -ne 124 ]; then
-  echo "FAIL: expected 124 release-surface mutations, observed $mutation_count" >&2
+if [ "$mutation_count" -ne 127 ]; then
+  echo "FAIL: expected 127 release-surface mutations, observed $mutation_count" >&2
+  exit 1
+fi
+if [ "$control_count" -ne 2 ]; then
+  echo "FAIL: expected 2 release-surface negative controls, observed $control_count" >&2
   exit 1
 fi
 echo "release-surface mutations: $mutation_count observed"
+echo "release-surface negative controls: $control_count observed"


### PR DESCRIPTION
Exact head: `39b90a9df2ee1ddb975d463ce1bbefb476d3162c`.

Closes #2798.

Test-only slice. Production is byte-identical to the gate SHA `6889ba7657084dc21ac50245098c582272f05b92`
— `git diff` against it over `check-release-surface.sh`, `check_internal_dep_versions.py` and
`.pre-commit-config.yaml` is empty. No production defect was found, so no separate disposition is
needed and no second file was required.

## The three residuals, reproduced before writing anything

Each production guard was deleted in an **isolated scratch copy** (a copy of `scripts/` plus
`.pre-commit-config.yaml` under a scratchpad, never the branch) and the existing harness run against
it. All three survived, so all three observations from the independent review of #2794 hold.

| Guard deleted | Site | Existing harness |
|---|---|---|
| both `-eq 0` branches | `check-release-surface.sh:118,126` | exit 0, 124 — survives |
| `resolved in excluded` | `check_internal_dep_versions.py:190` | exit 0, 124 — survives |
| `removeprefix("^")` | `check_internal_dep_versions.py:239` | exit 0, 124 — survives |

**One reproduction had to be redone, and it changes what the evidence means.** Deleting
`excluded = set(contained_entries("exclude"))` outright *did* fail the harness — but on
`exclude-entry-escapes-root`, the containment mutation #2794 already pins. That is evidence about
whether exclude entries are *contained*, not about whether exclusion *excludes*. Removing only the
application leaves containment intact and survives, which is the residual the issue names. The
coarse cut would have let this slice claim coverage that does not exist.

## The five tests

Built from the three named counterexamples, not new generic machinery.

| Test | Counterexample |
|---|---|
| `root-count-literal-zero` | empty `[workspace.dependencies]`; crate site untouched |
| `crate-count-literal-zero` | members narrowed to the one crate that declares nothing; root site untouched |
| `member-glob-intersects-exclude` | `members = ["crates/*", "sdk-z"]`, which genuinely selects `crates/assay-excluded` and its stale `5.0.0` declaration |
| `caret-correct-requirement` | `^5.2.0` must be accepted |
| `caret-mismatched-requirement` | `^5.0.0` must still be reported |

The two count tests are separate because a combined deletion cannot attribute a bite — deleting both
branches names only whichever test runs first. Deleted singly, each names its own.

Two of these are only expressible as a manifest that must be **accepted**, which
`mutate_and_expect_failure` cannot state. `mutate_and_expect_success` is added as its symmetric
counterpart with its own asserted counter.

## Deletion-survival, each guard cut singly with production otherwise pristine

| Guard | Test that bites | Reason it reported |
|---|---|---|
| root `-eq 0` | `root-count-literal-zero` | mutation not observed |
| crate `-eq 0` | `crate-count-literal-zero` | mutation not observed |
| `resolved in excluded` | `member-glob-intersects-exclude` | `crates/assay-excluded/Cargo.toml: assay-x in [dependencies] declares version "5.0.0", workspace is "5.2.0"` |
| `removeprefix("^")` | `caret-correct-requirement` | `crates/assay-y/Cargo.toml: assay-x in [dependencies] declares version "^5.2.0", workspace is "5.2.0"` |

Each fails for its own named reason rather than a setup or import error. Production was restored
after every mutation and the restoration verified by diff.

## Counts

**124 → 127** mutations (+3), plus **2** negative controls in a separate asserted counter. The
controls are deliberately not folded into the mutation figure: they assert acceptance and can never
observe a mutation, so merging them would inflate it. Both counters are asserted, so either one
silently losing a test fails the run.

Focused runs are not added to the suite total — the 127 is the full harness count, and the
deletion-survival runs above are separate invocations of that same harness.

## Commands run

```
bash scripts/ci/test-check-release-surface.sh      # exit 0 — 127 mutations, 2 controls
bash scripts/ci/check-release-surface.sh           # exit 0 — 13 root + 9 crate declarations
shellcheck -x -S warning scripts/ci/test-check-release-surface.sh scripts/ci/check-release-surface.sh
git diff --check
```

No Rust build, no cargo, no rustc — the scope is shell and Python only and the issue confirms none
is needed.

## Non-claims

- No change to Cargo compatibility scope, supported glob grammar, release versions,
  published-artifact availability, authentication, or product guarantees.
- The version rule is not duplicated in a second validator; these tests exercise the existing
  shared checker.
- `caret-mismatched-requirement` does **not** discriminate the caret guard: `^5.0.0` is reported
  with or without `removeprefix`. It pins that compatibility is not bought by loosening the
  comparison. Four of the five tests bite a guard; this one guards against a future over-permissive
  fix.
- The known gaps recorded on #2794 are unchanged and out of scope here: `=6.1.0` / range requirement
  syntaxes reported as drift, case-only path differences on a case-insensitive filesystem, and
  counts that remain floor-guarded.
- These tests and the code they exercise were written by the same author. Antigravity independently reviewed this exact head: READY, no actionable findings; see the SHA-bound review record in comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

