### PR TITLE
fix(ci): align Codex host-proof projection with 0.153.1 schema

### DIFF
--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -707,6 +707,55 @@ export function isProofRpcId(id) {
   return Number.isSafeInteger(id);
 }
 
+function retainedAppContextReason(value) {
+  if (value == null) {
+    return null;
+  }
+  if (!isPlainObject(value)) {
+    return "appContext must be an object or null";
+  }
+  const allowed = ["actionName", "appName", "connectorId", "linkId", "resourceUri"];
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) {
+      return `appContext contains unexpected key ${key}`;
+    }
+  }
+  if (!isNonemptyString(value.connectorId)) {
+    return "appContext requires non-empty string connectorId";
+  }
+  if (hasOwn(value, "actionName") && value.actionName !== null && typeof value.actionName !== "string") {
+    return "appContext actionName must be a string or null";
+  }
+  if (hasOwn(value, "appName") && value.appName !== null && typeof value.appName !== "string") {
+    return "appContext appName must be a string or null";
+  }
+  if (hasOwn(value, "linkId") && value.linkId !== null && typeof value.linkId !== "string") {
+    return "appContext linkId must be a string or null";
+  }
+  if (hasOwn(value, "resourceUri") && value.resourceUri !== null && typeof value.resourceUri !== "string") {
+    return "appContext resourceUri must be a string or null";
+  }
+  return null;
+}
+
+function retainedMcpToolCallErrorReason(value) {
+  if (value == null) {
+    return null;
+  }
+  if (!isPlainObject(value)) {
+    return "error must be an object or null";
+  }
+  for (const key of Object.keys(value)) {
+    if (key !== "message") {
+      return `error contains unexpected key ${key}`;
+    }
+  }
+  if (typeof value.message !== "string") {
+    return "error requires string message";
+  }
+  return null;
+}
+
 function retainedItemReason(item, label = "item/completed") {
   if (!isPlainObject(item) || !isNonemptyString(item.type) || !isNonemptyString(item.id)) {
     return `${label} item is not a typed retained item`;
@@ -719,17 +768,78 @@ function retainedItemReason(item, label = "item/completed") {
         return null;
       }
       return `${label} ${item.type} is not the closed non-evidentiary projection`;
-    case "mcpToolCall":
-      if (
-        isNonemptyString(item.server) &&
-        isNonemptyString(item.tool) &&
-        isPlainObject(item.arguments) &&
-        isNonemptyString(item.status) &&
-        (item.result == null || isPlainObject(item.result))
-      ) {
-        return null;
+    case "mcpToolCall": {
+      const allowedKeys = [
+        "appContext",
+        "arguments",
+        "durationMs",
+        "error",
+        "id",
+        "mcpAppResourceUri",
+        "pluginId",
+        "readOnlyHint",
+        "result",
+        "server",
+        "status",
+        "tool",
+        "type",
+      ];
+      for (const key of Object.keys(item)) {
+        if (!allowedKeys.includes(key)) {
+          return `${label} mcpToolCall contains unexpected key ${key}`;
+        }
       }
-      return `${label} mcpToolCall is missing required retained fields`;
+      if (
+        !isNonemptyString(item.server) ||
+        !isNonemptyString(item.tool) ||
+        !isPlainObject(item.arguments) ||
+        !isNonemptyString(item.status) ||
+        (hasOwn(item, "result") && item.result !== null && !isPlainObject(item.result))
+      ) {
+        return `${label} mcpToolCall is missing required retained fields`;
+      }
+      if (
+        hasOwn(item, "durationMs") &&
+        item.durationMs !== null &&
+        !(typeof item.durationMs === "number" && Number.isSafeInteger(item.durationMs) && item.durationMs >= 0)
+      ) {
+        return `${label} mcpToolCall durationMs must be a non-negative integer or null`;
+      }
+      if (
+        hasOwn(item, "readOnlyHint") &&
+        item.readOnlyHint !== null &&
+        typeof item.readOnlyHint !== "boolean"
+      ) {
+        return `${label} mcpToolCall readOnlyHint must be a boolean or null`;
+      }
+      if (
+        hasOwn(item, "pluginId") &&
+        item.pluginId !== null &&
+        typeof item.pluginId !== "string"
+      ) {
+        return `${label} mcpToolCall pluginId must be a string or null`;
+      }
+      if (
+        hasOwn(item, "mcpAppResourceUri") &&
+        item.mcpAppResourceUri !== null &&
+        typeof item.mcpAppResourceUri !== "string"
+      ) {
+        return `${label} mcpToolCall mcpAppResourceUri must be a string or null`;
+      }
+      if (hasOwn(item, "appContext")) {
+        const appContextReason = retainedAppContextReason(item.appContext);
+        if (appContextReason) {
+          return `${label} mcpToolCall ${appContextReason}`;
+        }
+      }
+      if (hasOwn(item, "error")) {
+        const errorReason = retainedMcpToolCallErrorReason(item.error);
+        if (errorReason) {
+          return `${label} mcpToolCall ${errorReason}`;
+        }
+      }
+      return null;
+    }
     case "userMessage":
       if (Array.isArray(item.content)) {
         return null;
@@ -1566,6 +1676,9 @@ function classifyInvocation(calls, expected, threadId, turnId, topology) {
   if (item.tool !== DECIDE_TOOL) {
     return cell("fail", `wrong tool ${item.tool}`);
   }
+  if (item.error != null) {
+    return cell("fail", "mcpToolCall contains an error");
+  }
   if (item.status !== "completed") {
     return cell("fail", `tool status ${item.status}`);
   }
@@ -2101,16 +2214,50 @@ function projectAppContext(value) {
     return invalidProjection(value);
   }
   const out = {};
-  if (hasOwn(value, "connectorId")) {
+  if (typeof value.connectorId === "string" && value.connectorId.length > 0) {
     out.connectorId = projectedScalar(value.connectorId);
+  } else {
+    out.connectorId = invalidProjection(value.connectorId);
+  }
+  if (hasOwn(value, "actionName")) {
+    out.actionName =
+      value.actionName == null
+        ? null
+        : typeof value.actionName === "string"
+          ? projectedScalar(value.actionName)
+          : invalidProjection(value.actionName);
+  }
+  if (hasOwn(value, "appName")) {
+    out.appName =
+      value.appName == null
+        ? null
+        : typeof value.appName === "string"
+          ? projectedScalar(value.appName)
+          : invalidProjection(value.appName);
   }
   if (hasOwn(value, "linkId")) {
-    out.linkId = value.linkId == null ? null : projectedScalar(value.linkId);
+    out.linkId =
+      value.linkId == null
+        ? null
+        : typeof value.linkId === "string"
+          ? projectedScalar(value.linkId)
+          : invalidProjection(value.linkId);
   }
   if (hasOwn(value, "resourceUri")) {
-    out.resourceUri = value.resourceUri == null ? null : projectedScalar(value.resourceUri);
+    out.resourceUri =
+      value.resourceUri == null
+        ? null
+        : typeof value.resourceUri === "string"
+          ? projectedScalar(value.resourceUri)
+          : invalidProjection(value.resourceUri);
   }
-  return withUnexpectedKeys(out, value, ["connectorId", "linkId", "resourceUri"]);
+  return withUnexpectedKeys(out, value, [
+    "actionName",
+    "appName",
+    "connectorId",
+    "linkId",
+    "resourceUri",
+  ]);
 }
 
 function projectMcpToolCallError(value) {
@@ -2121,11 +2268,10 @@ function projectMcpToolCallError(value) {
     return invalidProjection(value);
   }
   const out = {};
-  if (hasOwn(value, "message")) {
-    out.message =
-      typeof value.message === "string"
-        ? projectedScalar(scrub(value.message))
-        : invalidProjection(value.message);
+  if (typeof value.message === "string") {
+    out.message = projectedScalar(scrub(value.message));
+  } else {
+    out.message = invalidProjection(value.message);
   }
   return withUnexpectedKeys(out, value, ["message"]);
 }
@@ -2156,17 +2302,38 @@ function projectRetainedItem(item) {
     out.result = item.result == null ? null : projectToolResult(item.result);
   }
   if (hasOwn(item, "durationMs")) {
-    out.durationMs = item.durationMs == null ? null : projectedScalar(item.durationMs);
+    out.durationMs =
+      item.durationMs == null
+        ? null
+        : typeof item.durationMs === "number" &&
+            Number.isSafeInteger(item.durationMs) &&
+            item.durationMs >= 0
+          ? item.durationMs
+          : invalidProjection(item.durationMs);
   }
   if (hasOwn(item, "readOnlyHint")) {
-    out.readOnlyHint = item.readOnlyHint == null ? null : projectedScalar(item.readOnlyHint);
+    out.readOnlyHint =
+      item.readOnlyHint == null
+        ? null
+        : typeof item.readOnlyHint === "boolean"
+          ? item.readOnlyHint
+          : invalidProjection(item.readOnlyHint);
   }
   if (hasOwn(item, "pluginId")) {
-    out.pluginId = item.pluginId == null ? null : projectedScalar(item.pluginId);
+    out.pluginId =
+      item.pluginId == null
+        ? null
+        : typeof item.pluginId === "string"
+          ? projectedScalar(item.pluginId)
+          : invalidProjection(item.pluginId);
   }
   if (hasOwn(item, "mcpAppResourceUri")) {
     out.mcpAppResourceUri =
-      item.mcpAppResourceUri == null ? null : projectedScalar(item.mcpAppResourceUri);
+      item.mcpAppResourceUri == null
+        ? null
+        : typeof item.mcpAppResourceUri === "string"
+          ? projectedScalar(item.mcpAppResourceUri)
+          : invalidProjection(item.mcpAppResourceUri);
   }
   if (hasOwn(item, "appContext")) {
     out.appContext = projectAppContext(item.appContext);

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -459,7 +459,11 @@ export function requiredCellsForJourney(journey) {
 export const EXPECTED_ELICITATION = Object.freeze({
   serverName: "assay",
   mode: "form",
-  message: `approve ${DECIDE_TOOL}`,
+  messages: Object.freeze([
+    `Allow the assay MCP server to run tool "${DECIDE_TOOL}"?`,
+    `approve ${DECIDE_TOOL}`,
+  ]),
+  message: `Allow the assay MCP server to run tool "${DECIDE_TOOL}"?`,
   requestedSchema: Object.freeze({
     type: "object",
     properties: Object.freeze({}),
@@ -472,7 +476,7 @@ export function elicitationAcceptable(params, threadId, turnId) {
     typeof params === "object" &&
     params.serverName === EXPECTED_ELICITATION.serverName &&
     params.mode === EXPECTED_ELICITATION.mode &&
-    params.message === EXPECTED_ELICITATION.message &&
+    EXPECTED_ELICITATION.messages.includes(params.message) &&
     sameJson(params.requestedSchema, EXPECTED_ELICITATION.requestedSchema) &&
     typeof threadId === "string" &&
     threadId.length > 0 &&
@@ -628,6 +632,7 @@ export const LIFECYCLE_SERVER_NOTIFICATIONS = Object.freeze([
   "thread/tokenUsage/updated",
   "turn/started",
   "item/started",
+  "serverRequest/resolved",
 ]);
 export const SERVER_DIAGNOSTIC_NOTIFICATIONS = Object.freeze(["warning", "error"]);
 export const ALLOWED_SERVER_NOTIFICATIONS = Object.freeze([
@@ -709,6 +714,7 @@ function retainedItemReason(item, label = "item/completed") {
   switch (item.type) {
     case "reasoning":
     case "agentMessage":
+    case "commandExecution":
       if (exactKeys(item, ["type", "id"])) {
         return null;
       }
@@ -2087,6 +2093,43 @@ function retainedClientRequestParamsReason(method, params) {
   return null;
 }
 
+function projectAppContext(value) {
+  if (value == null) {
+    return null;
+  }
+  if (!isPlainObject(value)) {
+    return invalidProjection(value);
+  }
+  const out = {};
+  if (hasOwn(value, "connectorId")) {
+    out.connectorId = projectedScalar(value.connectorId);
+  }
+  if (hasOwn(value, "linkId")) {
+    out.linkId = value.linkId == null ? null : projectedScalar(value.linkId);
+  }
+  if (hasOwn(value, "resourceUri")) {
+    out.resourceUri = value.resourceUri == null ? null : projectedScalar(value.resourceUri);
+  }
+  return withUnexpectedKeys(out, value, ["connectorId", "linkId", "resourceUri"]);
+}
+
+function projectMcpToolCallError(value) {
+  if (value == null) {
+    return null;
+  }
+  if (!isPlainObject(value)) {
+    return invalidProjection(value);
+  }
+  const out = {};
+  if (hasOwn(value, "message")) {
+    out.message =
+      typeof value.message === "string"
+        ? projectedScalar(scrub(value.message))
+        : invalidProjection(value.message);
+  }
+  return withUnexpectedKeys(out, value, ["message"]);
+}
+
 function projectRetainedItem(item) {
   if (!isPlainObject(item)) {
     return invalidProjection(item);
@@ -2094,7 +2137,11 @@ function projectRetainedItem(item) {
   if (item.type === "userMessage") {
     return { type: "userMessage", id: projectedScalar(item.id), content: [] };
   }
-  if (item.type === "reasoning" || item.type === "agentMessage") {
+  if (
+    item.type === "reasoning" ||
+    item.type === "agentMessage" ||
+    item.type === "commandExecution"
+  ) {
     return { type: item.type, id: projectedScalar(item.id) };
   }
   const out = {
@@ -2108,8 +2155,44 @@ function projectRetainedItem(item) {
   if (hasOwn(item, "result")) {
     out.result = item.result == null ? null : projectToolResult(item.result);
   }
+  if (hasOwn(item, "durationMs")) {
+    out.durationMs = item.durationMs == null ? null : projectedScalar(item.durationMs);
+  }
+  if (hasOwn(item, "readOnlyHint")) {
+    out.readOnlyHint = item.readOnlyHint == null ? null : projectedScalar(item.readOnlyHint);
+  }
+  if (hasOwn(item, "pluginId")) {
+    out.pluginId = item.pluginId == null ? null : projectedScalar(item.pluginId);
+  }
+  if (hasOwn(item, "mcpAppResourceUri")) {
+    out.mcpAppResourceUri =
+      item.mcpAppResourceUri == null ? null : projectedScalar(item.mcpAppResourceUri);
+  }
+  if (hasOwn(item, "appContext")) {
+    out.appContext = projectAppContext(item.appContext);
+  }
+  if (hasOwn(item, "error")) {
+    out.error = projectMcpToolCallError(item.error);
+  }
   const unexpected = Object.keys(item)
-    .filter((key) => !["type", "id", "server", "tool", "arguments", "status", "result"].includes(key))
+    .filter(
+      (key) =>
+        ![
+          "type",
+          "id",
+          "server",
+          "tool",
+          "arguments",
+          "status",
+          "result",
+          "durationMs",
+          "readOnlyHint",
+          "pluginId",
+          "mcpAppResourceUri",
+          "appContext",
+          "error",
+        ].includes(key),
+    )
     .sort();
   if (unexpected.length > 0) {
     out.__unexpectedKeys = unexpected;

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -5045,3 +5045,73 @@ test("canonical Codex 0.153.1 elicitation prompt is accepted; unexpected prompt 
     "elicitation for an unpinned tool must be declined",
   );
 });
+
+test("classifyRecord rejects invalid 0.153.1 metadata types at the consumer boundary", async () => {
+  const control = await drive("valid");
+  assert.equal(allIntendedCellsPass(control.classified), true, "control must pass all cells");
+
+  const badMetadataVariants = [
+    { durationMs: "wrong" },
+    { durationMs: -1 },
+    { durationMs: 1.5 },
+    { readOnlyHint: 42 },
+    { readOnlyHint: "true" },
+    { pluginId: false },
+    { pluginId: 123 },
+    { mcpAppResourceUri: true },
+    { error: {} },
+    { error: { message: 123 } },
+    { appContext: {} },
+    { appContext: { connectorId: 123 } },
+    { durationMs: "wrong", readOnlyHint: 42, pluginId: false, error: {} },
+  ];
+
+  for (const badMeta of badMetadataVariants) {
+    const events = structuredClone(control.events);
+    const itemCompleted = events.find(
+      (e) => e.method === "item/completed" && e.params?.item?.type === "mcpToolCall",
+    );
+    assert.ok(itemCompleted);
+    Object.assign(itemCompleted.params.item, badMeta);
+
+    const terminal = events.find((e) => e.method === "turn/completed");
+    const terminalTool = terminal.params.turn.items.find(
+      (item) => item?.type === "mcpToolCall",
+    );
+    assert.ok(terminalTool);
+    Object.assign(terminalTool, badMeta);
+
+    const classified = classifyRecord({ ...control.manifest, events });
+    assert.equal(
+      allIntendedCellsPass(classified),
+      false,
+      `metadata ${JSON.stringify(badMeta)} must not produce an all-pass classification`,
+    );
+  }
+});
+
+test("mcpToolCall with non-null error fails oneToolInvoked even if status claims completed", async () => {
+  const control = await drive("valid");
+  const events = structuredClone(control.events);
+  const itemCompleted = events.find(
+    (e) => e.method === "item/completed" && e.params?.item?.type === "mcpToolCall",
+  );
+  itemCompleted.params.item.error = { message: "unexpected error" };
+
+  const terminal = events.find((e) => e.method === "turn/completed");
+  const terminalTool = terminal.params.turn.items.find(
+    (item) => item?.type === "mcpToolCall",
+  );
+  terminalTool.error = { message: "unexpected error" };
+
+  const classified = classifyRecord({ ...control.manifest, events });
+  assert.notEqual(
+    classified.cells.oneToolInvoked.status,
+    "pass",
+    "mcpToolCall with error must not pass oneToolInvoked",
+  );
+  assert.equal(
+    classified.cells.structuredResultValidated.status,
+    "unavailable",
+  );
+});

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -4622,12 +4622,28 @@ const OBSERVED_NON_EVIDENTIARY_ITEMS = Object.freeze([
     delivery: "final",
     memoryCitation: null,
   }),
+  Object.freeze({
+    type: "commandExecution",
+    id: "exec_1",
+    command: "ls -la /private/tmp",
+    commandActions: [{ type: "read", path: "/private/tmp" }],
+    cwd: "/private/tmp",
+    status: "completed",
+    aggregatedOutput: "sensitive directory output",
+    durationMs: 42,
+    exitCode: 0,
+    pluginId: null,
+    processId: "1234",
+    scriptPath: null,
+    source: "agent",
+  }),
 ]);
 
 const OBSERVED_NON_EVIDENTIARY_NOTIFICATIONS = Object.freeze([
   "account/rateLimits/updated",
   "item/agentMessage/delta",
   "thread/tokenUsage/updated",
+  "serverRequest/resolved",
 ]);
 
 test("stableStringify refuses non-JSON primitives; JSON null stays a valid token", () => {
@@ -4849,4 +4865,183 @@ test("non-finite numbers never silently become JSON null at either boundary", ()
   }
   assert.equal(stableStringify({ completedAtMs: 5 }), '{"completedAtMs":5}\n');
   assert.equal(stableStringify([0, -1.5]), '[0,-1.5]\n');
+});
+
+test("commandExecution projects to closed type and id only; sensitive fields are scrubbed", () => {
+  const rawItem = OBSERVED_NON_EVIDENTIARY_ITEMS.find((item) => item.type === "commandExecution");
+  assert.ok(rawItem, "fixture must contain commandExecution");
+  const projected = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 12345,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: rawItem,
+    },
+  });
+  assert.deepEqual(projected.params.item, {
+    type: "commandExecution",
+    id: "exec_1",
+  });
+  const serialized = stableStringify(projected);
+  assert.equal(serialized.includes("sensitive directory output"), false);
+  assert.equal(serialized.includes("ls -la"), false);
+  assert.equal(serialized.includes("/private/tmp"), false);
+
+  const unprojectedRaw = {
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 12345,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: rawItem,
+    },
+  };
+  const classified = classifyStoredEvent(unprojectedRaw);
+  assert.equal(
+    classified.type,
+    "unclassified",
+    "unprojected commandExecution containing raw fields must fail closed",
+  );
+});
+
+test("Codex 0.153.1 mcpToolCall schema fields project cleanly; unexpected keys and credentials fail closed", () => {
+  const rawToolCall = {
+    type: "mcpToolCall",
+    id: "tool-1",
+    server: "assay",
+    tool: "assay_policy_decide",
+    status: "completed",
+    arguments: { tool: "install_surface_allowed_probe", policy: "install-surface-policy.yaml" },
+    durationMs: 120,
+    readOnlyHint: true,
+    pluginId: "plugin-assay",
+    mcpAppResourceUri: "resource://assay",
+    appContext: {
+      connectorId: "connector-1",
+      linkId: "link-1",
+      resourceUri: "uri://assay-policy",
+    },
+    error: {
+      message: "authorization failed for token sk-secret12345678",
+    },
+    result: {
+      isError: false,
+      structuredContent: { allowed: true, reason: "ok" },
+    },
+  };
+
+  const projected = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 5000,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: rawToolCall,
+    },
+  });
+  const projectedItem = projected.params.item;
+  assert.equal(Object.hasOwn(projectedItem, "__unexpectedKeys"), false);
+  assert.equal(projectedItem.durationMs, 120);
+  assert.equal(projectedItem.readOnlyHint, true);
+  assert.equal(projectedItem.pluginId, "plugin-assay");
+  assert.equal(projectedItem.mcpAppResourceUri, "resource://assay");
+  assert.deepEqual(projectedItem.appContext, {
+    connectorId: "connector-1",
+    linkId: "link-1",
+    resourceUri: "uri://assay-policy",
+  });
+  assert.equal(
+    projectedItem.error.message,
+    "[redacted]",
+    "credential in error message must be scrubbed",
+  );
+
+  const unexpectedKeyCall = structuredClone(rawToolCall);
+  unexpectedKeyCall.unknownHostMetadata = "unexpected";
+  const projectedWithUnexpected = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 5000,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: unexpectedKeyCall,
+    },
+  });
+  assert.deepEqual(projectedWithUnexpected.params.item.__unexpectedKeys, [
+    "unknownHostMetadata",
+  ]);
+});
+
+test("failed MCP tool status fails oneToolInvoked and structuredResultValidated", async () => {
+  const control = await drive("valid");
+  const events = structuredClone(control.events);
+  const toolIndex = events.findIndex(
+    (event) => event.method === "item/completed" && event.params?.item?.type === "mcpToolCall",
+  );
+  assert.notEqual(toolIndex, -1);
+  events[toolIndex].params.item.status = "failed";
+  events[toolIndex].params.item.result = null;
+
+  const terminal = events.find((event) => event.method === "turn/completed");
+  const terminalTool = terminal.params.turn.items.find(
+    (item) => item?.type === "mcpToolCall",
+  );
+  if (terminalTool) {
+    terminalTool.status = "failed";
+    terminalTool.result = null;
+  }
+
+  const classified = classifyRecord({ ...control.manifest, events });
+  assert.equal(classified.cells.oneToolInvoked.status, "fail");
+  assert.match(classified.cells.oneToolInvoked.reason, /tool status failed/);
+  assert.equal(classified.cells.structuredResultValidated.status, "unavailable");
+});
+
+test("canonical Codex 0.153.1 elicitation prompt is accepted; unexpected prompt is declined", () => {
+  const canonical01531 = {
+    serverName: "assay",
+    threadId: "t-1",
+    turnId: "u-1",
+    mode: "form",
+    message: 'Allow the assay MCP server to run tool "assay_policy_decide"?',
+    requestedSchema: { type: "object", properties: {} },
+  };
+  assert.equal(
+    elicitationAcceptable(canonical01531, "t-1", "u-1"),
+    true,
+    "canonical 0.153.1 elicitation message must be accepted",
+  );
+
+  const syntheticLegacy = {
+    serverName: "assay",
+    threadId: "t-1",
+    turnId: "u-1",
+    mode: "form",
+    message: "approve assay_policy_decide",
+    requestedSchema: { type: "object", properties: {} },
+  };
+  assert.equal(
+    elicitationAcceptable(syntheticLegacy, "t-1", "u-1"),
+    true,
+    "legacy synthetic elicitation message must remain accepted",
+  );
+
+  const unexpectedPrompt = {
+    ...canonical01531,
+    message: 'Allow the assay MCP server to run tool "unrelated_tool"?',
+  };
+  assert.equal(
+    elicitationAcceptable(unexpectedPrompt, "t-1", "u-1"),
+    false,
+    "elicitation for an unpinned tool must be declined",
+  );
 });


### PR DESCRIPTION
Prepares #2684 for a fresh authenticated host-proof attempt following the observation in comment 5546686669 and review feedback in comments 5546994758 and 5547021077.

## Problem

The first authenticated v6.0.0 observation under Desktop-bundled Codex 0.153.1 retained manifest `fb82371241802dc1a89231956e8f203af0335639e332a56cbe93e3a3d115319a`. Inspection of `tool/events.json` against the exact generated 0.153.1 schema in `protocol-0.153.1/` revealed:

1. **`commandExecution` ThreadItem**: Codex 0.153.1 app-server emitted `commandExecution` items during the turn. Because `projectRetainedItem` only recognized `userMessage`, `reasoning`, and `agentMessage`, it defaulted `commandExecution` to `mcpToolCall`, populating `{ __invalidType: "undefined" }` for required tool fields and marking real command properties (`command`, `aggregatedOutput`, `cwd`, etc.) as `__unexpectedKeys`. `retainedItemReason` rejected it as `unknown retained item type commandExecution`.
2. **0.153.1 `mcpToolCall` schema validation and consumer boundaries**: The schema for `McpToolCallThreadItem` defines optional fields: `appContext`, `durationMs`, `error`, `pluginId`, `readOnlyHint`, and `mcpAppResourceUri`. In initial repair `e35acce945eee61acfb8b466035e45a2e5a024d5`, projection admitted generic scalars without verifying generated schema types, and `retainedItemReason` did not validate these fields at the consumer boundary. Consequently, malformed metadata (`durationMs="wrong"`, `readOnlyHint=42`, `pluginId=false`, `error={}`) could pass all nine cells through `classifyRecord`. Furthermore, non-null `item.error` on an `mcpToolCall` with `status: "completed"` could erroneously yield `pass` in `classifyInvocation`.
3. **`serverRequest/resolved` Notification**: Codex 0.153.1 emits `serverRequest/resolved` when a server request (such as elicitation) finishes. It was absent from `LIFECYCLE_SERVER_NOTIFICATIONS`, causing `classifyStoredEvent` to classify it as `unclassified server event`.
4. **Canonical Elicitation Prompt**: The driver declined the elicitation request (`action: "decline"`) because `params.message` was `'Allow the assay MCP server to run tool "assay_policy_decide"?'`, whereas `EXPECTED_ELICITATION.message` required exact match with legacy synthetic `"approve assay_policy_decide"`. This mismatch caused the MCP call to fail (`status: "failed", result: null`).

The historical failed pack is retained unchanged at:
`<private-proof-root>/tool/`

The run remains a failure. It is not reclassified or rewritten by this PR.

## Change

- Project `commandExecution` thread items as closed non-evidentiary items `{ type: "commandExecution", id }`, scrubbing command lines, cwd, and aggregated output in compliance with ADR-042/043 and SKILL.md;
- Validate that unprojected `commandExecution` carrying raw fields fails closed (`retainedItemReason`);
- Align `projectRetainedItem` and `retainedItemReason` with the exact Codex 0.153.1 schema for `mcpToolCall` by enforcing strict schema types and nested required members at both the consumer boundary and projection boundary:
  - `durationMs`: non-negative safe integer or null;
  - `readOnlyHint`: boolean or null;
  - `pluginId`: string or null;
  - `mcpAppResourceUri`: string or null;
  - `appContext`: closed object or null, requiring non-empty string `connectorId`, with typed optional fields (`actionName`, `appName`, `linkId`, `resourceUri`);
  - `error`: closed object or null, requiring string `message`, scrubbed via `CREDENTIAL_KEY` -> `"[redacted]"`;
  - closed allowed keys on `mcpToolCall` only: unexpected keys fail closed with `__unexpectedKeys` in projection and descriptive reasons at the consumer boundary;
- Reject non-null `item.error` in `classifyInvocation`: contradictory error objects on `mcpToolCall` fail `oneToolInvoked` (`cell("fail", "mcpToolCall contains an error")`) and render `structuredResultValidated` unavailable;
- Add `serverRequest/resolved` to `LIFECYCLE_SERVER_NOTIFICATIONS` so it is scrubbed to `{}` and classified as `server-notification`;
- Accept canonical Codex 0.153.1 prompt `Allow the assay MCP server to run tool "assay_policy_decide"?` alongside legacy synthetic prompt in `elicitationAcceptable`;
- Preserve failure semantics: failed MCP calls (`status === "failed"`) continue to fail `oneToolInvoked` and `structuredResultValidated`.

## Verification

Exact candidate: `f552bb8277c568e122e7c7921e3e9fef5b19a39d`.
Base commit: `e3e0888ab4fe80e87251a1bcd16eb30423aa8dbc` (`origin/main`).

- behavioral RED on prior head `e35acce945eee61acfb8b466035e45a2e5a024d5`:
  - `classifyRecord rejects invalid 0.153.1 metadata types at the consumer boundary`: verified RED (assertion failed on `{"durationMs":"wrong"}` returning all cells pass);
  - `mcpToolCall with non-null error fails oneToolInvoked even if status claims completed`: verified RED (assertion failed on `oneToolInvoked` returning `pass`);
- full Node contract: 118/118 pass, 0 fail;
- `node --check scripts/ci/codex_host_proof_validator.mjs`: pass;
- `node --check scripts/ci/codex_host_proof.mjs`: pass;
- `node --check scripts/ci/test_codex_host_proof.mjs`: pass;
- `git diff --check`: clean (0 warnings/errors);
- commit and pre-push hooks (including workspace clippy, cargo fmt, and cross-target compile): all passed;
- mutation controls:
  - unprojected raw `commandExecution` fails closed;
  - unexpected keys on `mcpToolCall` fail closed;
  - credentials in `error.message` are scrubbed to `"[redacted]"`;
  - invalid metadata types (`durationMs`, `readOnlyHint`, `pluginId`, `error`, `appContext`) fail closed in `classifyRecord`;
  - non-null `item.error` fails `oneToolInvoked` and makes `structuredResultValidated` unavailable;
  - unrelated elicitation messages remain declined;
  - failed MCP status (`status: "failed"`, `result: null`) keeps `oneToolInvoked` failing and `structuredResultValidated` unavailable.

## Non-claims

This PR does not claim issue #2684 is closed, does not prove a live model-mediated tool call, and does not alter the historical failed pack. It repairs driver/projection compatibility against the generated Codex 0.153.1 schema. No live model turn was run, and no auth or profile files were accessed. A separately authorized live run against the published release is required after independent review and merge.

