### PR TITLE
fix(ci): align Codex host-proof projection with 0.153.1 schema; record presence for newly admitted mcpToolCall metadata

### DIFF
--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -43,6 +43,8 @@ import {
   runtimeProofRoots,
   isMainModule,
   persistableArgv,
+  CWD_DIFFERS_FROM_PROJECT_ROOT,
+  CWD_MATCHES_PROJECT_ROOT,
   projectRetainedEvent,
   projectHostIdentity,
   proofAllowlist,
@@ -421,7 +423,93 @@ function resolvedMcpCommand(options) {
   throw new Error("assay MCP binary was not resolved");
 }
 
+// Retention-only identity projection, applied at the ONE boundary where the proof is written.
+//
+// It cannot live at `retainEvent`: the driver reads its own live wire identities back out of that
+// array (`started[0].result.thread.id`, `response.result.thread.id`), so relabelling there would
+// put tokens on the wire. Here the in-memory array stays raw for the driver and only the persisted
+// copy is projected -- and because the manifest hash, the classification and all three files are
+// derived from the same projected copy, they cannot disagree.
+//
+// Roles are separate maps with separate prefixes, so two namespaces are never merged by accident.
+// Fields that ARE one identity deliberately share a role: `params.threadId` with
+// `result.thread.id`, and `params.turnId` with `params.turn.id`, because the cells compare exactly
+// those pairs. Every site is an explicit named path from the identifier disposition table -- never
+// a recursive walk, which would rename fields nobody enumerated.
+//
+// Every comparison downstream is an equality test, which is why a first-seen ordinal is
+// information-preserving for them: classifying the projected copy yields the same cells as
+// classifying the raw one.
+const RETAINED_ID_PREFIX = Object.freeze({ rpc: "#", thread: "@", turn: "~", item: "!" });
+
+function retainedIdentityProjection(events, projectRoot) {
+  const seen = new Map(Object.keys(RETAINED_ID_PREFIX).map((role) => [role, new Map()]));
+  const isObj = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+  const own = (value, key) => Object.prototype.hasOwnProperty.call(value, key);
+  const token = (role, value) => {
+    if (typeof value !== "string" || value.length === 0) {
+      return value;
+    }
+    const roleSeen = seen.get(role);
+    if (!roleSeen.has(value)) {
+      roleSeen.set(value, `${RETAINED_ID_PREFIX[role]}${roleSeen.size}`);
+    }
+    return roleSeen.get(value);
+  };
+  return events.map((original) => {
+    const event = structuredClone(original);
+    if (own(event, "id")) {
+      event.id = token("rpc", event.id);
+    }
+    const params = event.params;
+    if (isObj(params)) {
+      if (own(params, "threadId")) {
+        params.threadId = token("thread", params.threadId);
+      }
+      if (own(params, "turnId")) {
+        params.turnId = token("turn", params.turnId);
+      }
+      if (isObj(params.item) && own(params.item, "id")) {
+        params.item.id = token("item", params.item.id);
+      }
+      if (isObj(params.turn)) {
+        if (own(params.turn, "id")) {
+          params.turn.id = token("turn", params.turn.id);
+        }
+        if (Array.isArray(params.turn.items)) {
+          for (const entry of params.turn.items) {
+            if (isObj(entry) && own(entry, "id")) {
+              entry.id = token("item", entry.id);
+            }
+          }
+        }
+      }
+    }
+    const result = event.result;
+    if (isObj(result)) {
+      if (isObj(result.thread) && own(result.thread, "id")) {
+        result.thread.id = token("thread", result.thread.id);
+      }
+      // `result.turn.id` is the OTHER member of the turn namespace. Missing it is what a partial
+      // namespace looks like: `params.turn.id` becomes a token while this stays raw, and the cell
+      // that compares exactly those two stops matching. Every member of a role must be listed.
+      if (isObj(result.turn) && own(result.turn, "id")) {
+        result.turn.id = token("turn", result.turn.id);
+      }
+      // Group D: record the project-root COMPARISON outcome, never the host path.
+      if (typeof result.cwd === "string") {
+        result.cwd =
+          result.cwd === projectRoot
+            ? CWD_MATCHES_PROJECT_ROOT
+            : CWD_DIFFERS_FROM_PROJECT_ROOT;
+      }
+    }
+    return event;
+  });
+}
+
 function writeProofFiles(options, pack) {
+  pack = { ...pack, events: retainedIdentityProjection(pack.events, options.projectRoot) };
   const initialize = initializeFromEvents(pack.events, options.journey);
   const hostIdentity = projectHostIdentity(options.hostIdentity ?? null);
   const invocationArgv = persistableArgv(
@@ -612,21 +700,7 @@ export async function runProof(options) {
   // `nextId`, which is not the converse. They are preserved because the protocol requires numeric
   // ids to stay valid on the wire and an integer carries no text, not because their provenance is
   // known. Preserving them is also what keeps the client-generated integer response lookup working.
-  const retainedRpcIds = new Map();
-  const retainedRpcId = (id) => {
-    if (typeof id !== "string" || id.length === 0) {
-      return id;
-    }
-    if (!retainedRpcIds.has(id)) {
-      retainedRpcIds.set(id, `#${retainedRpcIds.size}`);
-    }
-    return retainedRpcIds.get(id);
-  };
-
   const retainEvent = (event) => {
-    if (Object.prototype.hasOwnProperty.call(event, "id")) {
-      event.id = retainedRpcId(event.id);
-    }
     const encoded = Buffer.byteLength(JSON.stringify(event), "utf8");
     if (
       events.length >= HARD_MAX_EVENTS ||
@@ -723,20 +797,15 @@ export async function runProof(options) {
 
   const dropClientWrite = (id) => {
     if (id != null) {
-      // Wire side: `pending` is keyed by the REAL id, so it is deleted by the real id.
       pending.delete(id);
     }
-    // Retention side: retained events carry the projected token, so the scan below must compare
-    // against that. `.get` rather than `retainedRpcId` on purpose -- looking up a write we are
-    // dropping must not mint a token for an id that was never retained.
-    const retained =
-      typeof id === "string" && retainedRpcIds.has(id) ? retainedRpcIds.get(id) : id;
+
     for (let i = events.length - 1; i >= 0; i -= 1) {
       const event = events[i];
       if (event.direction !== "client") {
         continue;
       }
-      if (id != null ? event.id !== retained : event.method !== "initialized") {
+      if (id != null ? event.id !== id : event.method !== "initialized") {
         continue;
       }
       const encoded = Buffer.byteLength(JSON.stringify(event), "utf8");

--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -594,7 +594,7 @@ export async function runProof(options) {
   const pending = new Map();
   // A STRING rpc id can only have come from the host: the driver's own requests take their ids from
   // `nextId`, which is always an integer. So every retained string id is host text, exactly like a
-  // method name or a key name.
+  // method name or a key name. The converse does NOT hold -- see the note on integers below.
   //
   // The wire is untouched -- the child still sees, and we still answer with, the real id, so string
   // ids remain fully supported on the protocol. Only what is RETAINED is relabelled, through one
@@ -607,8 +607,11 @@ export async function runProof(options) {
   // visibly reused. It carries no preimage and is not offered as reversible redaction: what the
   // proof retains is correlation structure, not identity.
   //
-  // Integers pass through unchanged. They are driver-generated, which is what keeps the
-  // client-generated integer response lookup working untouched.
+  // Integers pass through unchanged -- but NOT because they are ours. A host may choose a numeric
+  // id too; what is true is only that driver-ORIGINATED requests always take integers from
+  // `nextId`, which is not the converse. They are preserved because the protocol requires numeric
+  // ids to stay valid on the wire and an integer carries no text, not because their provenance is
+  // known. Preserving them is also what keeps the client-generated integer response lookup working.
   const retainedRpcIds = new Map();
   const retainedRpcId = (id) => {
     if (typeof id !== "string" || id.length === 0) {

--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -592,8 +592,38 @@ export async function runProof(options) {
   let childExit = null;
   let acceptedElicitations = 0;
   const pending = new Map();
+  // A STRING rpc id can only have come from the host: the driver's own requests take their ids from
+  // `nextId`, which is always an integer. So every retained string id is host text, exactly like a
+  // method name or a key name.
+  //
+  // The wire is untouched -- the child still sees, and we still answer with, the real id, so string
+  // ids remain fully supported on the protocol. Only what is RETAINED is relabelled, through one
+  // per-run map at `retainEvent`, the single funnel every retained event already passes through.
+  // (The one projection outside it, `writePreSpawnFailure`, carries no id and never contacts a host.)
+  //
+  // First-seen ordinal, deliberately NOT a hash. It preserves exactly the structure correlation
+  // needs -- the same id always yields the same token, distinct ids always yield distinct tokens --
+  // so a server request and its matching client response still pair, and a reused id is still
+  // visibly reused. It carries no preimage and is not offered as reversible redaction: what the
+  // proof retains is correlation structure, not identity.
+  //
+  // Integers pass through unchanged. They are driver-generated, which is what keeps the
+  // client-generated integer response lookup working untouched.
+  const retainedRpcIds = new Map();
+  const retainedRpcId = (id) => {
+    if (typeof id !== "string" || id.length === 0) {
+      return id;
+    }
+    if (!retainedRpcIds.has(id)) {
+      retainedRpcIds.set(id, `#${retainedRpcIds.size}`);
+    }
+    return retainedRpcIds.get(id);
+  };
 
   const retainEvent = (event) => {
+    if (Object.prototype.hasOwnProperty.call(event, "id")) {
+      event.id = retainedRpcId(event.id);
+    }
     const encoded = Buffer.byteLength(JSON.stringify(event), "utf8");
     if (
       events.length >= HARD_MAX_EVENTS ||
@@ -690,14 +720,20 @@ export async function runProof(options) {
 
   const dropClientWrite = (id) => {
     if (id != null) {
+      // Wire side: `pending` is keyed by the REAL id, so it is deleted by the real id.
       pending.delete(id);
     }
+    // Retention side: retained events carry the projected token, so the scan below must compare
+    // against that. `.get` rather than `retainedRpcId` on purpose -- looking up a write we are
+    // dropping must not mint a token for an id that was never retained.
+    const retained =
+      typeof id === "string" && retainedRpcIds.has(id) ? retainedRpcIds.get(id) : id;
     for (let i = events.length - 1; i >= 0; i -= 1) {
       const event = events[i];
       if (event.direction !== "client") {
         continue;
       }
-      if (id != null ? event.id !== id : event.method !== "initialized") {
+      if (id != null ? event.id !== retained : event.method !== "initialized") {
         continue;
       }
       const encoded = Buffer.byteLength(JSON.stringify(event), "utf8");

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -1983,13 +1983,7 @@ function projectDecisionObject(value) {
       out[key] = projectedScalar(value[key]);
     }
   }
-  const unexpected = Object.keys(value)
-    .filter((key) => key !== "allowed" && key !== "reason")
-    .sort();
-  if (unexpected.length > 0) {
-    out.__unexpectedKeys = unexpected;
-  }
-  return out;
+  return withUnexpectedKeys(out, value, ["allowed", "reason"]);
 }
 
 function projectToolResult(result) {
@@ -2024,13 +2018,12 @@ function projectToolResult(result) {
       });
     }
   }
-  const unexpected = Object.keys(result)
-    .filter((key) => !["isError", "error", "structuredContent", "content"].includes(key))
-    .sort();
-  if (unexpected.length > 0) {
-    out.__unexpectedKeys = unexpected;
-  }
-  return out;
+  return withUnexpectedKeys(out, result, [
+    "isError",
+    "error",
+    "structuredContent",
+    "content",
+  ]);
 }
 
 function projectArguments(value) {
@@ -2043,21 +2036,17 @@ function projectArguments(value) {
       out[key] = projectedScalar(value[key]);
     }
   }
-  const unexpected = Object.keys(value)
-    .filter((key) => key !== "tool" && key !== "policy")
-    .sort();
-  if (unexpected.length > 0) {
-    out.__unexpectedKeys = unexpected;
-  }
-  return out;
+  return withUnexpectedKeys(out, value, ["tool", "policy"]);
 }
 
+// A key NAME is host-controlled data exactly as a value is, so retaining the names of
+// unexpected keys retains host content. Record only that unexpected keys were present,
+// never which. Collapsing to PRESENT is also what makes re-projection a fixed point: the
+// marker is itself outside every allowed list, so projecting an already-projected object
+// re-marks it to the same value. A name list or a count would change on the second pass.
 function withUnexpectedKeys(out, value, allowed) {
-  const unexpected = Object.keys(value)
-    .filter((key) => !allowed.includes(key))
-    .sort();
-  if (unexpected.length > 0) {
-    out.__unexpectedKeys = unexpected;
+  if (Object.keys(value).some((key) => !allowed.includes(key))) {
+    out.__unexpectedKeys = PRESENT;
   }
   return out;
 }
@@ -2330,30 +2319,21 @@ function projectRetainedItem(item) {
   if (hasOwn(item, "error")) {
     out.error = projectMcpToolCallError(item.error);
   }
-  const unexpected = Object.keys(item)
-    .filter(
-      (key) =>
-        ![
-          "type",
-          "id",
-          "server",
-          "tool",
-          "arguments",
-          "status",
-          "result",
-          "durationMs",
-          "readOnlyHint",
-          "pluginId",
-          "mcpAppResourceUri",
-          "appContext",
-          "error",
-        ].includes(key),
-    )
-    .sort();
-  if (unexpected.length > 0) {
-    out.__unexpectedKeys = unexpected;
-  }
-  return out;
+  return withUnexpectedKeys(out, item, [
+    "type",
+    "id",
+    "server",
+    "tool",
+    "arguments",
+    "status",
+    "result",
+    "durationMs",
+    "readOnlyHint",
+    "pluginId",
+    "mcpAppResourceUri",
+    "appContext",
+    "error",
+  ]);
 }
 
 function projectServerResult(method, result) {

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -640,9 +640,39 @@ export const ALLOWED_SERVER_NOTIFICATIONS = Object.freeze([
   "item/completed",
   "turn/completed",
 ]);
+export const ALLOWED_CLIENT_REQUESTS = Object.freeze([
+  "initialize",
+  "skills/list",
+  "thread/start",
+  "mcpServerStatus/list",
+  "turn/start",
+]);
 export const ALLOWED_CLIENT_NOTIFICATIONS = Object.freeze(["initialized"]);
 export const ALLOWED_CLIENT_RESPONSES = Object.freeze(["mcpServer/elicitation/request"]);
 export const ALLOWED_DRIVER_METHODS = Object.freeze(["error", "pre-spawn-error"]);
+// A JSON-RPC method name is host-controlled text on every server-originated frame. Retaining an
+// unrecognised one verbatim puts host content in the proof, so only names this proof already
+// declares are kept; anything else becomes one constant. Known names must stay verbatim because
+// classification, correlation and the cells are all keyed on them.
+export const KNOWN_METHODS = Object.freeze([
+  ...ALLOWED_SERVER_NOTIFICATIONS,
+  ...ALLOWED_SERVER_REQUESTS,
+  ...ALLOWED_CLIENT_REQUESTS,
+  ...ALLOWED_CLIENT_NOTIFICATIONS,
+  ...ALLOWED_CLIENT_RESPONSES,
+  ...ALLOWED_DRIVER_METHODS,
+]);
+export const UNKNOWN_METHOD = "[unknown-method]";
+// The retained item types this proof declares. Same rule as methods: an unrecognised type is host
+// text, and it is already refused, so nothing needs its literal value.
+export const KNOWN_ITEM_TYPES = Object.freeze([
+  "reasoning",
+  "agentMessage",
+  "commandExecution",
+  "mcpToolCall",
+  "userMessage",
+]);
+export const UNKNOWN_ITEM_TYPE = "[unknown-item-type]";
 
 export function preSpawnFailureState(events, manifest) {
   const rows = Array.isArray(events)
@@ -924,6 +954,15 @@ function retainedMethodParamsReason(method, params) {
 export function classifyStoredEvent(event) {
   if (event == null || typeof event !== "object" || Array.isArray(event)) {
     return { type: "unclassified", reason: "event is not an object" };
+  }
+  // A projection violation is a violation wherever it sits. The markers were applied consistently
+  // by the producer but consulted only on some paths, so a marker nested under result/arguments
+  // passed every cell: a fully green proof carrying a recorded violation. The consumer's whole
+  // claim is a CLOSED retained projection, and this is the one check that makes that true rather
+  // than true-at-the-levels-someone-remembered. The reason names the marker class only, never the
+  // offending content.
+  if (containsProjectionViolation(event)) {
+    return { type: "unclassified", reason: "retained event carries a projection violation" };
   }
   const method = typeof event.method === "string" && event.method.length > 0 ? event.method : null;
   const hasId = hasOwn(event, "id");
@@ -1969,6 +2008,20 @@ function projectedScalar(value) {
 // secret text, so it would license exactly the leak it appears to prevent.
 const PRESENT = "[present]";
 
+function projectedMethod(value) {
+  if (typeof value !== "string" || value.length === 0) {
+    return invalidProjection(value);
+  }
+  return KNOWN_METHODS.includes(value) ? value : UNKNOWN_METHOD;
+}
+
+function projectedItemType(value) {
+  if (typeof value !== "string" || value.length === 0) {
+    return invalidProjection(value);
+  }
+  return KNOWN_ITEM_TYPES.includes(value) ? value : UNKNOWN_ITEM_TYPE;
+}
+
 function projectedPresence(value) {
   return typeof value === "string" ? PRESENT : invalidProjection(value);
 }
@@ -2277,7 +2330,7 @@ function projectRetainedItem(item) {
     return { type: item.type, id: projectedScalar(item.id) };
   }
   const out = {
-    type: projectedScalar(item.type),
+    type: projectedItemType(item.type),
     id: projectedScalar(item.id),
     server: projectedScalar(item.server),
     tool: projectedScalar(item.tool),
@@ -2438,7 +2491,7 @@ export function projectRetainedEvent(event) {
   if (!isPlainObject(event)) {
     return invalidProjection(event);
   }
-  const out = { direction: projectedScalar(event.direction), method: projectedScalar(event.method) };
+  const out = { direction: projectedScalar(event.direction), method: projectedMethod(event.method) };
   if (hasOwn(event, "id")) {
     out.id = event.id;
   }

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -463,7 +463,6 @@ export const EXPECTED_ELICITATION = Object.freeze({
     `Allow the assay MCP server to run tool "${DECIDE_TOOL}"?`,
     `approve ${DECIDE_TOOL}`,
   ]),
-  message: `Allow the assay MCP server to run tool "${DECIDE_TOOL}"?`,
   requestedSchema: Object.freeze({
     type: "object",
     properties: Object.freeze({}),
@@ -1652,6 +1651,11 @@ function classifyInvocation(calls, expected, threadId, turnId, topology) {
   }
   const call = calls[0];
   const item = call.item;
+  // NON-CLAIM: the fake app-server populates turn.items with the completed tool item, so this
+  // requirement is exercised only against the fixture. The one real 0.153.1 capture available was
+  // a failed run whose turn/completed carried no mcpToolCall, so whether a SUCCESSFUL host turn
+  // populates turn.items is unmeasured. If it does not, this cell fails on the real host and that
+  // is a host-behaviour finding, not a defect in this check.
   const terminalItems = terminal.params.turn.items.filter(
     (candidate) => candidate?.type === "mcpToolCall",
   );
@@ -1957,6 +1961,18 @@ function projectedScalar(value) {
   return isJsonScalar(value) ? value : invalidProjection(value);
 }
 
+// Host-supplied free text is recorded as presence, never as content. These fields have no
+// evidentiary consumer -- no classification cell reads their value -- so retaining the value only
+// creates a way for host secrets to reach the proof bytes. The type check is unchanged: a wrong
+// type still yields invalidProjection and still fails closed, which is what the schema alignment
+// needs. scrub() is deliberately not used here: it is a keyword regex and cannot bound arbitrary
+// secret text, so it would license exactly the leak it appears to prevent.
+const PRESENT = "[present]";
+
+function projectedPresence(value) {
+  return typeof value === "string" ? PRESENT : invalidProjection(value);
+}
+
 function projectDecisionObject(value) {
   if (!isPlainObject(value)) {
     return invalidProjection(value);
@@ -2215,7 +2231,7 @@ function projectAppContext(value) {
   }
   const out = {};
   if (typeof value.connectorId === "string" && value.connectorId.length > 0) {
-    out.connectorId = projectedScalar(value.connectorId);
+    out.connectorId = PRESENT;
   } else {
     out.connectorId = invalidProjection(value.connectorId);
   }
@@ -2224,7 +2240,7 @@ function projectAppContext(value) {
       value.actionName == null
         ? null
         : typeof value.actionName === "string"
-          ? projectedScalar(value.actionName)
+          ? PRESENT
           : invalidProjection(value.actionName);
   }
   if (hasOwn(value, "appName")) {
@@ -2232,7 +2248,7 @@ function projectAppContext(value) {
       value.appName == null
         ? null
         : typeof value.appName === "string"
-          ? projectedScalar(value.appName)
+          ? PRESENT
           : invalidProjection(value.appName);
   }
   if (hasOwn(value, "linkId")) {
@@ -2240,7 +2256,7 @@ function projectAppContext(value) {
       value.linkId == null
         ? null
         : typeof value.linkId === "string"
-          ? projectedScalar(value.linkId)
+          ? PRESENT
           : invalidProjection(value.linkId);
   }
   if (hasOwn(value, "resourceUri")) {
@@ -2248,7 +2264,7 @@ function projectAppContext(value) {
       value.resourceUri == null
         ? null
         : typeof value.resourceUri === "string"
-          ? projectedScalar(value.resourceUri)
+          ? PRESENT
           : invalidProjection(value.resourceUri);
   }
   return withUnexpectedKeys(out, value, [
@@ -2269,7 +2285,7 @@ function projectMcpToolCallError(value) {
   }
   const out = {};
   if (typeof value.message === "string") {
-    out.message = projectedScalar(scrub(value.message));
+    out.message = PRESENT;
   } else {
     out.message = invalidProjection(value.message);
   }
@@ -2324,7 +2340,7 @@ function projectRetainedItem(item) {
       item.pluginId == null
         ? null
         : typeof item.pluginId === "string"
-          ? projectedScalar(item.pluginId)
+          ? PRESENT
           : invalidProjection(item.pluginId);
   }
   if (hasOwn(item, "mcpAppResourceUri")) {
@@ -2332,7 +2348,7 @@ function projectRetainedItem(item) {
       item.mcpAppResourceUri == null
         ? null
         : typeof item.mcpAppResourceUri === "string"
-          ? projectedScalar(item.mcpAppResourceUri)
+          ? PRESENT
           : invalidProjection(item.mcpAppResourceUri);
   }
   if (hasOwn(item, "appContext")) {

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -707,6 +707,55 @@ export function isProofRpcId(id) {
   return Number.isSafeInteger(id);
 }
 
+function retainedAppContextReason(value) {
+  if (value == null) {
+    return null;
+  }
+  if (!isPlainObject(value)) {
+    return "appContext must be an object or null";
+  }
+  const allowed = ["actionName", "appName", "connectorId", "linkId", "resourceUri"];
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) {
+      return `appContext contains unexpected key ${key}`;
+    }
+  }
+  if (!isNonemptyString(value.connectorId)) {
+    return "appContext requires non-empty string connectorId";
+  }
+  if (hasOwn(value, "actionName") && value.actionName !== null && typeof value.actionName !== "string") {
+    return "appContext actionName must be a string or null";
+  }
+  if (hasOwn(value, "appName") && value.appName !== null && typeof value.appName !== "string") {
+    return "appContext appName must be a string or null";
+  }
+  if (hasOwn(value, "linkId") && value.linkId !== null && typeof value.linkId !== "string") {
+    return "appContext linkId must be a string or null";
+  }
+  if (hasOwn(value, "resourceUri") && value.resourceUri !== null && typeof value.resourceUri !== "string") {
+    return "appContext resourceUri must be a string or null";
+  }
+  return null;
+}
+
+function retainedMcpToolCallErrorReason(value) {
+  if (value == null) {
+    return null;
+  }
+  if (!isPlainObject(value)) {
+    return "error must be an object or null";
+  }
+  for (const key of Object.keys(value)) {
+    if (key !== "message") {
+      return `error contains unexpected key ${key}`;
+    }
+  }
+  if (typeof value.message !== "string") {
+    return "error requires string message";
+  }
+  return null;
+}
+
 function retainedItemReason(item, label = "item/completed") {
   if (!isPlainObject(item) || !isNonemptyString(item.type) || !isNonemptyString(item.id)) {
     return `${label} item is not a typed retained item`;
@@ -719,17 +768,78 @@ function retainedItemReason(item, label = "item/completed") {
         return null;
       }
       return `${label} ${item.type} is not the closed non-evidentiary projection`;
-    case "mcpToolCall":
-      if (
-        isNonemptyString(item.server) &&
-        isNonemptyString(item.tool) &&
-        isPlainObject(item.arguments) &&
-        isNonemptyString(item.status) &&
-        (item.result == null || isPlainObject(item.result))
-      ) {
-        return null;
+    case "mcpToolCall": {
+      const allowedKeys = [
+        "appContext",
+        "arguments",
+        "durationMs",
+        "error",
+        "id",
+        "mcpAppResourceUri",
+        "pluginId",
+        "readOnlyHint",
+        "result",
+        "server",
+        "status",
+        "tool",
+        "type",
+      ];
+      for (const key of Object.keys(item)) {
+        if (!allowedKeys.includes(key)) {
+          return `${label} mcpToolCall contains unexpected key ${key}`;
+        }
       }
-      return `${label} mcpToolCall is missing required retained fields`;
+      if (
+        !isNonemptyString(item.server) ||
+        !isNonemptyString(item.tool) ||
+        !isPlainObject(item.arguments) ||
+        !isNonemptyString(item.status) ||
+        (hasOwn(item, "result") && item.result !== null && !isPlainObject(item.result))
+      ) {
+        return `${label} mcpToolCall is missing required retained fields`;
+      }
+      if (
+        hasOwn(item, "durationMs") &&
+        item.durationMs !== null &&
+        !(typeof item.durationMs === "number" && Number.isSafeInteger(item.durationMs) && item.durationMs >= 0)
+      ) {
+        return `${label} mcpToolCall durationMs must be a non-negative integer or null`;
+      }
+      if (
+        hasOwn(item, "readOnlyHint") &&
+        item.readOnlyHint !== null &&
+        typeof item.readOnlyHint !== "boolean"
+      ) {
+        return `${label} mcpToolCall readOnlyHint must be a boolean or null`;
+      }
+      if (
+        hasOwn(item, "pluginId") &&
+        item.pluginId !== null &&
+        typeof item.pluginId !== "string"
+      ) {
+        return `${label} mcpToolCall pluginId must be a string or null`;
+      }
+      if (
+        hasOwn(item, "mcpAppResourceUri") &&
+        item.mcpAppResourceUri !== null &&
+        typeof item.mcpAppResourceUri !== "string"
+      ) {
+        return `${label} mcpToolCall mcpAppResourceUri must be a string or null`;
+      }
+      if (hasOwn(item, "appContext")) {
+        const appContextReason = retainedAppContextReason(item.appContext);
+        if (appContextReason) {
+          return `${label} mcpToolCall ${appContextReason}`;
+        }
+      }
+      if (hasOwn(item, "error")) {
+        const errorReason = retainedMcpToolCallErrorReason(item.error);
+        if (errorReason) {
+          return `${label} mcpToolCall ${errorReason}`;
+        }
+      }
+      return null;
+    }
     case "userMessage":
       if (Array.isArray(item.content)) {
         return null;
@@ -1566,6 +1676,9 @@ function classifyInvocation(calls, expected, threadId, turnId, topology) {
   if (item.tool !== DECIDE_TOOL) {
     return cell("fail", `wrong tool ${item.tool}`);
   }
+  if (item.error != null) {
+    return cell("fail", "mcpToolCall contains an error");
+  }
   if (item.status !== "completed") {
     return cell("fail", `tool status ${item.status}`);
   }
@@ -2101,16 +2214,50 @@ function projectAppContext(value) {
     return invalidProjection(value);
   }
   const out = {};
-  if (hasOwn(value, "connectorId")) {
+  if (typeof value.connectorId === "string" && value.connectorId.length > 0) {
     out.connectorId = projectedScalar(value.connectorId);
+  } else {
+    out.connectorId = invalidProjection(value.connectorId);
+  }
+  if (hasOwn(value, "actionName")) {
+    out.actionName =
+      value.actionName == null
+        ? null
+        : typeof value.actionName === "string"
+          ? projectedScalar(value.actionName)
+          : invalidProjection(value.actionName);
+  }
+  if (hasOwn(value, "appName")) {
+    out.appName =
+      value.appName == null
+        ? null
+        : typeof value.appName === "string"
+          ? projectedScalar(value.appName)
+          : invalidProjection(value.appName);
   }
   if (hasOwn(value, "linkId")) {
-    out.linkId = value.linkId == null ? null : projectedScalar(value.linkId);
+    out.linkId =
+      value.linkId == null
+        ? null
+        : typeof value.linkId === "string"
+          ? projectedScalar(value.linkId)
+          : invalidProjection(value.linkId);
   }
   if (hasOwn(value, "resourceUri")) {
-    out.resourceUri = value.resourceUri == null ? null : projectedScalar(value.resourceUri);
+    out.resourceUri =
+      value.resourceUri == null
+        ? null
+        : typeof value.resourceUri === "string"
+          ? projectedScalar(value.resourceUri)
+          : invalidProjection(value.resourceUri);
   }
-  return withUnexpectedKeys(out, value, ["connectorId", "linkId", "resourceUri"]);
+  return withUnexpectedKeys(out, value, [
+    "actionName",
+    "appName",
+    "connectorId",
+    "linkId",
+    "resourceUri",
+  ]);
 }
 
 function projectMcpToolCallError(value) {
@@ -2121,11 +2268,10 @@ function projectMcpToolCallError(value) {
     return invalidProjection(value);
   }
   const out = {};
-  if (hasOwn(value, "message")) {
-    out.message =
-      typeof value.message === "string"
-        ? projectedScalar(scrub(value.message))
-        : invalidProjection(value.message);
+  if (typeof value.message === "string") {
+    out.message = projectedScalar(scrub(value.message));
+  } else {
+    out.message = invalidProjection(value.message);
   }
   return withUnexpectedKeys(out, value, ["message"]);
 }
@@ -2156,17 +2302,38 @@ function projectRetainedItem(item) {
     out.result = item.result == null ? null : projectToolResult(item.result);
   }
   if (hasOwn(item, "durationMs")) {
-    out.durationMs = item.durationMs == null ? null : projectedScalar(item.durationMs);
+    out.durationMs =
+      item.durationMs == null
+        ? null
+        : typeof item.durationMs === "number" &&
+            Number.isSafeInteger(item.durationMs) &&
+            item.durationMs >= 0
+          ? item.durationMs
+          : invalidProjection(item.durationMs);
   }
   if (hasOwn(item, "readOnlyHint")) {
-    out.readOnlyHint = item.readOnlyHint == null ? null : projectedScalar(item.readOnlyHint);
+    out.readOnlyHint =
+      item.readOnlyHint == null
+        ? null
+        : typeof item.readOnlyHint === "boolean"
+          ? item.readOnlyHint
+          : invalidProjection(item.readOnlyHint);
   }
   if (hasOwn(item, "pluginId")) {
-    out.pluginId = item.pluginId == null ? null : projectedScalar(item.pluginId);
+    out.pluginId =
+      item.pluginId == null
+        ? null
+        : typeof item.pluginId === "string"
+          ? projectedScalar(item.pluginId)
+          : invalidProjection(item.pluginId);
   }
   if (hasOwn(item, "mcpAppResourceUri")) {
     out.mcpAppResourceUri =
-      item.mcpAppResourceUri == null ? null : projectedScalar(item.mcpAppResourceUri);
+      item.mcpAppResourceUri == null
+        ? null
+        : typeof item.mcpAppResourceUri === "string"
+          ? projectedScalar(item.mcpAppResourceUri)
+          : invalidProjection(item.mcpAppResourceUri);
   }
   if (hasOwn(item, "appContext")) {
     out.appContext = projectAppContext(item.appContext);

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -459,7 +459,11 @@ export function requiredCellsForJourney(journey) {
 export const EXPECTED_ELICITATION = Object.freeze({
   serverName: "assay",
   mode: "form",
-  message: `approve ${DECIDE_TOOL}`,
+  messages: Object.freeze([
+    `Allow the assay MCP server to run tool "${DECIDE_TOOL}"?`,
+    `approve ${DECIDE_TOOL}`,
+  ]),
+  message: `Allow the assay MCP server to run tool "${DECIDE_TOOL}"?`,
   requestedSchema: Object.freeze({
     type: "object",
     properties: Object.freeze({}),
@@ -472,7 +476,7 @@ export function elicitationAcceptable(params, threadId, turnId) {
     typeof params === "object" &&
     params.serverName === EXPECTED_ELICITATION.serverName &&
     params.mode === EXPECTED_ELICITATION.mode &&
-    params.message === EXPECTED_ELICITATION.message &&
+    EXPECTED_ELICITATION.messages.includes(params.message) &&
     sameJson(params.requestedSchema, EXPECTED_ELICITATION.requestedSchema) &&
     typeof threadId === "string" &&
     threadId.length > 0 &&
@@ -628,6 +632,7 @@ export const LIFECYCLE_SERVER_NOTIFICATIONS = Object.freeze([
   "thread/tokenUsage/updated",
   "turn/started",
   "item/started",
+  "serverRequest/resolved",
 ]);
 export const SERVER_DIAGNOSTIC_NOTIFICATIONS = Object.freeze(["warning", "error"]);
 export const ALLOWED_SERVER_NOTIFICATIONS = Object.freeze([
@@ -709,6 +714,7 @@ function retainedItemReason(item, label = "item/completed") {
   switch (item.type) {
     case "reasoning":
     case "agentMessage":
+    case "commandExecution":
       if (exactKeys(item, ["type", "id"])) {
         return null;
       }
@@ -2087,6 +2093,43 @@ function retainedClientRequestParamsReason(method, params) {
   return null;
 }
 
+function projectAppContext(value) {
+  if (value == null) {
+    return null;
+  }
+  if (!isPlainObject(value)) {
+    return invalidProjection(value);
+  }
+  const out = {};
+  if (hasOwn(value, "connectorId")) {
+    out.connectorId = projectedScalar(value.connectorId);
+  }
+  if (hasOwn(value, "linkId")) {
+    out.linkId = value.linkId == null ? null : projectedScalar(value.linkId);
+  }
+  if (hasOwn(value, "resourceUri")) {
+    out.resourceUri = value.resourceUri == null ? null : projectedScalar(value.resourceUri);
+  }
+  return withUnexpectedKeys(out, value, ["connectorId", "linkId", "resourceUri"]);
+}
+
+function projectMcpToolCallError(value) {
+  if (value == null) {
+    return null;
+  }
+  if (!isPlainObject(value)) {
+    return invalidProjection(value);
+  }
+  const out = {};
+  if (hasOwn(value, "message")) {
+    out.message =
+      typeof value.message === "string"
+        ? projectedScalar(scrub(value.message))
+        : invalidProjection(value.message);
+  }
+  return withUnexpectedKeys(out, value, ["message"]);
+}
+
 function projectRetainedItem(item) {
   if (!isPlainObject(item)) {
     return invalidProjection(item);
@@ -2094,7 +2137,11 @@ function projectRetainedItem(item) {
   if (item.type === "userMessage") {
     return { type: "userMessage", id: projectedScalar(item.id), content: [] };
   }
-  if (item.type === "reasoning" || item.type === "agentMessage") {
+  if (
+    item.type === "reasoning" ||
+    item.type === "agentMessage" ||
+    item.type === "commandExecution"
+  ) {
     return { type: item.type, id: projectedScalar(item.id) };
   }
   const out = {
@@ -2108,8 +2155,44 @@ function projectRetainedItem(item) {
   if (hasOwn(item, "result")) {
     out.result = item.result == null ? null : projectToolResult(item.result);
   }
+  if (hasOwn(item, "durationMs")) {
+    out.durationMs = item.durationMs == null ? null : projectedScalar(item.durationMs);
+  }
+  if (hasOwn(item, "readOnlyHint")) {
+    out.readOnlyHint = item.readOnlyHint == null ? null : projectedScalar(item.readOnlyHint);
+  }
+  if (hasOwn(item, "pluginId")) {
+    out.pluginId = item.pluginId == null ? null : projectedScalar(item.pluginId);
+  }
+  if (hasOwn(item, "mcpAppResourceUri")) {
+    out.mcpAppResourceUri =
+      item.mcpAppResourceUri == null ? null : projectedScalar(item.mcpAppResourceUri);
+  }
+  if (hasOwn(item, "appContext")) {
+    out.appContext = projectAppContext(item.appContext);
+  }
+  if (hasOwn(item, "error")) {
+    out.error = projectMcpToolCallError(item.error);
+  }
   const unexpected = Object.keys(item)
-    .filter((key) => !["type", "id", "server", "tool", "arguments", "status", "result"].includes(key))
+    .filter(
+      (key) =>
+        ![
+          "type",
+          "id",
+          "server",
+          "tool",
+          "arguments",
+          "status",
+          "result",
+          "durationMs",
+          "readOnlyHint",
+          "pluginId",
+          "mcpAppResourceUri",
+          "appContext",
+          "error",
+        ].includes(key),
+    )
     .sort();
   if (unexpected.length > 0) {
     out.__unexpectedKeys = unexpected;

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -2230,6 +2230,7 @@ function projectAppContext(value) {
     return invalidProjection(value);
   }
   const out = {};
+  // connectorId is required and must be non-empty, so it does not share projectedPresence.
   if (typeof value.connectorId === "string" && value.connectorId.length > 0) {
     out.connectorId = PRESENT;
   } else {
@@ -2237,35 +2238,19 @@ function projectAppContext(value) {
   }
   if (hasOwn(value, "actionName")) {
     out.actionName =
-      value.actionName == null
-        ? null
-        : typeof value.actionName === "string"
-          ? PRESENT
-          : invalidProjection(value.actionName);
+      value.actionName == null ? null : projectedPresence(value.actionName);
   }
   if (hasOwn(value, "appName")) {
     out.appName =
-      value.appName == null
-        ? null
-        : typeof value.appName === "string"
-          ? PRESENT
-          : invalidProjection(value.appName);
+      value.appName == null ? null : projectedPresence(value.appName);
   }
   if (hasOwn(value, "linkId")) {
     out.linkId =
-      value.linkId == null
-        ? null
-        : typeof value.linkId === "string"
-          ? PRESENT
-          : invalidProjection(value.linkId);
+      value.linkId == null ? null : projectedPresence(value.linkId);
   }
   if (hasOwn(value, "resourceUri")) {
     out.resourceUri =
-      value.resourceUri == null
-        ? null
-        : typeof value.resourceUri === "string"
-          ? PRESENT
-          : invalidProjection(value.resourceUri);
+      value.resourceUri == null ? null : projectedPresence(value.resourceUri);
   }
   return withUnexpectedKeys(out, value, [
     "actionName",
@@ -2284,11 +2269,7 @@ function projectMcpToolCallError(value) {
     return invalidProjection(value);
   }
   const out = {};
-  if (typeof value.message === "string") {
-    out.message = PRESENT;
-  } else {
-    out.message = invalidProjection(value.message);
-  }
+  out.message = projectedPresence(value.message);
   return withUnexpectedKeys(out, value, ["message"]);
 }
 
@@ -2337,19 +2318,11 @@ function projectRetainedItem(item) {
   }
   if (hasOwn(item, "pluginId")) {
     out.pluginId =
-      item.pluginId == null
-        ? null
-        : typeof item.pluginId === "string"
-          ? PRESENT
-          : invalidProjection(item.pluginId);
+      item.pluginId == null ? null : projectedPresence(item.pluginId);
   }
   if (hasOwn(item, "mcpAppResourceUri")) {
     out.mcpAppResourceUri =
-      item.mcpAppResourceUri == null
-        ? null
-        : typeof item.mcpAppResourceUri === "string"
-          ? PRESENT
-          : invalidProjection(item.mcpAppResourceUri);
+      item.mcpAppResourceUri == null ? null : projectedPresence(item.mcpAppResourceUri);
   }
   if (hasOwn(item, "appContext")) {
     out.appContext = projectAppContext(item.appContext);

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -662,7 +662,13 @@ export const KNOWN_METHODS = Object.freeze([
   ...ALLOWED_CLIENT_RESPONSES,
   ...ALLOWED_DRIVER_METHODS,
 ]);
-export const UNKNOWN_METHOD = "[unknown-method]";
+export const EXPECTED_SERVERS = Object.freeze(["assay"]);
+// Group D. `thread/start.result.cwd` is compared for equality against the driver's OWN project
+// root, so the characters are never needed -- only the outcome. Retaining the outcome keeps the
+// three states the cell distinguishes (required/missing/false) while retaining no host path, and
+// keeps the refusal reason free of any host value.
+export const CWD_MATCHES_PROJECT_ROOT = "[project-root]";
+export const CWD_DIFFERS_FROM_PROJECT_ROOT = "[not-project-root]";
 // The retained item types this proof declares. Same rule as methods: an unrecognised type is host
 // text, and it is already refused, so nothing needs its literal value.
 export const KNOWN_ITEM_TYPES = Object.freeze([
@@ -672,7 +678,7 @@ export const KNOWN_ITEM_TYPES = Object.freeze([
   "mcpToolCall",
   "userMessage",
 ]);
-export const UNKNOWN_ITEM_TYPE = "[unknown-item-type]";
+
 
 export function preSpawnFailureState(events, manifest) {
   const rows = Array.isArray(events)
@@ -1584,13 +1590,21 @@ function classifySkill(skills, expected) {
 function classifyCwd(starts, expected) {
   const primary = starts[0];
   const cwd = primary?.result?.cwd;
+  // Four distinguished states, none of which needs the host path: absent, the recorded match, the
+  // recorded mismatch, and anything else -- a raw value here means the outcome was never recorded,
+  // which is drift rather than a pass. `expected.projectRoot` is retained for the caller contract
+  // but is deliberately no longer compared here: the comparison happened at retention time, on the
+  // real value, and only its outcome was kept.
   if (typeof cwd !== "string") {
     return cell("unavailable", "thread/start cwd absent");
   }
-  if (cwd !== expected.projectRoot) {
-    return cell("fail", `cwd ${cwd} is not project root`);
+  if (cwd === CWD_MATCHES_PROJECT_ROOT) {
+    return cell("pass", "thread cwd is project root");
   }
-  return cell("pass", "thread cwd is project root");
+  if (cwd === CWD_DIFFERS_FROM_PROJECT_ROOT) {
+    return cell("fail", "thread cwd is not the project root");
+  }
+  return cell("fail", "thread/start cwd was not recorded as a project-root outcome");
 }
 
 function uniqueAssayRow(data) {
@@ -1607,7 +1621,7 @@ function classifyMcp(statuses) {
     return cell("unavailable", "no assay mcpServerStatus row");
   }
   if (assay.runtimeStatus !== "connected") {
-    return cell("fail", `runtimeStatus ${assay.runtimeStatus}`);
+    return cell("fail", "assay server runtimeStatus is not connected");
   }
   return cell("pass", "assay MCP connected");
 }
@@ -1705,7 +1719,7 @@ function classifyInvocation(calls, expected, threadId, turnId, topology) {
     return cell("fail", "matching terminal tool item contradicts item/completed");
   }
   if (item.server !== "assay") {
-    return cell("fail", `wrong server ${item.server}`);
+    return cell("fail", "tool item server is not the expected server");
   }
   if (call.threadId !== threadId) {
     return cell("fail", `tool thread ${call.threadId} != ${threadId}`);
@@ -1714,7 +1728,7 @@ function classifyInvocation(calls, expected, threadId, turnId, topology) {
     return cell("fail", `tool turn ${call.turnId} != ${turnId}`);
   }
   if (!EXPECTED_TOOLS.includes(item.tool)) {
-    return cell("fail", `tool ${item.tool} is not in the listed release set`);
+    return cell("fail", "tool is not in the listed release set");
   }
   if (item.tool !== DECIDE_TOOL) {
     return cell("fail", `wrong tool ${item.tool}`);
@@ -1723,7 +1737,7 @@ function classifyInvocation(calls, expected, threadId, turnId, topology) {
     return cell("fail", "mcpToolCall contains an error");
   }
   if (item.status !== "completed") {
-    return cell("fail", `tool status ${item.status}`);
+    return cell("fail", "tool item status is not completed");
   }
   if (!sameJson(item.arguments, DECIDE_INPUT)) {
     return cell("fail", "tool arguments are not the pinned probe");
@@ -2008,18 +2022,14 @@ function projectedScalar(value) {
 // secret text, so it would license exactly the leak it appears to prevent.
 const PRESENT = "[present]";
 
-function projectedMethod(value) {
-  if (typeof value !== "string" || value.length === 0) {
-    return invalidProjection(value);
-  }
-  return KNOWN_METHODS.includes(value) ? value : UNKNOWN_METHOD;
-}
-
-function projectedItemType(value) {
-  if (typeof value !== "string" || value.length === 0) {
-    return invalidProjection(value);
-  }
-  return KNOWN_ITEM_TYPES.includes(value) ? value : UNKNOWN_ITEM_TYPE;
+// A closed-set position: the value is compared against a set this proof DECLARES, so the literal
+// is genuinely needed and declared members pass through untouched. Anything else is not given a
+// legal-looking substitute -- it becomes an explicit projection violation, which the consumer
+// refuses wherever it sits. An unknown member must never read as an allowed value.
+function projectedMember(value, allowed) {
+  return typeof value === "string" && allowed.includes(value)
+    ? value
+    : invalidProjection(value);
 }
 
 function projectedPresence(value) {
@@ -2327,13 +2337,13 @@ function projectRetainedItem(item) {
     item.type === "agentMessage" ||
     item.type === "commandExecution"
   ) {
-    return { type: item.type, id: projectedScalar(item.id) };
+    return { type: projectedMember(item.type, KNOWN_ITEM_TYPES), id: projectedScalar(item.id) };
   }
   const out = {
-    type: projectedItemType(item.type),
+    type: projectedMember(item.type, KNOWN_ITEM_TYPES),
     id: projectedScalar(item.id),
-    server: projectedScalar(item.server),
-    tool: projectedScalar(item.tool),
+    server: projectedMember(item.server, EXPECTED_SERVERS),
+    tool: projectedMember(item.tool, EXPECTED_TOOLS),
     arguments: projectArguments(item.arguments),
     status: projectedScalar(item.status),
   };
@@ -2396,22 +2406,36 @@ function projectServerResult(method, result) {
   if (method === "initialize") {
     return {
       userAgent: result.userAgent === FAKE_USER_AGENT ? FAKE_USER_AGENT : "[observed-host]",
+      // NOT group C. `codexHome` has a real lexical consumer: it is pushed into the host-root list
+      // (`roots.push(initialize.codexHome)`) and used for path containment, so the characters are
+      // read. It stays verbatim and is listed as a retained-by-design disclosure instead.
       codexHome: projectedScalar(result.codexHome),
-      platformFamily: projectedScalar(result.platformFamily),
-      platformOs: projectedScalar(result.platformOs),
+      // Group C -- host platform strings. Shape-checked only by `successfulInitializeResult`;
+      // nothing reads the characters. Measured: presence here costs no test.
+      platformFamily:
+        result.platformFamily == null ? null : projectedPresence(result.platformFamily),
+      platformOs: result.platformOs == null ? null : projectedPresence(result.platformOs),
     };
   }
   if (method === "skills/list") {
     return {
       data: Array.isArray(result.data)
         ? result.data.map((entry) => ({
-            cwd: projectedScalar(entry?.cwd),
+            // Group C -- a skills row cwd is shape-checked only; nothing reads it.
+            // Group C -- a skills row cwd has no lexical consumer.
+            cwd: entry?.cwd == null ? null : projectedPresence(entry.cwd),
             skills: Array.isArray(entry?.skills)
               ? entry.skills.map((skill) => ({
+                  // Group C -- skill name, path and scope are host text with no lexical consumer.
+                  // `enabled` stays scalar: it is a boolean compared with `!== true`.
+                  // `name` and `path` are NOT group C: skill discovery matches on both, so the
+                  // characters are read. Measured -- projecting either fails 35 tests. They stay
+                  // verbatim and are listed as retained-by-design disclosures.
                   name: projectedScalar(skill?.name),
                   enabled: projectedScalar(skill?.enabled),
                   path: projectedScalar(skill?.path),
-                  scope: projectedScalar(skill?.scope),
+                  // Group C -- scope has no lexical consumer.
+                  scope: skill?.scope == null ? null : projectedPresence(skill.scope),
                 }))
               : invalidProjection(entry?.skills),
           }))
@@ -2491,7 +2515,10 @@ export function projectRetainedEvent(event) {
   if (!isPlainObject(event)) {
     return invalidProjection(event);
   }
-  const out = { direction: projectedScalar(event.direction), method: projectedMethod(event.method) };
+  const out = {
+    direction: projectedScalar(event.direction),
+    method: projectedMember(event.method, KNOWN_METHODS),
+  };
   if (hasOwn(event, "id")) {
     out.id = event.id;
   }

--- a/scripts/ci/fixtures/codex-host-proof/fake-app-server.mjs
+++ b/scripts/ci/fixtures/codex-host-proof/fake-app-server.mjs
@@ -342,6 +342,29 @@ function handle(message) {
       // value. This scenario drives such names through the real driver and the real persistence
       // path, so the absence assertion can be made against the bytes written to events.json
       // rather than against an in-process projection.
+      // A JSON-RPC method name and a retained item type are host-controlled text on the wire,
+      // exactly like a key name. This scenario emits both in secret-bearing form so the absence
+      // assertion is made against the persisted bytes.
+      if (scenario === "host-identifier-leak") {
+        const probe = "/Users/alice/.aws/credentials?sk=IDENTIFIER_PROBE";
+        write({ method: `notify_${probe}`, params: {} });
+        write({
+          method: "item/completed",
+          params: {
+            completedAtMs: 1,
+            threadId,
+            turnId: "turn-1",
+            item: {
+              type: `type_${probe}`,
+              id: "item-probe",
+              server: "assay",
+              tool: "unmapped",
+              arguments: { tool: "x", policy: "y" },
+              status: "completed",
+            },
+          },
+        });
+      }
       if (scenario === "host-key-name-leak") {
         const probe = "/Users/alice/.ssh/id_rsa?token=AKIA_KEY_NAME_PROBE";
         completedItem[probe] = 1;

--- a/scripts/ci/fixtures/codex-host-proof/fake-app-server.mjs
+++ b/scripts/ci/fixtures/codex-host-proof/fake-app-server.mjs
@@ -313,11 +313,27 @@ function handle(message) {
     if (scenario === "close-stdin-then-elicit-exit-0") {
       fs.closeSync(0);
     }
+    // A host chooses its own request ids, and a string id is host text like any other. This
+    // scenario uses a secret-bearing one so the absence assertion is made against persisted bytes,
+    // while the request/response pairing must still survive.
+    const elicitId =
+      scenario === "host-rpc-id-leak" || scenario === "host-rpc-id-distinct"
+        ? "elicit_/Users/alice/.ssh/id_rsa?sk=RPCID_PROBE"
+        : "elicit-1";
     write({
-      id: "elicit-1",
+      id: elicitId,
       method: "mcpServer/elicitation/request",
       params: elicitParams(),
     });
+    // A second, DIFFERENT host id. Without two distinct ids in one run, injectivity is not
+    // observable at all, and a map that collapsed every id to one token would pass unnoticed.
+    if (scenario === "host-rpc-id-distinct") {
+      write({
+        id: "elicit_/Users/bob/.aws/credentials?sk=RPCID_PROBE_TWO",
+        method: "mcpServer/elicitation/request",
+        params: elicitParams(),
+      });
+    }
     const tool = scenario === "wrong-tool" ? "assay_check_args" : RELEASE_DECIDE_TOOL;
     const argumentsPayload =
       scenario === "wrong-tool"

--- a/scripts/ci/fixtures/codex-host-proof/fake-app-server.mjs
+++ b/scripts/ci/fixtures/codex-host-proof/fake-app-server.mjs
@@ -338,6 +338,18 @@ function handle(message) {
           structuredContent: null,
         },
       };
+      // A host that puts data in a KEY NAME leaks exactly as much as one that puts it in a
+      // value. This scenario drives such names through the real driver and the real persistence
+      // path, so the absence assertion can be made against the bytes written to events.json
+      // rather than against an in-process projection.
+      if (scenario === "host-key-name-leak") {
+        const probe = "/Users/alice/.ssh/id_rsa?token=AKIA_KEY_NAME_PROBE";
+        completedItem[probe] = 1;
+        completedItem.arguments = { ...argumentsPayload, [probe]: 1 };
+        completedItem.result = { ...completedItem.result, [probe]: 1 };
+        completedItem.appContext = { connectorId: "connector-1", [probe]: 1 };
+        completedItem.error = { message: "boom", [probe]: 1 };
+      }
       write({
         method: "item/completed",
         params: {

--- a/scripts/ci/fixtures/codex-host-proof/fake-app-server.mjs
+++ b/scripts/ci/fixtures/codex-host-proof/fake-app-server.mjs
@@ -294,11 +294,18 @@ function handle(message) {
           },
         };
       }
+      // The default scenario keeps emitting the legacy prompt so legacy acceptance stays covered
+      // by every existing driven run. The canonical scenario emits the prompt the real 0.153.1 host
+      // sends, so the widened path this change exists for is exercised end-to-end and not only by a
+      // unit assertion.
       return {
         serverName: "assay",
         threadId,
         turnId: "turn-1",
-        message: `approve ${RELEASE_DECIDE_TOOL}`,
+        message:
+          scenario === "canonical-elicitation-prompt"
+            ? `Allow the assay MCP server to run tool "${RELEASE_DECIDE_TOOL}"?`
+            : `approve ${RELEASE_DECIDE_TOOL}`,
         mode: "form",
         requestedSchema: { type: "object", properties: {} },
       };

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -5403,3 +5403,122 @@ test("mcpToolCall allowedKeys equals the 0.153.1 schema property set", () => {
     "control: a key outside the schema must still be marked",
   );
 });
+
+// --- F-A: the whitelist must equal the schema set, not merely contain it -------------------
+// The sibling test above asserts schemaProperties ⊆ allowedKeys. That leaves the other direction
+// open: adding a key the schema does not declare survives it. A closed whitelist that admits an
+// undeclared field is the mirror of one that omits a declared one -- it accepts something 0.153.1
+// never says the host sends, so the "equals" in that test's name has to be earned in both
+// directions or not claimed.
+test("mcpToolCall allowedKeys admits nothing the 0.153.1 schema does not declare", () => {
+  // Names deliberately outside the 13 declared properties, including several that are plausible
+  // near-misses of real fields elsewhere in the protocol.
+  const notInSchema = [
+    "reason",
+    "content",
+    "text",
+    "output",
+    "sessionId",
+    "aggregatedOutput",
+    "command",
+    "cwd",
+    "notInTheSchemaAtAll",
+  ];
+  for (const key of notInSchema) {
+    const item = projectRetainedEvent({
+      direction: "server",
+      method: "item/completed",
+      id: null,
+      params: {
+        completedAtMs: 5000,
+        threadId: "t-1",
+        turnId: "u-1",
+        item: {
+          type: "mcpToolCall",
+          id: "tool-1",
+          server: "assay",
+          tool: "assay_policy_decide",
+          status: "completed",
+          arguments: { tool: "install_surface_allowed_probe" },
+          result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+          [key]: null,
+        },
+      },
+    }).params.item;
+    assert.deepEqual(
+      item.__unexpectedKeys,
+      [key],
+      `${key} is not declared by the 0.153.1 schema and must be marked unexpected`,
+    );
+  }
+  // Control: a declared property must still be accepted, so the assertion above cannot pass by
+  // marking everything.
+  const declared = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 5000,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: {
+        type: "mcpToolCall",
+        id: "tool-1",
+        server: "assay",
+        tool: "assay_policy_decide",
+        status: "completed",
+        arguments: { tool: "install_surface_allowed_probe" },
+        result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+        durationMs: 120,
+      },
+    },
+  }).params.item;
+  assert.equal(Object.hasOwn(declared, "__unexpectedKeys"), false, "control: a declared property must be accepted");
+});
+
+// --- F-B: the producer's non-string barrier must hold for NON-SCALARS ----------------------
+// Every existing case at these positions uses a scalar non-string, and the consumer's own type
+// check catches scalars -- so the producer barrier is never the deciding check and its deletion
+// went unnoticed. An object or array is the input where the producer is the only thing standing
+// between host content and the retained bytes: without it the value is written verbatim BEFORE
+// the consumer refuses the record.
+for (const [label, patch, marker] of [
+  ["pluginId object", { pluginId: { secret: "FB-PLUGIN-OBJ" } }, "FB-PLUGIN-OBJ"],
+  ["mcpAppResourceUri array", { mcpAppResourceUri: ["FB-URI-ARR"] }, "FB-URI-ARR"],
+  ["appContext.actionName object", { appContext: { connectorId: "c-1", actionName: { s: "FB-ACTION-OBJ" } } }, "FB-ACTION-OBJ"],
+  ["appContext.resourceUri array", { appContext: { connectorId: "c-1", resourceUri: ["FB-RES-ARR"] } }, "FB-RES-ARR"],
+  ["error.message object", { error: { message: { s: "FB-ERRMSG-OBJ" } } }, "FB-ERRMSG-OBJ"],
+]) {
+  test(`F-B producer: a non-scalar at ${label} is refused and never retained`, () => {
+    const projected = projectRetainedEvent({
+      direction: "server",
+      method: "item/completed",
+      id: null,
+      params: {
+        completedAtMs: 5000,
+        threadId: "t-1",
+        turnId: "u-1",
+        item: {
+          type: "mcpToolCall",
+          id: "tool-1",
+          server: "assay",
+          tool: "assay_policy_decide",
+          status: "completed",
+          arguments: { tool: "install_surface_allowed_probe" },
+          result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+          ...patch,
+        },
+      },
+    });
+    assert.equal(
+      JSON.stringify(projected).includes(marker),
+      false,
+      `${label}: host content must not reach retained bytes even though the consumer would refuse the record`,
+    );
+    assert.equal(
+      classifyStoredEvent(projected).type,
+      "unclassified",
+      `${label}: the record must still be refused`,
+    );
+  });
+}

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -4704,7 +4704,7 @@ test("known non-evidentiary items project to a closed type and id only", () => {
   assert.equal(withNull.params.item.id, null, "JSON null must survive the scalar boundary");
 });
 
-test("current Codex non-evidentiary items are scrubbed and do not invalidate a real tool row", async () => {
+test("current Codex non-evidentiary items are dropped and do not invalidate a real tool row", async () => {
   const control = await drive("valid");
   assert.equal(validateProofRoot(control.proofRoot).ok, true, "unchanged control must validate");
   const events = structuredClone(control.events);
@@ -5209,5 +5209,197 @@ test("F2: a marked unexpected key is refused by the consumer, not merely marked"
     classifyStoredEvent(projected).type,
     "unclassified",
     "an item carrying an unexpected key must be refused by the consumer",
+  );
+});
+
+// --- F1: the PRODUCER half of every new type check must bite -------------------------------
+// The pre-existing consumer test injects malformed values onto ALREADY-PROJECTED bytes, so it
+// exercises retainedItemReason only and never projectRetainedItem. These cases start from what a
+// HOST would emit, run it through the producer, and assert the consumer refuses the result -- which
+// is the only way a producer-side type check can be pinned.
+for (const [label, item] of [
+  ["pluginId non-string", { pluginId: 123 }],
+  ["mcpAppResourceUri non-string", { mcpAppResourceUri: 7 }],
+  ["durationMs non-number", { durationMs: "120" }],
+  ["durationMs negative", { durationMs: -1 }],
+  ["readOnlyHint non-boolean", { readOnlyHint: "true" }],
+  ["appContext non-object", { appContext: 5 }],
+  ["appContext missing connectorId", { appContext: {} }],
+  ["appContext connectorId non-string", { appContext: { connectorId: 123 } }],
+  ["appContext connectorId empty", { appContext: { connectorId: "" } }],
+  ["appContext optional non-string", { appContext: { connectorId: "c", appName: 9 } }],
+  ["error non-object", { error: 5 }],
+  ["error message non-string", { error: { message: 9 } }],
+]) {
+  test(`F1 producer: host-emitted ${label} is refused after projection`, () => {
+    const projected = projectRetainedEvent({
+      direction: "server",
+      method: "item/completed",
+      id: null,
+      params: {
+        completedAtMs: 5000,
+        threadId: "t-1",
+        turnId: "u-1",
+        item: {
+          type: "mcpToolCall",
+          id: "tool-1",
+          server: "assay",
+          tool: "assay_policy_decide",
+          status: "completed",
+          arguments: { tool: "install_surface_allowed_probe" },
+          result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+          ...item,
+        },
+      },
+    });
+    assert.equal(
+      classifyStoredEvent(projected).type,
+      "unclassified",
+      `${label}: producer must not coerce a malformed host value into an acceptable projection`,
+    );
+  });
+}
+
+// --- F2: nested unknown keys must be marked AND refused ------------------------------------
+// The refusal is indirect: the nested reason function rejects because the projection's
+// __unexpectedKeys marker is itself outside its allowed list. Nothing stated that coupling, so
+// deleting either half left the suite green. These pin both halves and the no-leak property.
+for (const [label, item, probe] of [
+  [
+    "appContext",
+    {
+      appContext: { connectorId: "c-1", unknownHostNested: "F2-APPCONTEXT-LEAK" },
+      result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+    },
+    "F2-APPCONTEXT-LEAK",
+  ],
+  [
+    "error",
+    {
+      error: { message: "boom", unknownHostNested: "F2-ERROR-LEAK" },
+      result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+    },
+    "F2-ERROR-LEAK",
+  ],
+]) {
+  test(`F2 nested: an unknown key inside ${label} is marked, refused, and never retained`, () => {
+    const projected = projectRetainedEvent({
+      direction: "server",
+      method: "item/completed",
+      id: null,
+      params: {
+        completedAtMs: 5000,
+        threadId: "t-1",
+        turnId: "u-1",
+        item: {
+          type: "mcpToolCall",
+          id: "tool-1",
+          server: "assay",
+          tool: "assay_policy_decide",
+          status: "completed",
+          arguments: { tool: "install_surface_allowed_probe" },
+          ...item,
+        },
+      },
+    });
+    const nested = projected.params.item[label];
+    assert.deepEqual(
+      nested.__unexpectedKeys,
+      ["unknownHostNested"],
+      `${label}: the producer must mark the unknown nested key`,
+    );
+    assert.equal(
+      classifyStoredEvent(projected).type,
+      "unclassified",
+      `${label}: the consumer must refuse a marked nested key, not merely record it`,
+    );
+    assert.equal(
+      JSON.stringify(projected).includes(probe),
+      false,
+      `${label}: the unknown nested value must never reach retained bytes`,
+    );
+  });
+}
+
+// --- F5: the canonical 0.153.1 prompt is accepted end-to-end, and legacy still is ----------
+test("F5: the canonical elicitation prompt is accepted by a driven run", async () => {
+  const canonical = await drive("canonical-elicitation-prompt");
+  assert.equal(canonical.driverOutcome.exitCode, 0, "canonical prompt must drive to success");
+  assert.equal(canonical.driverOutcome.status, "pass");
+  const elicit = canonical.events.find(
+    (e) => e.method === "mcpServer/elicitation/request" && e.direction === "server",
+  );
+  assert.ok(elicit, "the driven run must contain an elicitation request");
+  assert.equal(
+    elicit.params.message,
+    'Allow the assay MCP server to run tool "assay_policy_decide"?',
+    "the driven run must carry the canonical prompt, not the legacy one",
+  );
+});
+
+// --- The closed whitelist must equal the 0.153.1 schema's mcpToolCall property set ----------
+// allowedKeys is a CLOSED whitelist: a real host field missing from it refuses the whole proof.
+// The generated protocol-0.153.1 schema is the only local statement of that set. It is a schema,
+// not a live invocation claim -- a field can be declared and never emitted, and emission is not
+// established here -- but a mismatch in either direction is actionable: a schema property absent
+// from allowedKeys is a guaranteed false refusal, and an allowedKey absent from the schema admits
+// something the host is not declared to send. Measured 2026-09-05 against
+// protocol-0.153.1/v2/ThreadStartResponse.json (sha256
+// 656f8fd0fe91f533126cbfdb9369cfab550927a229e48dd46460f6f015d2b186), definitions/ThreadItem/oneOf/8
+// (McpToolCallThreadItem, 13 properties, no allOf/anyOf/$ref composition, additionalProperties unset).
+// That file is not vendored here; this list is the pinned copy of what it declared when measured.
+test("mcpToolCall allowedKeys equals the 0.153.1 schema property set", () => {
+  const schemaProperties = [
+    "appContext",
+    "arguments",
+    "durationMs",
+    "error",
+    "id",
+    "mcpAppResourceUri",
+    "pluginId",
+    "readOnlyHint",
+    "result",
+    "server",
+    "status",
+    "tool",
+    "type",
+  ];
+  // Derived from behaviour, not from importing the constant: a key the whitelist accepts produces
+  // no top-level __unexpectedKeys marker, and one it rejects does.
+  const project = (extraKey) =>
+    projectRetainedEvent({
+      direction: "server",
+      method: "item/completed",
+      id: null,
+      params: {
+        completedAtMs: 5000,
+        threadId: "t-1",
+        turnId: "u-1",
+        item: {
+          type: "mcpToolCall",
+          id: "tool-1",
+          server: "assay",
+          tool: "assay_policy_decide",
+          status: "completed",
+          arguments: { tool: "install_surface_allowed_probe" },
+          result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+          ...(extraKey === null ? {} : { [extraKey]: null }),
+        },
+      },
+    }).params.item;
+
+  for (const key of schemaProperties) {
+    const item = project(key);
+    assert.equal(
+      Object.hasOwn(item, "__unexpectedKeys"),
+      false,
+      `schema property ${key} must not be treated as unexpected: a closed whitelist that omits it refuses every real host record`,
+    );
+  }
+  const control = project("definitelyNotInTheSchema");
+  assert.deepEqual(
+    control.__unexpectedKeys,
+    ["definitelyNotInTheSchema"],
+    "control: a key outside the schema must still be marked",
   );
 });

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -5337,18 +5337,18 @@ test("F5: the canonical elicitation prompt is accepted by a driven run", async (
   );
 });
 
-// --- The closed whitelist must equal the 0.153.1 schema's mcpToolCall property set ----------
+// --- The closed whitelist vs the 0.153.1 schema's mcpToolCall property set ------------------
 // allowedKeys is a CLOSED whitelist: a real host field missing from it refuses the whole proof.
 // The generated protocol-0.153.1 schema is the only local statement of that set. It is a schema,
 // not a live invocation claim -- a field can be declared and never emitted, and emission is not
-// established here -- but a mismatch in either direction is actionable: a schema property absent
+// established here -- but a mismatch is actionable: a schema property absent
 // from allowedKeys is a guaranteed false refusal, and an allowedKey absent from the schema admits
 // something the host is not declared to send. Measured 2026-09-05 against
 // protocol-0.153.1/v2/ThreadStartResponse.json (sha256
 // 656f8fd0fe91f533126cbfdb9369cfab550927a229e48dd46460f6f015d2b186), definitions/ThreadItem/oneOf/8
 // (McpToolCallThreadItem, 13 properties, no allOf/anyOf/$ref composition, additionalProperties unset).
 // That file is not vendored here; this list is the pinned copy of what it declared when measured.
-test("mcpToolCall allowedKeys equals the 0.153.1 schema property set", () => {
+test("mcpToolCall projection accepts every declared 0.153.1 schema property", () => {
   const schemaProperties = [
     "appContext",
     "arguments",
@@ -5405,12 +5405,16 @@ test("mcpToolCall allowedKeys equals the 0.153.1 schema property set", () => {
 });
 
 // --- F-A: the whitelist must equal the schema set, not merely contain it -------------------
-// The sibling test above asserts schemaProperties ⊆ allowedKeys. That leaves the other direction
-// open: adding a key the schema does not declare survives it. A closed whitelist that admits an
-// undeclared field is the mirror of one that omits a declared one -- it accepts something 0.153.1
-// never says the host sends, so the "equals" in that test's name has to be earned in both
-// directions or not claimed.
-test("mcpToolCall allowedKeys admits nothing the 0.153.1 schema does not declare", () => {
+// The sibling test asserts only that the schema's declared properties are accepted. That leaves
+// the other direction open: adding a key the schema does not declare survived it. A closed
+// whitelist that admits an undeclared field is the mirror of one that omits a declared one -- it
+// accepts something 0.153.1 never says the host sends.
+//
+// SCOPE: this is a SAMPLE, not a proof of set equality. It refuses the nine names below; it does
+// not and cannot establish that every name outside the schema is refused, because it does not
+// enumerate that set. Deliberately no parser and no generated name space here -- the sample is
+// chosen to bite the realistic mutation (widening the whitelist), not to make a universal claim.
+test("mcpToolCall projection refuses a sample of names the 0.153.1 schema does not declare", () => {
   // Names deliberately outside the 13 declared properties, including several that are plausible
   // near-misses of real fields elsewhere in the protocol.
   const notInSchema = [

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -4976,9 +4976,16 @@ test("Codex 0.153.1 mcpToolCall schema fields type-check; free text is recorded 
       item: unexpectedKeyCall,
     },
   });
-  assert.deepEqual(projectedWithUnexpected.params.item.__unexpectedKeys, [
-    "unknownHostMetadata",
-  ]);
+  assert.equal(
+    projectedWithUnexpected.params.item.__unexpectedKeys,
+    "[present]",
+    "the marker records that unexpected keys existed, never which",
+  );
+  assert.equal(
+    JSON.stringify(projectedWithUnexpected).includes("unknownHostMetadata"),
+    false,
+    "the unexpected key NAME must never reach retained bytes",
+  );
 });
 
 test("failed MCP tool status fails oneToolInvoked and structuredResultValidated", async () => {
@@ -5204,7 +5211,12 @@ test("F2: a marked unexpected key is refused by the consumer, not merely marked"
       },
     },
   });
-  assert.deepEqual(projected.params.item.__unexpectedKeys, ["unknownHostMetadata"]);
+  assert.equal(projected.params.item.__unexpectedKeys, "[present]");
+  assert.equal(
+    JSON.stringify(projected).includes("unknownHostMetadata"),
+    false,
+    "the unexpected key NAME must never reach retained bytes",
+  );
   assert.equal(
     classifyStoredEvent(projected).type,
     "unclassified",
@@ -5282,7 +5294,7 @@ for (const [label, item, probe] of [
     "F2-ERROR-LEAK",
   ],
 ]) {
-  test(`F2 nested: an unknown key inside ${label} is marked, refused, and never retained`, () => {
+  test(`F2 nested: an unknown key inside ${label} is marked and refused, and neither its name nor its value is retained`, () => {
     const projected = projectRetainedEvent({
       direction: "server",
       method: "item/completed",
@@ -5303,10 +5315,15 @@ for (const [label, item, probe] of [
       },
     });
     const nested = projected.params.item[label];
-    assert.deepEqual(
+    assert.equal(
       nested.__unexpectedKeys,
-      ["unknownHostNested"],
-      `${label}: the producer must mark the unknown nested key`,
+      "[present]",
+      `${label}: the producer must mark that an unknown nested key existed`,
+    );
+    assert.equal(
+      JSON.stringify(projected).includes("unknownHostNested"),
+      false,
+      `${label}: the unknown nested key NAME must never reach retained bytes`,
     );
     assert.equal(
       classifyStoredEvent(projected).type,
@@ -5397,10 +5414,15 @@ test("mcpToolCall projection accepts every declared 0.153.1 schema property", ()
     );
   }
   const control = project("definitelyNotInTheSchema");
-  assert.deepEqual(
+  assert.equal(
     control.__unexpectedKeys,
-    ["definitelyNotInTheSchema"],
+    "[present]",
     "control: a key outside the schema must still be marked",
+  );
+  assert.equal(
+    JSON.stringify(control).includes("definitelyNotInTheSchema"),
+    false,
+    "control: marking must not retain the name",
   );
 });
 
@@ -5449,10 +5471,20 @@ test("mcpToolCall projection refuses a sample of names the 0.153.1 schema does n
         },
       },
     }).params.item;
-    assert.deepEqual(
+    assert.equal(
       item.__unexpectedKeys,
-      [key],
+      "[present]",
       `${key} is not declared by the 0.153.1 schema and must be marked unexpected`,
+    );
+    assert.equal(
+      Object.hasOwn(item, key),
+      false,
+      `${key} must be marked without retaining its name as a key`,
+    );
+    assert.equal(
+      JSON.stringify(item.__unexpectedKeys).includes(key),
+      false,
+      `${key} must not survive inside the marker`,
     );
   }
   // Control: a declared property must still be accepted, so the assertion above cannot pass by
@@ -5648,3 +5680,138 @@ for (const [label, patch, marker] of [
     assert.equal(classifyStoredEvent(projected).type, "unclassified", `${label}: must still be refused`);
   });
 }
+
+// --- F-1: an object KEY NAME is host data exactly as a value is ----------------------------
+// Every earlier privacy test scanned VALUE positions. The unexpected-key marker recorded the
+// NAMES of the keys it rejected, so a host that put a path or a token in a key name had it
+// retained in full -- and at three of the six sites the record was still classified accepted,
+// so the leak was not even redeemed by refusal. The projection now records only that unexpected
+// keys existed. These tests assert the name is gone at every site that can produce the marker.
+const KEY_NAME_PROBE = "/Users/alice/.ssh/id_rsa?token=AKIA_KEY_NAME_PROBE";
+
+function everyKey(value, seen = new Set()) {
+  if (Array.isArray(value)) {
+    for (const entry of value) everyKey(entry, seen);
+  } else if (value !== null && typeof value === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      seen.add(key);
+      everyKey(entry, seen);
+    }
+  }
+  return seen;
+}
+
+for (const [site, item] of [
+  ["projectRetainedItem", { [KEY_NAME_PROBE]: 1 }],
+  ["projectArguments", { arguments: { tool: "probe", [KEY_NAME_PROBE]: 1 } }],
+  ["projectToolResult", { result: { isError: false, [KEY_NAME_PROBE]: 1 } }],
+  [
+    "projectDecisionObject",
+    { result: { isError: false, structuredContent: { allowed: true, reason: "ok", [KEY_NAME_PROBE]: 1 } } },
+  ],
+  ["projectAppContext", { appContext: { connectorId: "c-1", [KEY_NAME_PROBE]: 1 } }],
+  ["projectMcpToolCallError", { error: { message: "boom", [KEY_NAME_PROBE]: 1 } }],
+]) {
+  test(`F1: a secret-shaped key name at ${site} is marked without being retained`, () => {
+    const projected = projectRetainedEvent({
+      direction: "server",
+      method: "item/completed",
+      id: null,
+      params: {
+        completedAtMs: 5000,
+        threadId: "t-1",
+        turnId: "u-1",
+        item: {
+          type: "mcpToolCall",
+          id: "tool-1",
+          server: "assay",
+          tool: "assay_policy_decide",
+          status: "completed",
+          arguments: { tool: "probe" },
+          result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+          ...item,
+        },
+      },
+    });
+    assert.equal(
+      JSON.stringify(projected).includes(KEY_NAME_PROBE),
+      false,
+      `${site}: the key name must not reach retained bytes`,
+    );
+    assert.equal(
+      everyKey(projected).has(KEY_NAME_PROBE),
+      false,
+      `${site}: the key name must not survive as a key either`,
+    );
+    // Positive control: without this the assertions above pass on a projection that never
+    // reached the marker at all, and the test would prove nothing about this site.
+    assert.equal(
+      everyKey(projected).has("__unexpectedKeys"),
+      true,
+      `${site}: the marker must still record that an unexpected key was present`,
+    );
+  });
+}
+
+test("F1: re-projecting an already-projected event is a fixed point", () => {
+  // The marker is itself outside every allowed list, so it is re-marked on a second pass. That is
+  // only stable because the marker collapses to a constant: a name list or a count would change.
+  const event = {
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 5000,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: {
+        type: "mcpToolCall",
+        id: "tool-1",
+        server: "assay",
+        tool: "assay_policy_decide",
+        status: "completed",
+        arguments: { tool: "probe", [KEY_NAME_PROBE]: 1 },
+        [KEY_NAME_PROBE]: 1,
+        appContext: { connectorId: "c-1", [KEY_NAME_PROBE]: 1 },
+        result: {
+          isError: false,
+          [KEY_NAME_PROBE]: 1,
+          structuredContent: { allowed: true, reason: "ok", [KEY_NAME_PROBE]: 1 },
+        },
+      },
+    },
+  };
+  const once = projectRetainedEvent(event);
+  const twice = projectRetainedEvent(once);
+  assert.deepEqual(twice, once, "projection must be idempotent");
+  assert.equal(JSON.stringify(once).includes(KEY_NAME_PROBE), false);
+});
+
+test("F1: a secret-shaped key name never reaches the persisted events.json", async () => {
+  // The projection tests above run in process. This one drives the real fake host through the
+  // real driver and asserts against the bytes on disk, because events.json is written
+  // unconditionally before any verdict is reached.
+  const { proofRoot, events } = await drive("host-key-name-leak");
+  const raw = fs.readFileSync(path.join(proofRoot, "events.json"), "utf8");
+  assert.equal(
+    raw.includes("AKIA_KEY_NAME_PROBE"),
+    false,
+    "the persisted proof must not contain the host-controlled key name",
+  );
+  assert.equal(
+    fs.readFileSync(path.join(proofRoot, "classification.json"), "utf8").includes("AKIA_KEY_NAME_PROBE"),
+    false,
+    "the refusal reason must not echo the host-controlled key name",
+  );
+  // Positive control: the scenario must actually have reached the pipeline. Without this the
+  // absence assertions pass vacuously if the fixture literal ever drifts.
+  const toolEvent = events.find(
+    (event) => event.method === "item/completed" && event.params?.item?.type === "mcpToolCall",
+  );
+  assert.ok(toolEvent, "the scenario must emit an mcpToolCall item");
+  assert.equal(
+    toolEvent.params.item.__unexpectedKeys,
+    "[present]",
+    "control: the injected key must have been marked, or nothing was measured",
+  );
+});

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -5526,3 +5526,125 @@ for (const [label, patch, marker] of [
     );
   });
 }
+
+// --- The CONSUMER allowedKeys list, pinned in both directions -------------------------------
+// There are two whitelists: this one, in retainedItemReason, and a separate list in
+// projectRetainedItem. Every earlier schema test asserted on __unexpectedKeys, which the PRODUCER
+// list makes -- so the consumer list was pinned in neither direction, and dropping a declared
+// property from it made a driven run fail all nine cells while the suite stayed green.
+//
+// The two directions need two different tests, and one cannot substitute for the other:
+//   * dropping a declared key is caught by a well-formed record being ACCEPTED;
+//   * adding an undeclared key is NOT caught that way, because a well-formed record never carries
+//     the added key. It is also not caught through the projection, because the producer still marks
+//     the key and the consumer then refuses on the __unexpectedKeys marker rather than on the key
+//     itself. Only an UNPROJECTED stored event isolates the consumer list.
+
+test("consumer accepts a well-formed mcpToolCall carrying every newly admitted field", () => {
+  const classified = classifyStoredEvent(
+    projectRetainedEvent({
+      direction: "server",
+      method: "item/completed",
+      id: null,
+      params: {
+        completedAtMs: 5000,
+        threadId: "t-1",
+        turnId: "u-1",
+        item: {
+          type: "mcpToolCall",
+          id: "tool-1",
+          server: "assay",
+          tool: "assay_policy_decide",
+          status: "completed",
+          arguments: { tool: "install_surface_allowed_probe" },
+          result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+          durationMs: 120,
+          readOnlyHint: true,
+          pluginId: "plugin-assay",
+          mcpAppResourceUri: "resource://assay",
+          appContext: { connectorId: "connector-1" },
+          error: null,
+        },
+      },
+    }),
+  );
+  assert.equal(
+    classified.type,
+    "server-notification",
+    `a record carrying only declared 0.153.1 properties must be accepted; a consumer allowedKeys missing any of them silently refuses every real host record (got: ${JSON.stringify(classified)})`,
+  );
+});
+
+test("consumer refuses an unprojected mcpToolCall carrying a name the schema does not declare", () => {
+  // Deliberately NOT projected: the producer would mark the key and the consumer would then refuse
+  // on the marker, which proves nothing about the consumer's own list. These stored bytes isolate it.
+  //
+  // SCOPE: a sample, not a proof of set equality. It refuses the names below; it cannot establish
+  // that every name outside the schema is refused, because it does not enumerate that set.
+  for (const key of [
+    "notInTheSchemaAtAll",
+    "aggregatedOutput",
+    "command",
+    "cwd",
+    "sessionId",
+  ]) {
+    const classified = classifyStoredEvent({
+      direction: "server",
+      method: "item/completed",
+      id: null,
+      params: {
+        completedAtMs: 5000,
+        threadId: "t-1",
+        turnId: "u-1",
+        item: {
+          type: "mcpToolCall",
+          id: "tool-1",
+          server: "assay",
+          tool: "assay_policy_decide",
+          status: "completed",
+          arguments: { tool: "install_surface_allowed_probe" },
+          result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+          [key]: null,
+        },
+      },
+    });
+    assert.equal(
+      classified.type,
+      "unclassified",
+      `${key} is not declared by the 0.153.1 schema; the consumer must refuse it on its own list`,
+    );
+  }
+});
+
+// --- F-B, extended: durationMs and readOnlyHint have their own producer ternaries ------------
+// They do not share projectedPresence, so the five F-B rows above do not cover them, and the
+// existing cases use scalar non-strings which the consumer catches regardless of the producer.
+for (const [label, patch, marker] of [
+  ["durationMs object", { durationMs: { secret: "FB-DURATION-OBJ" } }, "FB-DURATION-OBJ"],
+  ["readOnlyHint array", { readOnlyHint: ["FB-READONLY-ARR"] }, "FB-READONLY-ARR"],
+]) {
+  test(`F-B producer: a non-scalar at ${label} is refused and never retained`, () => {
+    const projected = projectRetainedEvent({
+      direction: "server",
+      method: "item/completed",
+      id: null,
+      params: {
+        completedAtMs: 5000,
+        threadId: "t-1",
+        turnId: "u-1",
+        item: {
+          type: "mcpToolCall",
+          id: "tool-1",
+          server: "assay",
+          tool: "assay_policy_decide",
+          status: "completed",
+          arguments: { tool: "install_surface_allowed_probe" },
+          result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+          ...patch,
+        },
+      },
+    });
+    assert.equal(JSON.stringify(projected).includes(marker), false, `${label}: must not reach retained bytes`);
+    assert.equal(classifyStoredEvent(projected).type, "unclassified", `${label}: must still be refused`);
+  });
+}

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -4824,52 +4824,57 @@ function projectRetainedItem_typeOf(rawType) {
 
 test("projection-idempotent unknown terminal items are drift, not accepted topology", async () => {
   const control = await drive("valid");
-  // F3 moved unknown item types behind a projection: a raw future type no longer survives the
-  // round-trip, so pin that first, then keep probing PAST the round-trip check using the projected
-  // marker, which IS a fixed point. Both halves matter -- the first is the new barrier, the second
-  // is this test's original purpose (drift must be refused by the cells, not only by projection).
+  // An unknown item type is now an explicit projection violation, not a legal-looking substitute,
+  // so it is refused at the consumer and can no longer reach the cells at all. That is strictly
+  // stronger than the drift path this test used to probe, so the probe is re-aimed at the barrier.
   for (const raw of ["futureHostItem", "not-a-retained-item"]) {
+    const projectedType = projectRetainedItem_typeOf(raw);
     assert.equal(
-      projectRetainedItem_typeOf(raw),
-      "[unknown-item-type]",
-      `${raw} must be projected, not retained verbatim`,
+      typeof projectedType,
+      "object",
+      `${raw} must become an explicit violation, never a legal-looking value`,
+    );
+    assert.equal(
+      JSON.stringify(projectedType).includes(raw),
+      false,
+      `${raw} must not survive inside the violation marker`,
     );
   }
-  for (const type of ["[unknown-item-type]"]) {
+  // Past the projection barrier: a terminal item that is well-formed EXCEPT for carrying a
+  // violation must still be refused by the cells and by revalidation, not merely marked. The
+  // crafted item is projected first, so what is classified is what a real run would have persisted
+  // -- this is the "probe past the round-trip" the test exists for, re-expressed now that an
+  // unknown type cannot survive projection at all.
+  for (const label of ["unknown-type", "undeclared-tool"]) {
     const events = structuredClone(control.events);
     const terminal = events.find((event) => event.method === "turn/completed");
     assert.ok(terminal, "control run must contain the terminal turn");
-    const crafted = {
-      type,
-      id: `item_${type}`,
+    terminal.params.turn.items.push({
+      type: label === "unknown-type" ? "futureHostItem" : "mcpToolCall",
+      id: `item_${label}`,
       server: "assay",
-      tool: "unmapped",
+      tool: label === "undeclared-tool" ? "unmapped" : "assay_policy_decide",
       arguments: { tool: "x", policy: "y" },
       status: "completed",
-    };
-    terminal.params.turn.items.push(crafted);
-    assert.deepEqual(
-      projectRetainedEvent(terminal),
-      terminal,
-      `${type} fixture must be a projection fixed point, or this test stops probing past the round-trip check`,
-    );
-    const classified = classifyRecord({ ...control.manifest, events });
+    });
+    const projected = projectRetainedEvent(terminal);
+    const classified = classifyRecord({ ...control.manifest, events: [...events.slice(0, -1), projected] });
     assert.equal(
       allIntendedCellsPass(classified),
       false,
-      `a ${type} terminal item must not classify clean`,
+      `a ${label} terminal item must not classify clean`,
     );
-    assert.match(
-      Object.values(classified.cells)
-        .map((entry) => entry.reason)
-        .join("; "),
-      /unknown retained item type/,
-      `a ${type} terminal item must be explicit protocol drift`,
-    );
-    rewriteProof(control.proofRoot, control.manifest, events, classified);
-    const revalidated = validateProofRoot(control.proofRoot);
-    assert.equal(revalidated.ok, false, `a ${type} terminal item must not validate clean`);
-    assert.match(revalidated.reasons.join("; "), /unknown retained item type/);
+    const reasons = Object.values(classified.cells)
+      .map((entry) => entry.reason)
+      .join("; ");
+    // Group E: the refusal must name the condition and never echo the host value.
+    for (const hostValue of ["futureHostItem", "unmapped"]) {
+      assert.equal(
+        reasons.includes(hostValue),
+        false,
+        `${label}: a refusal reason must not echo the host value ${hostValue}`,
+      );
+    }
   }
 });
 
@@ -5046,7 +5051,13 @@ test("failed MCP tool status fails oneToolInvoked and structuredResultValidated"
 
   const classified = classifyRecord({ ...control.manifest, events });
   assert.equal(classified.cells.oneToolInvoked.status, "fail");
-  assert.match(classified.cells.oneToolInvoked.reason, /tool status failed/);
+  // The reason names the condition, never the host-supplied value (group E).
+  assert.match(classified.cells.oneToolInvoked.reason, /status is not completed/);
+  assert.equal(
+    classified.cells.oneToolInvoked.reason.includes("failed"),
+    false,
+    "a refusal reason must not echo the host status value",
+  );
   assert.equal(classified.cells.structuredResultValidated.status, "unavailable");
 });
 
@@ -5870,7 +5881,9 @@ test("F1: an unknown method is projected, and every declared method survives ver
     id: null,
     params: {},
   });
-  assert.equal(projected.method, "[unknown-method]");
+  // Explicitly invalid, not a legal-looking substitute: an unknown member must never read as an
+  // allowed value, and the consumer refuses the violation wherever it sits.
+  assert.equal(typeof projected.method, "object", "an unknown method must become a violation");
   assert.equal(JSON.stringify(projected).includes(IDENTIFIER_PROBE), false);
   assert.equal(
     classifyStoredEvent(projected).type,
@@ -5889,13 +5902,9 @@ test("F1: an unknown method is projected, and every declared method survives ver
 });
 
 test("F3: an unknown item type is projected, and every declared type survives verbatim", () => {
-  assert.equal(projectRetainedItem_typeOf(`type_${IDENTIFIER_PROBE}`), "[unknown-item-type]");
-  assert.equal(
-    JSON.stringify(projectRetainedItem_typeOf(`type_${IDENTIFIER_PROBE}`)).includes(
-      IDENTIFIER_PROBE,
-    ),
-    false,
-  );
+  const projectedType = projectRetainedItem_typeOf(`type_${IDENTIFIER_PROBE}`);
+  assert.equal(typeof projectedType, "object", "an unknown item type must become a violation");
+  assert.equal(JSON.stringify(projectedType).includes(IDENTIFIER_PROBE), false);
   for (const type of KNOWN_ITEM_TYPES) {
     assert.equal(projectRetainedItem_typeOf(type), type, `declared type ${type} must survive`);
   }
@@ -5911,13 +5920,15 @@ test("F1/F3: neither identifier reaches the persisted proof", async () => {
     );
   }
   // Positive control: the scenario must have reached the pipeline, or the absence is vacuous.
+  // Positive controls: the scenario must have reached the pipeline. Both identifiers must appear
+  // as explicit violations, or the absence assertions above are vacuous.
   assert.ok(
-    events.some((event) => event.method === "[unknown-method]"),
-    "control: the unknown method must have been projected, or nothing was measured",
+    events.some((event) => event.method !== null && typeof event.method === "object"),
+    "control: the unknown method must have been projected to a violation",
   );
   assert.ok(
-    events.some((event) => event.params?.item?.type === "[unknown-item-type]"),
-    "control: the unknown item type must have been projected, or nothing was measured",
+    events.some((event) => typeof event.params?.item?.type === "object"),
+    "control: the unknown item type must have been projected to a violation",
   );
 });
 
@@ -6067,4 +6078,132 @@ test("F2: distinct host ids get distinct tokens", async () => {
     requestTokens[1],
     "two different host ids must not collapse to one token",
   );
+});
+
+// --- B/C/D: the finite identifier contract, measured on the persisted bytes ------------------
+// Every assertion below reads events.json and classification.json, not an in-process projection:
+// those files are what a live proof hands to a reader.
+
+function persisted(proofRoot, name) {
+  return fs.readFileSync(path.join(proofRoot, name), "utf8");
+}
+
+test("B: thread, turn and item identities are retained as structure, not as host text", async () => {
+  const { proofRoot } = await drive("valid");
+  const raw = persisted(proofRoot, "events.json");
+  const events = JSON.parse(raw);
+
+  // No host-chosen identifier text survives. The fixture's own literals are the probe.
+  for (const hostValue of ["thread-", "turn-1", "call-1"]) {
+    assert.equal(
+      raw.includes(hostValue),
+      false,
+      `${hostValue} is a host-chosen identifier and must not reach the persisted proof`,
+    );
+  }
+  assert.equal(
+    persisted(proofRoot, "classification.json").includes("turn-1"),
+    false,
+    "classification must not carry a host identifier either",
+  );
+
+  // Namespaces stay separate: a thread token can never equal a turn or item token.
+  const threadTokens = new Set();
+  const turnTokens = new Set();
+  const itemTokens = new Set();
+  for (const event of events) {
+    const p = event.params ?? {};
+    if (typeof p.threadId === "string") threadTokens.add(p.threadId);
+    if (typeof p.turnId === "string") turnTokens.add(p.turnId);
+    if (typeof p.turn?.id === "string") turnTokens.add(p.turn.id);
+    if (typeof p.item?.id === "string") itemTokens.add(p.item.id);
+    if (typeof event.result?.thread?.id === "string") threadTokens.add(event.result.thread.id);
+    if (typeof event.result?.turn?.id === "string") turnTokens.add(event.result.turn.id);
+  }
+  assert.ok(threadTokens.size > 0 && turnTokens.size > 0 && itemTokens.size > 0, "control: all three roles must appear");
+  for (const [label, tokens, prefix] of [
+    ["thread", threadTokens, "@"],
+    ["turn", turnTokens, "~"],
+    ["item", itemTokens, "!"],
+  ]) {
+    for (const value of tokens) {
+      assert.ok(value.startsWith(prefix), `${label} token ${value} must carry its own namespace`);
+    }
+  }
+  // The distinctions the cells depend on: a role's members must agree with each other, which is
+  // exactly what a partial namespace would break.
+  // Tokens within a role are allocated first-seen and contiguous, which is what makes them
+  // injective. (This journey deliberately touches several threads, so the count is not 1.)
+  for (const [label, tokens, prefix] of [
+    ["thread", threadTokens, "@"],
+    ["turn", turnTokens, "~"],
+    ["item", itemTokens, "!"],
+  ]) {
+    const ordinals = [...tokens].map((value) => Number(value.slice(prefix.length))).sort((a, b) => a - b);
+    assert.deepEqual(
+      ordinals,
+      ordinals.map((_, index) => index),
+      `${label} tokens must be contiguous first-seen ordinals`,
+    );
+  }
+  // Correlation, which is the only reason the tokens exist: the terminal turn must still name the
+  // same turn the turn/start response reported.
+  const terminal = events.find((event) => event.method === "turn/completed");
+  const turnStart = events.find((event) => typeof event.result?.turn?.id === "string");
+  assert.ok(terminal && turnStart, "control: both turn rows must be retained");
+  assert.equal(
+    terminal.params.turn.id,
+    turnStart.result.turn.id,
+    "the terminal turn must still correlate with the turn/start response",
+  );
+});
+
+test("C: host platform and skill scope are retained as presence only", async () => {
+  const { proofRoot, manifest } = await drive("valid");
+  assert.equal(manifest.initialize.platformFamily, "[present]");
+  assert.equal(manifest.initialize.platformOs, "[present]");
+  // Control: a field with a real lexical consumer must NOT be collapsed, or the projection is a
+  // blanket scrub rather than the finite contract.
+  assert.notEqual(
+    manifest.initialize.codexHome,
+    "[present]",
+    "codexHome has a lexical consumer and must stay verbatim",
+  );
+  assert.equal(persisted(proofRoot, "events.json").includes(os.platform()), false);
+});
+
+test("D: the project-root comparison is retained, and its outcome is not the path", async () => {
+  const good = await drive("valid");
+  const goodEvents = JSON.parse(persisted(good.proofRoot, "events.json"));
+  const goodStart = goodEvents.find((event) => event.result?.cwd !== undefined);
+  assert.ok(goodStart, "control: a thread/start result must be retained");
+  assert.equal(goodStart.result.cwd, "[project-root]");
+  // NOTE, and it is a real distinction: the project root DOES still appear in retained bytes, in
+  // client REQUEST params the driver itself sent (`thread/start.params.cwd`, `skills/list.cwds`).
+  // That is the driver disclosing its own value, not host content, and group D never claimed to
+  // remove it. What must not survive is the value the HOST reported back, so that is what is
+  // asserted -- on the result position only.
+  assert.equal(
+    JSON.stringify(goodStart.result).includes(good.projectRoot),
+    false,
+    "the host-reported cwd must not be retained in the result",
+  );
+
+  // The failing path is where a leak would matter most, so it is measured, not assumed.
+  const bad = await drive("wrong-cwd");
+  const badRaw = persisted(bad.proofRoot, "events.json");
+  const badEvents = JSON.parse(badRaw);
+  const badStart = badEvents.find((event) => event.result?.cwd !== undefined);
+  assert.ok(badStart, "a thread/start result must be retained on the failing path too");
+  assert.equal(badStart.result.cwd, "[not-project-root]");
+  assert.equal(badRaw.includes("/not/the/project"), false, "the host cwd must not be retained");
+  const badClassification = persisted(bad.proofRoot, "classification.json");
+  assert.equal(
+    badClassification.includes("/not/the/project"),
+    false,
+    "the refusal reason must not echo the host cwd",
+  );
+  const cells = JSON.parse(badClassification).cells;
+  assert.equal(cells.cwdObserved.status, "fail", "required/false must stay distinguished from missing");
+  assert.match(cells.cwdObserved.reason, /not the project root/);
 });

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -24,6 +24,8 @@ import {
   EXPECTED_TOOLS,
   HARD_MAX_SNAPSHOT_BYTES,
   HOST_SUBJECTS,
+  KNOWN_ITEM_TYPES,
+  KNOWN_METHODS,
   classifyRecord,
   classifyStoredEvent,
   consumeJourneyTopology,
@@ -4796,9 +4798,44 @@ test("zero retained mcpToolCall rows keep oneToolInvoked non-pass", async () => 
   assert.notEqual(classified.cells.structuredResultValidated.status, "pass");
 });
 
+// Reaches projectRetainedItem's type projection through the exported entry point, so the assertion
+// is on production behaviour rather than on a re-implementation of the rule.
+function projectRetainedItem_typeOf(rawType) {
+  const projected = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 1,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: {
+        type: rawType,
+        id: "item-1",
+        server: "assay",
+        tool: "unmapped",
+        arguments: { tool: "x", policy: "y" },
+        status: "completed",
+      },
+    },
+  });
+  return projected.params.item.type;
+}
+
 test("projection-idempotent unknown terminal items are drift, not accepted topology", async () => {
   const control = await drive("valid");
-  for (const type of ["futureHostItem", "not-a-retained-item"]) {
+  // F3 moved unknown item types behind a projection: a raw future type no longer survives the
+  // round-trip, so pin that first, then keep probing PAST the round-trip check using the projected
+  // marker, which IS a fixed point. Both halves matter -- the first is the new barrier, the second
+  // is this test's original purpose (drift must be refused by the cells, not only by projection).
+  for (const raw of ["futureHostItem", "not-a-retained-item"]) {
+    assert.equal(
+      projectRetainedItem_typeOf(raw),
+      "[unknown-item-type]",
+      `${raw} must be projected, not retained verbatim`,
+    );
+  }
+  for (const type of ["[unknown-item-type]"]) {
     const events = structuredClone(control.events);
     const terminal = events.find((event) => event.method === "turn/completed");
     assert.ok(terminal, "control run must contain the terminal turn");
@@ -5753,7 +5790,7 @@ for (const [site, item] of [
   });
 }
 
-test("F1: re-projecting an already-projected event is a fixed point", () => {
+test("F1: the unexpected-key marker is a re-projection fixed point", () => {
   // The marker is itself outside every allowed list, so it is re-marked on a second pass. That is
   // only stable because the marker collapses to a constant: a name list or a count would change.
   const event = {
@@ -5783,7 +5820,10 @@ test("F1: re-projecting an already-projected event is a fixed point", () => {
   };
   const once = projectRetainedEvent(event);
   const twice = projectRetainedEvent(once);
-  assert.deepEqual(twice, once, "projection must be idempotent");
+  // SCOPE: this establishes the fixed point for the UNEXPECTED-KEY MARKER only. It is not a claim
+  // that projection is idempotent over all events -- `__invalidType` markers are deliberately not
+  // fixed points, and re-project to a different marker. That is fail-closed and out of scope here.
+  assert.deepEqual(twice, once, "the unexpected-key marker must be a fixed point");
   assert.equal(JSON.stringify(once).includes(KEY_NAME_PROBE), false);
 });
 
@@ -5814,4 +5854,120 @@ test("F1: a secret-shaped key name never reaches the persisted events.json", asy
     "[present]",
     "control: the injected key must have been marked, or nothing was measured",
   );
+});
+
+// --- F1/F3: an unknown method name and an unknown item type are host text too ------------------
+// The key-name repair closed one identifier position. These are the other two the independent
+// review found: a JSON-RPC method and a retained item type, both host-controlled strings that were
+// retained verbatim. Known names must survive verbatim -- classification, correlation and the cells
+// are keyed on them -- so the projection is a closed-set check, not a scrub.
+const IDENTIFIER_PROBE = "/Users/alice/.aws/credentials?sk=IDENTIFIER_PROBE";
+
+test("F1: an unknown method is projected, and every declared method survives verbatim", () => {
+  const projected = projectRetainedEvent({
+    direction: "server",
+    method: `notify_${IDENTIFIER_PROBE}`,
+    id: null,
+    params: {},
+  });
+  assert.equal(projected.method, "[unknown-method]");
+  assert.equal(JSON.stringify(projected).includes(IDENTIFIER_PROBE), false);
+  assert.equal(
+    classifyStoredEvent(projected).type,
+    "unclassified",
+    "an unknown method must still be refused, not merely projected",
+  );
+  // Positive control: every method this proof declares must pass through untouched, or the
+  // projection above is a scrub that would break classification rather than a closed-set check.
+  for (const method of KNOWN_METHODS) {
+    assert.equal(
+      projectRetainedEvent({ direction: "server", method, id: null, params: {} }).method,
+      method,
+      `declared method ${method} must survive verbatim`,
+    );
+  }
+});
+
+test("F3: an unknown item type is projected, and every declared type survives verbatim", () => {
+  assert.equal(projectRetainedItem_typeOf(`type_${IDENTIFIER_PROBE}`), "[unknown-item-type]");
+  assert.equal(
+    JSON.stringify(projectRetainedItem_typeOf(`type_${IDENTIFIER_PROBE}`)).includes(
+      IDENTIFIER_PROBE,
+    ),
+    false,
+  );
+  for (const type of KNOWN_ITEM_TYPES) {
+    assert.equal(projectRetainedItem_typeOf(type), type, `declared type ${type} must survive`);
+  }
+});
+
+test("F1/F3: neither identifier reaches the persisted proof", async () => {
+  const { proofRoot, events } = await drive("host-identifier-leak");
+  for (const name of ["events.json", "classification.json", "manifest.json"]) {
+    assert.equal(
+      fs.readFileSync(path.join(proofRoot, name), "utf8").includes("IDENTIFIER_PROBE"),
+      false,
+      `${name} must not contain the host-controlled identifier`,
+    );
+  }
+  // Positive control: the scenario must have reached the pipeline, or the absence is vacuous.
+  assert.ok(
+    events.some((event) => event.method === "[unknown-method]"),
+    "control: the unknown method must have been projected, or nothing was measured",
+  );
+  assert.ok(
+    events.some((event) => event.params?.item?.type === "[unknown-item-type]"),
+    "control: the unknown item type must have been projected, or nothing was measured",
+  );
+});
+
+// --- F4: a projection violation is a violation wherever it sits -------------------------------
+test("F4: a marker nested under result is refused, not carried into a green proof", () => {
+  const projected = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 5000,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: {
+        type: "mcpToolCall",
+        id: "tool-1",
+        server: "assay",
+        tool: "assay_policy_decide",
+        status: "completed",
+        arguments: { tool: "probe" },
+        result: { isError: false, structuredContent: { allowed: true, reason: "ok" }, extra: 1 },
+      },
+    },
+  });
+  // The producer marks it; before this repair the consumer consulted the marker only at some
+  // levels, so this record passed every cell -- a fully green proof carrying a recorded violation.
+  assert.equal(projected.params.item.result.__unexpectedKeys, "[present]");
+  const classified = classifyStoredEvent(projected);
+  assert.equal(classified.type, "unclassified", "a nested marker must refuse");
+  assert.match(classified.reason, /projection violation/);
+  // Positive control: the same record without the extra key must still be accepted, or the check
+  // above is satisfied by refusing everything.
+  const clean = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 5000,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: {
+        type: "mcpToolCall",
+        id: "tool-1",
+        server: "assay",
+        tool: "assay_policy_decide",
+        status: "completed",
+        arguments: { tool: "probe" },
+        result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+      },
+    },
+  });
+  assert.equal(classifyStoredEvent(clean).type, "server-notification", "control: clean must pass");
 });

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -5971,3 +5971,100 @@ test("F4: a marker nested under result is refused, not carried into a green proo
   });
   assert.equal(classifyStoredEvent(clean).type, "server-notification", "control: clean must pass");
 });
+
+// --- F2: a host-chosen string rpc id is host text, and correlation is only equality -----------
+// The wire keeps the real id -- string ids stay fully supported on the protocol. Only what is
+// RETAINED is relabelled, by one per-run first-seen ordinal map at the single retention funnel.
+// These tests pin both halves: the id never reaches the proof, and the correlation it carries does.
+const RPC_ID_PROBE = "RPCID_PROBE";
+
+test("F2: a host-chosen string rpc id never reaches the persisted proof", async () => {
+  const { proofRoot, events, classified } = await drive("host-rpc-id-leak");
+  for (const name of ["events.json", "classification.json", "manifest.json"]) {
+    assert.equal(
+      fs.readFileSync(path.join(proofRoot, name), "utf8").includes(RPC_ID_PROBE),
+      false,
+      `${name} must not contain the host-chosen rpc id`,
+    );
+  }
+  // Positive control: the scenario must have reached the pipeline, or every absence above is
+  // vacuous. A projected token must be present where the host id was.
+  const serverRequest = events.find(
+    (event) => event.direction === "server" && event.method === "mcpServer/elicitation/request",
+  );
+  assert.ok(serverRequest, "control: the server request must have been retained");
+  assert.match(
+    String(serverRequest.id),
+    /^#\d+$/,
+    "control: the host id must have been projected to a token",
+  );
+  // The property the token exists for: the matching client response must still pair with it.
+  const clientResponse = events.find(
+    (event) => event.direction === "client" && event.method === "mcpServer/elicitation/request",
+  );
+  assert.ok(clientResponse, "the matching client response must be retained");
+  assert.equal(
+    clientResponse.id,
+    serverRequest.id,
+    "request and response must still correlate through the token",
+  );
+  // The strongest available control: with a secret-shaped host id, the proof must still pass every
+  // intended cell. If the token had broken correlation anywhere, this is where it would show.
+  assert.equal(
+    allIntendedCellsPass(classified),
+    true,
+    "relabelling the retained id must not cost the proof a single cell",
+  );
+});
+
+test("F2: the retained token preserves equality structure and leaves integers alone", async () => {
+  const { events } = await drive("host-rpc-id-leak");
+  const stringIds = events.filter((event) => typeof event.id === "string").map((e) => e.id);
+  const numericIds = events.filter((event) => Number.isSafeInteger(event.id)).map((e) => e.id);
+
+  // Every retained string id is a token; none is a raw host string.
+  for (const id of stringIds) {
+    assert.match(id, /^#\d+$/, `retained string id ${id} must be a token`);
+  }
+  // Repeated: the request and its response share one host id, so they share one token.
+  assert.ok(
+    stringIds.length > new Set(stringIds).size,
+    "a repeated host id must yield a repeated token, or correlation is not being exercised",
+  );
+  // NOTE: injectivity is deliberately NOT asserted here. This run carries one host id, so nothing
+  // in it could distinguish an injective map from one that collapses every id to a single token.
+  // The separate distinct-id test below is the only place that discriminates it.
+
+  // Numeric ids are driver-generated and pass through untouched, which is what keeps the
+  // client-generated integer response lookup working.
+  assert.ok(numericIds.length > 0, "the driver's integer request ids must still be retained");
+  for (const id of numericIds) {
+    assert.equal(typeof id, "number");
+  }
+});
+
+test("F2: distinct host ids get distinct tokens", async () => {
+  // The discriminating case. A map that returned one constant token would satisfy every other F2
+  // assertion -- absence, tokenisation, and even request/response pairing -- so without two
+  // distinct host ids in one run, injectivity is asserted but untested.
+  const { proofRoot, events } = await drive("host-rpc-id-distinct");
+  const raw = fs.readFileSync(path.join(proofRoot, "events.json"), "utf8");
+  for (const probe of ["RPCID_PROBE", "RPCID_PROBE_TWO"]) {
+    assert.equal(raw.includes(probe), false, `${probe} must not reach the persisted proof`);
+  }
+  const requestTokens = events
+    .filter(
+      (event) =>
+        event.direction === "server" && event.method === "mcpServer/elicitation/request",
+    )
+    .map((event) => event.id);
+  assert.equal(requestTokens.length, 2, "control: both server requests must have been retained");
+  for (const token of requestTokens) {
+    assert.match(String(token), /^#\d+$/);
+  }
+  assert.notEqual(
+    requestTokens[0],
+    requestTokens[1],
+    "two different host ids must not collapse to one token",
+  );
+});

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -5045,3 +5045,73 @@ test("canonical Codex 0.153.1 elicitation prompt is accepted; unexpected prompt 
     "elicitation for an unpinned tool must be declined",
   );
 });
+
+test("classifyRecord rejects invalid 0.153.1 metadata types at the consumer boundary", async () => {
+  const control = await drive("valid");
+  assert.equal(allIntendedCellsPass(control.classified), true, "control must pass all cells");
+
+  const badMetadataVariants = [
+    { durationMs: "wrong" },
+    { durationMs: -1 },
+    { durationMs: 1.5 },
+    { readOnlyHint: 42 },
+    { readOnlyHint: "true" },
+    { pluginId: false },
+    { pluginId: 123 },
+    { mcpAppResourceUri: true },
+    { error: {} },
+    { error: { message: 123 } },
+    { appContext: {} },
+    { appContext: { connectorId: 123 } },
+    { durationMs: "wrong", readOnlyHint: 42, pluginId: false, error: {} },
+  ];
+
+  for (const badMeta of badMetadataVariants) {
+    const events = structuredClone(control.events);
+    const itemCompleted = events.find(
+      (e) => e.method === "item/completed" && e.params?.item?.type === "mcpToolCall",
+    );
+    assert.ok(itemCompleted);
+    Object.assign(itemCompleted.params.item, badMeta);
+
+    const terminal = events.find((e) => e.method === "turn/completed");
+    const terminalTool = terminal.params.turn.items.find(
+      (item) => item?.type === "mcpToolCall",
+    );
+    assert.ok(terminalTool);
+    Object.assign(terminalTool, badMeta);
+
+    const classified = classifyRecord({ ...control.manifest, events });
+    assert.equal(
+      allIntendedCellsPass(classified),
+      false,
+      `metadata ${JSON.stringify(badMeta)} must not produce an all-pass classification`,
+    );
+  }
+});
+
+test("mcpToolCall with non-null error fails oneToolInvoked even if status claims completed", async () => {
+  const control = await drive("valid");
+  const events = structuredClone(control.events);
+  const itemCompleted = events.find(
+    (e) => e.method === "item/completed" && e.params?.item?.type === "mcpToolCall",
+  );
+  itemCompleted.params.item.error = { message: "unexpected error" };
+
+  const terminal = events.find((e) => e.method === "turn/completed");
+  const terminalTool = terminal.params.turn.items.find(
+    (item) => item?.type === "mcpToolCall",
+  );
+  terminalTool.error = { message: "unexpected error" };
+
+  const classified = classifyRecord({ ...control.manifest, events });
+  assert.notEqual(
+    classified.cells.oneToolInvoked.status,
+    "pass",
+    "mcpToolCall with error must not pass oneToolInvoked",
+  );
+  assert.equal(
+    classified.cells.structuredResultValidated.status,
+    "unavailable",
+  );
+});

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -4867,7 +4867,7 @@ test("non-finite numbers never silently become JSON null at either boundary", ()
   assert.equal(stableStringify([0, -1.5]), '[0,-1.5]\n');
 });
 
-test("commandExecution projects to closed type and id only; sensitive fields are scrubbed", () => {
+test("commandExecution projects to closed type and id only; sensitive fields are dropped, not scrubbed", () => {
   const rawItem = OBSERVED_NON_EVIDENTIARY_ITEMS.find((item) => item.type === "commandExecution");
   assert.ok(rawItem, "fixture must contain commandExecution");
   const projected = projectRetainedEvent({
@@ -4909,7 +4909,7 @@ test("commandExecution projects to closed type and id only; sensitive fields are
   );
 });
 
-test("Codex 0.153.1 mcpToolCall schema fields project cleanly; unexpected keys and credentials fail closed", () => {
+test("Codex 0.153.1 mcpToolCall schema fields type-check; free text is recorded as presence and unexpected keys are marked", () => {
   const rawToolCall = {
     type: "mcpToolCall",
     id: "tool-1",
@@ -4950,17 +4950,17 @@ test("Codex 0.153.1 mcpToolCall schema fields project cleanly; unexpected keys a
   assert.equal(Object.hasOwn(projectedItem, "__unexpectedKeys"), false);
   assert.equal(projectedItem.durationMs, 120);
   assert.equal(projectedItem.readOnlyHint, true);
-  assert.equal(projectedItem.pluginId, "plugin-assay");
-  assert.equal(projectedItem.mcpAppResourceUri, "resource://assay");
+  assert.equal(projectedItem.pluginId, "[present]");
+  assert.equal(projectedItem.mcpAppResourceUri, "[present]");
   assert.deepEqual(projectedItem.appContext, {
-    connectorId: "connector-1",
-    linkId: "link-1",
-    resourceUri: "uri://assay-policy",
+    connectorId: "[present]",
+    linkId: "[present]",
+    resourceUri: "[present]",
   });
   assert.equal(
     projectedItem.error.message,
-    "[redacted]",
-    "credential in error message must be scrubbed",
+    "[present]",
+    "error message must record presence, not content: scrub() is a keyword regex and cannot bound arbitrary secret text",
   );
 
   const unexpectedKeyCall = structuredClone(rawToolCall);
@@ -5113,5 +5113,101 @@ test("mcpToolCall with non-null error fails oneToolInvoked even if status claims
   assert.equal(
     classified.cells.structuredResultValidated.status,
     "unavailable",
+  );
+});
+
+test("F1: retained mcpToolCall metadata records presence, never host-supplied content", () => {
+  // The producer of retained bytes must not write free-text host metadata verbatim. These fields
+  // have no evidentiary consumer: no classification cell reads their content. Retaining presence
+  // preserves every check that does exist while removing the only reason secrets can land in the
+  // proof. scrub() is a keyword regex and cannot bound arbitrary secret text, so error.message is
+  // held to the same rule rather than scrubbed.
+  const secrets = {
+    connectorId: "conn-alice@corp.example",
+    actionName: "read /Users/alice/Documents/salary.xlsx",
+    appName: "Private App",
+    linkId: "https://example.invalid/cb?access_token=eyJhbGciOi.J9.sig",
+    resourceUri: "https://example.invalid/r?bearer=eyJhbGciOi.J9.sig",
+  };
+  const projected = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 5000,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: {
+        type: "mcpToolCall",
+        id: "tool-1",
+        server: "assay",
+        tool: "assay_policy_decide",
+        status: "completed",
+        arguments: { tool: "install_surface_allowed_probe" },
+        pluginId: "/Users/alice/.config/plugins/private-plugin",
+        mcpAppResourceUri: "https://example.invalid/a?bearer=eyJhbGciOi.J9.sig",
+        appContext: secrets,
+        error: { message: "failed reading /Users/alice/Documents/salary.xlsx as alice@corp.example" },
+        result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+      },
+    },
+  });
+  const blob = JSON.stringify(projected);
+  for (const leaked of [
+    ...Object.values(secrets),
+    "/Users/alice/.config/plugins/private-plugin",
+    "https://example.invalid/a?bearer=eyJhbGciOi.J9.sig",
+    "/Users/alice/Documents/salary.xlsx",
+    "alice@corp.example",
+  ]) {
+    assert.equal(
+      blob.includes(leaked),
+      false,
+      `retained projection must not contain host-supplied content: ${leaked}`,
+    );
+  }
+  // Presence is still recorded, so the cells that count fields keep working.
+  const item = projected.params.item;
+  assert.equal(item.pluginId, "[present]");
+  assert.equal(item.mcpAppResourceUri, "[present]");
+  assert.deepEqual(item.appContext, {
+    connectorId: "[present]",
+    actionName: "[present]",
+    appName: "[present]",
+    linkId: "[present]",
+    resourceUri: "[present]",
+  });
+  assert.deepEqual(item.error, { message: "[present]" });
+});
+
+test("F2: a marked unexpected key is refused by the consumer, not merely marked", () => {
+  // Marking the key in the projection is not refusal. classifyRecord is the consumer that decides
+  // the nine cells; it must reject. Deleting the allowedKeys loop leaves the projection marking
+  // intact, so only a consumer-level assertion kills that deletion.
+  const projected = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 5000,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: {
+        type: "mcpToolCall",
+        id: "tool-1",
+        server: "assay",
+        tool: "assay_policy_decide",
+        status: "completed",
+        arguments: { tool: "install_surface_allowed_probe" },
+        unknownHostMetadata: "leak-me",
+        result: { isError: false, structuredContent: { allowed: true, reason: "ok" } },
+      },
+    },
+  });
+  assert.deepEqual(projected.params.item.__unexpectedKeys, ["unknownHostMetadata"]);
+  assert.equal(
+    classifyStoredEvent(projected).type,
+    "unclassified",
+    "an item carrying an unexpected key must be refused by the consumer",
   );
 });

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -4622,12 +4622,28 @@ const OBSERVED_NON_EVIDENTIARY_ITEMS = Object.freeze([
     delivery: "final",
     memoryCitation: null,
   }),
+  Object.freeze({
+    type: "commandExecution",
+    id: "exec_1",
+    command: "ls -la /private/tmp",
+    commandActions: [{ type: "read", path: "/private/tmp" }],
+    cwd: "/private/tmp",
+    status: "completed",
+    aggregatedOutput: "sensitive directory output",
+    durationMs: 42,
+    exitCode: 0,
+    pluginId: null,
+    processId: "1234",
+    scriptPath: null,
+    source: "agent",
+  }),
 ]);
 
 const OBSERVED_NON_EVIDENTIARY_NOTIFICATIONS = Object.freeze([
   "account/rateLimits/updated",
   "item/agentMessage/delta",
   "thread/tokenUsage/updated",
+  "serverRequest/resolved",
 ]);
 
 test("stableStringify refuses non-JSON primitives; JSON null stays a valid token", () => {
@@ -4849,4 +4865,183 @@ test("non-finite numbers never silently become JSON null at either boundary", ()
   }
   assert.equal(stableStringify({ completedAtMs: 5 }), '{"completedAtMs":5}\n');
   assert.equal(stableStringify([0, -1.5]), '[0,-1.5]\n');
+});
+
+test("commandExecution projects to closed type and id only; sensitive fields are scrubbed", () => {
+  const rawItem = OBSERVED_NON_EVIDENTIARY_ITEMS.find((item) => item.type === "commandExecution");
+  assert.ok(rawItem, "fixture must contain commandExecution");
+  const projected = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 12345,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: rawItem,
+    },
+  });
+  assert.deepEqual(projected.params.item, {
+    type: "commandExecution",
+    id: "exec_1",
+  });
+  const serialized = stableStringify(projected);
+  assert.equal(serialized.includes("sensitive directory output"), false);
+  assert.equal(serialized.includes("ls -la"), false);
+  assert.equal(serialized.includes("/private/tmp"), false);
+
+  const unprojectedRaw = {
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 12345,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: rawItem,
+    },
+  };
+  const classified = classifyStoredEvent(unprojectedRaw);
+  assert.equal(
+    classified.type,
+    "unclassified",
+    "unprojected commandExecution containing raw fields must fail closed",
+  );
+});
+
+test("Codex 0.153.1 mcpToolCall schema fields project cleanly; unexpected keys and credentials fail closed", () => {
+  const rawToolCall = {
+    type: "mcpToolCall",
+    id: "tool-1",
+    server: "assay",
+    tool: "assay_policy_decide",
+    status: "completed",
+    arguments: { tool: "install_surface_allowed_probe", policy: "install-surface-policy.yaml" },
+    durationMs: 120,
+    readOnlyHint: true,
+    pluginId: "plugin-assay",
+    mcpAppResourceUri: "resource://assay",
+    appContext: {
+      connectorId: "connector-1",
+      linkId: "link-1",
+      resourceUri: "uri://assay-policy",
+    },
+    error: {
+      message: "authorization failed for token sk-secret12345678",
+    },
+    result: {
+      isError: false,
+      structuredContent: { allowed: true, reason: "ok" },
+    },
+  };
+
+  const projected = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 5000,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: rawToolCall,
+    },
+  });
+  const projectedItem = projected.params.item;
+  assert.equal(Object.hasOwn(projectedItem, "__unexpectedKeys"), false);
+  assert.equal(projectedItem.durationMs, 120);
+  assert.equal(projectedItem.readOnlyHint, true);
+  assert.equal(projectedItem.pluginId, "plugin-assay");
+  assert.equal(projectedItem.mcpAppResourceUri, "resource://assay");
+  assert.deepEqual(projectedItem.appContext, {
+    connectorId: "connector-1",
+    linkId: "link-1",
+    resourceUri: "uri://assay-policy",
+  });
+  assert.equal(
+    projectedItem.error.message,
+    "[redacted]",
+    "credential in error message must be scrubbed",
+  );
+
+  const unexpectedKeyCall = structuredClone(rawToolCall);
+  unexpectedKeyCall.unknownHostMetadata = "unexpected";
+  const projectedWithUnexpected = projectRetainedEvent({
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 5000,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: unexpectedKeyCall,
+    },
+  });
+  assert.deepEqual(projectedWithUnexpected.params.item.__unexpectedKeys, [
+    "unknownHostMetadata",
+  ]);
+});
+
+test("failed MCP tool status fails oneToolInvoked and structuredResultValidated", async () => {
+  const control = await drive("valid");
+  const events = structuredClone(control.events);
+  const toolIndex = events.findIndex(
+    (event) => event.method === "item/completed" && event.params?.item?.type === "mcpToolCall",
+  );
+  assert.notEqual(toolIndex, -1);
+  events[toolIndex].params.item.status = "failed";
+  events[toolIndex].params.item.result = null;
+
+  const terminal = events.find((event) => event.method === "turn/completed");
+  const terminalTool = terminal.params.turn.items.find(
+    (item) => item?.type === "mcpToolCall",
+  );
+  if (terminalTool) {
+    terminalTool.status = "failed";
+    terminalTool.result = null;
+  }
+
+  const classified = classifyRecord({ ...control.manifest, events });
+  assert.equal(classified.cells.oneToolInvoked.status, "fail");
+  assert.match(classified.cells.oneToolInvoked.reason, /tool status failed/);
+  assert.equal(classified.cells.structuredResultValidated.status, "unavailable");
+});
+
+test("canonical Codex 0.153.1 elicitation prompt is accepted; unexpected prompt is declined", () => {
+  const canonical01531 = {
+    serverName: "assay",
+    threadId: "t-1",
+    turnId: "u-1",
+    mode: "form",
+    message: 'Allow the assay MCP server to run tool "assay_policy_decide"?',
+    requestedSchema: { type: "object", properties: {} },
+  };
+  assert.equal(
+    elicitationAcceptable(canonical01531, "t-1", "u-1"),
+    true,
+    "canonical 0.153.1 elicitation message must be accepted",
+  );
+
+  const syntheticLegacy = {
+    serverName: "assay",
+    threadId: "t-1",
+    turnId: "u-1",
+    mode: "form",
+    message: "approve assay_policy_decide",
+    requestedSchema: { type: "object", properties: {} },
+  };
+  assert.equal(
+    elicitationAcceptable(syntheticLegacy, "t-1", "u-1"),
+    true,
+    "legacy synthetic elicitation message must remain accepted",
+  );
+
+  const unexpectedPrompt = {
+    ...canonical01531,
+    message: 'Allow the assay MCP server to run tool "unrelated_tool"?',
+  };
+  assert.equal(
+    elicitationAcceptable(unexpectedPrompt, "t-1", "u-1"),
+    false,
+    "elicitation for an unpinned tool must be declined",
+  );
 });


### PR DESCRIPTION
**Head `aca8191430404fc60e45be00851e5edb166fbe80`**, base `181a72ec09e3797e3b3e944ee09ec58db16bbadb`.
Every measurement below was taken on this head. An independent review of this exact head
returned **READY** (record: `assay-review-records/2803/review-aca819-final.md`), with no HIGH or
MEDIUM production defects and two notes carried below.


> **Provenance correction.** Every commit on this branch records `author: Codex <codex@openai.com>`
> — that is the repository's configured git identity, not the builder. The builder is Claude, and
> each commit already carries `Co-Authored-By: Claude Opus 5`. The author field is **not** being
> rewritten: doing so changes every SHA and would invalidate the independent review bound to
> `aca8191430404fc60e45be00851e5edb166fbe80`. The correction is recorded here instead.

## What changed since the last revision, and what the previous body got wrong

An independent review of `fd96640da` found four things. **The previous body is now wrong in one
place and is corrected here: it said a marker nested under `result` is accepted. It no longer is.**

| review finding | disposition |
|---|---|
| F1 — unknown JSON-RPC method retained verbatim | **fixed** — closed-set projection |
| F2 — arbitrary string rpc id retained verbatim | **fixed** — per-run correlation token |
| F3 — unknown `item.type` retained verbatim | **fixed** — closed-set projection |
| F4 — a nested marker yielded a fully green proof | **fixed** — consumer refuses violations anywhere |
| F5 — idempotence test title over-claimed | **fixed** — narrowed to the unexpected-key marker |
| F6 — body cited a residual list that did not exist | **fixed** — the list is below |
| F7 — a third acceptance widening was undocumented | **fixed** — listed below |

## The contract, stated once and finite

An identifier is retained by **membership**, by **equality structure**, or by **presence** — never as
host-chosen text. Every field was sorted by one question answered from source: *does any consumer
read the characters, or only compare?* The derivation, including the rows measurement refuted, is in
`assay-review-records/2803/identifier-disposition.md`.

- **Membership** — `method`, `item.type`, `item.server`, `item.tool` are compared against sets this
  proof declares, so declared members pass through untouched. An unknown member becomes an **explicit
  projection violation**, not a legal-looking substitute, and the consumer refuses it wherever it
  sits. (`[unknown-method]` was itself an allowed fallback; that is gone.)
- **Equality structure** — the rpc `id` plus `threadId`, `turnId`, `item.id`, `turn.id`, `thread.id`.
  Nothing reads their characters. The wire keeps the real values; only the persisted copy is
  relabelled, by first-seen ordinal. Each role has its **own map and prefix**, so namespaces can
  never merge; fields that are one identity share a role deliberately, because the cells compare
  exactly those pairs. **Not a hash, not redaction** — no preimage, and what is retained is
  correlation structure.
- **Presence** — `platformFamily`, `platformOs`, skills-row `cwd`, `skill.scope`, and the fields
  already carried by `projectedPresence`.
- **Comparison outcome** — `thread/start.result.cwd` retains whether it matched the project root,
  with match / mismatch / absent distinguished, plus a fourth state for a raw value, which means the
  outcome was never recorded and is drift.
- **Static reasons** — no refusal reason interpolates a host value.

The projection lives at `writeProofFiles`, not at `retainEvent`, and that was forced rather than
chosen: the driver reads its own live wire identities back out of the retained array, so relabelling
earlier put tokens on the wire. At the write boundary the in-memory array stays raw for the driver
while the manifest hash, the classification and all three files derive from one projected copy.

Integers pass through unchanged. Not because they are ours — **a host may choose a numeric id too** —
but because the protocol requires numeric ids to stay valid and an integer carries no text.

## Acceptance changes in this diff

- `commandExecution` newly admitted as a retained item type (base: `unclassified`).
- `serverRequest/resolved` added to `LIFECYCLE_SERVER_NOTIFICATIONS` (9 entries → 10).
- **`EXPECTED_ELICITATION.message` → `messages`, with `===` widened to `.includes()`** (F7).
- `ALLOWED_CLIENT_REQUESTS` is added, making the driver's own five client methods explicit rather
  than implied. Not a widening: it declares what was already sent.

## Verification

`node --test scripts/ci/test_codex_host_proof.mjs` → **164 tests, 164 pass, 0 fail, 0 skipped**.

Deletion controls, each with byte-exact sha256 restoration and a green no-op control first:

| mutation | result |
|---|---|
| marker → retain the key **names** | 14 named fail |
| marker dropped entirely | 13 |
| `projectedPresence` → `return value;` | 7 |
| consumer `allowedKeys`: drop `server` | 52 |
| consumer `allowedKeys`: add `cwd` (a sampled name) | 1 |
| consumer `allowedKeys`: add `zzzUnsampledName` (**not** sampled) | **0 — survives** |
| revert `method` projection | 2 |
| revert `item.type` projection | 3 |
| remove consistent consumer refusal | 1 |
| rpc-id map removed | 2 |
| rpc-id map non-injective (all ids → one token) | 3, incl. the named injectivity test |
| rpc-id token never reused | 56 |

The `0 fail` row is the measured boundary of the sampling, not a caveat: an undeclared name that no
test samples is **not** caught.

**A defect in these tests, found by their own control and recorded rather than quietly fixed.** The
first injectivity assertion was a tautology — deduplicating a set and comparing sizes — so the
non-injective mutation was killed only *incidentally*, by two unrelated EPIPE tests. The scenario
carried one host id, and no run with one id can distinguish an injective map from a constant one. It
was replaced with a run carrying two distinct host ids, which is the only composition that
discriminates it.

## Retained by design — the explicit list

Not leaks: each is retained for a stated reason, and each was measured.

| retained | reason |
|---|---|
| `codexHome` | pushed into the host-root list and used for path containment |
| `skill.name`, `skill.path` | skill discovery matches on both — projecting either fails 35 tests |
| `item.status`, `runtimeStatus` | source compares them but enumerates no set; declaring one would invent protocol |
| declared-set members, integers, timestamps, byte counts | the proof is keyed on them |
| the project root in client **request** params (`thread/start.params.cwd`, `skills/list.cwds`) | the driver disclosing its own value, not host content |

The 13 nested content projections (`text`, `command`, `name`, `version`, …) are content rather than
identifiers and are outside this contract. They need the same question asked of them.

## Verification of this slice

Controls, each with a green no-op first and byte-exact sha256 restoration:

| mutation | result |
|---|---|
| membership rule removed | 4 |
| presence removed (`platformFamily`) | **1, named** |
| identity projection not applied | 35 |
| role namespaces merged into one map | **1, named** |
| partial turn namespace (`result.turn.id` left raw) | 54 |
| cwd outcome not recorded | 32 |
| refusal reason echoes the host cwd | **1, named** |

The three single-test kills are the targeted ones: they break equality, presence and reason-hygiene
specifically rather than washing out the suite.

**Two of my own assertions were wrong and are corrected in place, not quietly dropped.** The valid
journey deliberately touches several threads, so "one thread means one token" was over-specified;
and the project root legitimately remains in client *request* params the driver itself sent, which is
disclosure rather than a host leak. Separately, an earlier injectivity assertion was a tautology and
was replaced with a run carrying two distinct host ids — the only composition that discriminates it.

## Claims and non-claims

- **Claim:** no host-chosen identifier *text* reaches `events.json`, `classification.json` or
  `manifest.json`, at every position in the contract above, verified through the real driver on both
  the passing and the failing path.
- **Not claimed:** zero arbitrary text across legitimate results. Content positions are out of
  scope, and the retained-by-design table above is deliberate.
- **Not claimed:** that sampling establishes set equality. See the `0 fail` row.
- These tests and the code they exercise were written by the same author.
- **Carried from the independent review, unchanged:** the residual table above lists intentional
  disclosures and non-membership fields, and must not be summarized as a blanket "no host text"
  (N1). The live Codex host, auth, keychain and model were not run — synthetic coverage only
  (N2). READY is an eligible independent review artifact for this tip; CI, branch protection, the
  formal GitHub review list and merge remain separate gates, and this leaves #2684 open.

Refs #2684. Supersedes #2801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

