### PR TITLE
fix(ci): admit the app-server _meta field the live 0.153.1 host sends

### DIFF
--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -2105,15 +2105,21 @@ function projectToolResult(result) {
     }
   }
   // `isError` and `error` are retained deliberately, and NOT because this item type declares them
-  // -- it does not. They stay because a host that sends either anyway must reach the consumer's
-  // refusals rather than be silently dropped: `retainedItemReason` refuses a non-Boolean `isError`
-  // and refuses `isError === true`, and those checks can only fire on a field the projection
-  // carried through. Removing them because one host type omits them would delete live refusals to
-  // tidy a list.
+  // -- it does not. They stay so that a host sending either reaches the check written FOR it:
+  // `classifyToolResultEnvelope` (:1480-1484) refuses a non-Boolean `isError` and refuses
+  // `isError === true`, each with its own named reason, and those can only fire on a field the
+  // projection carried through.
+  //
+  // Two corrections from the independent review of this change, kept rather than quietly dropped:
+  // an earlier comment here named `retainedItemReason`, which never reads `isError` at all; and it
+  // claimed dropping these fields would "delete live refusals". It would not -- measured, the three
+  // cases are still refused, by the generic projection-violation gate, as `unclassified`. So the
+  // refusal would be RELOCATED to a coarser gate that reports a different reason, not deleted.
+  // That is still worth avoiding, but it is a weaker claim than the one first written here.
   //
   // Precise about what pins what: the existing tests named around `isError` mutate ALREADY
-  // PROJECTED events, so they pin the CONSUMER's refusal, not the producer's `"[invalid]"`
-  // conversion above. The producer-side barrier is pinned separately by the #2807 tests below.
+  // PROJECTED events, so they pin the consumer, not the producer's `"[invalid]"` conversion above.
+  // The producer-side barrier is pinned separately by the #2807 tests.
   return withUnexpectedKeys(out, result, [
     "_meta",
     "isError",

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -2110,12 +2110,21 @@ function projectToolResult(result) {
   // `isError === true`, each with its own named reason, and those can only fire on a field the
   // projection carried through.
   //
-  // Two corrections from the independent review of this change, kept rather than quietly dropped:
-  // an earlier comment here named `retainedItemReason`, which never reads `isError` at all; and it
-  // claimed dropping these fields would "delete live refusals". It would not -- measured, the three
-  // cases are still refused, by the generic projection-violation gate, as `unclassified`. So the
-  // refusal would be RELOCATED to a coarser gate that reports a different reason, not deleted.
-  // That is still worth avoiding, but it is a weaker claim than the one first written here.
+  // Three corrections from independent review, kept rather than quietly dropped. An earlier
+  // comment named `retainedItemReason`, which never reads `isError` at all. It then claimed that
+  // dropping these fields would "delete live refusals", which a second review showed is imprecise
+  // in a way that depends entirely on WHICH variant is measured -- so the variant is named here:
+  //
+  //   - drop the retention bodies AND these two allow-list entries: the three cases are still
+  //     refused, as `unclassified`, by the generic projection-violation gate. Refusal RELOCATED to
+  //     a coarser gate reporting a different reason. But a legitimate `isError: false` result is
+  //     then refused too -- which is exactly the #2807 failure class, a schema-correct record
+  //     rejected by an incomplete allow list. That is worse than "relocated", not milder.
+  //   - drop only the retention bodies, keep the allow-list entries: all three cases become clean
+  //     `server-notification`. The refusal is DELETED outright.
+  //
+  // So both readings are bad, for opposite reasons, and neither is the mild "relocation" first
+  // written here. The fields stay.
   //
   // Precise about what pins what: the existing tests named around `isError` mutate ALREADY
   // PROJECTED events, so they pin the consumer, not the producer's `"[invalid]"` conversion above.

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -2060,6 +2060,29 @@ function projectToolResult(result) {
   if (result.error != null) {
     out.error = { present: true };
   }
+  if (hasOwn(result, "_meta")) {
+    // `_meta` is a DECLARED field of the app-server item result. From the pinned host schema
+    // (openai/codex rust-v0.153.1, codex-rs/app-server-protocol/src/protocol/v2/mcp.rs):
+    //
+    //   pub struct McpToolCallResult {
+    //       pub content: Vec<JsonValue>,
+    //       pub structured_content: Option<JsonValue>,
+    //       #[serde(rename = "_meta")] pub meta: Option<JsonValue>,
+    //   }
+    //
+    // No field carries skip_serializing_if, so a live host serializes `_meta: null` rather than
+    // omitting it. Marking it unexpected refused a schema-correct record (#2807).
+    //
+    // This is NOT `CallToolResult` and NOT `McpServerToolCallResponse`: those declare `isError`
+    // and DO skip `None`. The two shapes differ in both directions, so admitting this field here
+    // says nothing about them.
+    //
+    // Its value is arbitrary host JSON with no consumer in this proof, so only PRESENCE is
+    // retained -- never a key name, never a value. `null` stays null because the schema declares
+    // it and absent must stay distinguishable from present-and-empty. Idempotent: `PRESENT` is a
+    // non-null value, so re-projecting yields `PRESENT` again.
+    out._meta = result._meta == null ? null : PRESENT;
+  }
   if (hasOwn(result, "structuredContent")) {
     out.structuredContent =
       result.structuredContent == null ? null : projectDecisionObject(result.structuredContent);
@@ -2081,7 +2104,18 @@ function projectToolResult(result) {
       });
     }
   }
+  // `isError` and `error` are retained deliberately, and NOT because this item type declares them
+  // -- it does not. They stay because a host that sends either anyway must reach the consumer's
+  // refusals rather than be silently dropped: `retainedItemReason` refuses a non-Boolean `isError`
+  // and refuses `isError === true`, and those checks can only fire on a field the projection
+  // carried through. Removing them because one host type omits them would delete live refusals to
+  // tidy a list.
+  //
+  // Precise about what pins what: the existing tests named around `isError` mutate ALREADY
+  // PROJECTED events, so they pin the CONSUMER's refusal, not the producer's `"[invalid]"`
+  // conversion above. The producer-side barrier is pinned separately by the #2807 tests below.
   return withUnexpectedKeys(out, result, [
+    "_meta",
     "isError",
     "error",
     "structuredContent",

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -2126,6 +2126,19 @@ function projectToolResult(result) {
   // So both readings are bad, for opposite reasons, and neither is the mild "relocation" first
   // written here. The fields stay.
   //
+  // F4, resolved by citation rather than by widening anything. The RESULT-level declared set is
+  // exactly three names -- `content`, `structuredContent`, `_meta` -- per `McpToolCallResult` in
+  // the pinned host schema (openai/codex rust-v0.153.1,
+  // codex-rs/app-server-protocol/src/protocol/v2/mcp.rs). The list below therefore carries two
+  // names BEYOND the schema, `isError` and `error`, deliberately and for the reason above.
+  //
+  // The gap an independent review proved by execution: unlike the item level, nothing here pins
+  // the list against WIDENING -- adding an undeclared name such as `telemetryBlob` survives the
+  // whole suite. That is the class that allowed #2807 in the first direction (too narrow) and is
+  // still open in the other (too wide). It is recorded here and deferred to its own slice; adding
+  // an enumeration test inside a comment-only repair would be the scope creep this note exists to
+  // avoid.
+  //
   // Precise about what pins what: the existing tests named around `isError` mutate ALREADY
   // PROJECTED events, so they pin the consumer, not the producer's `"[invalid]"` conversion above.
   // The producer-side barrier is pinned separately by the #2807 tests.

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -6207,3 +6207,157 @@ test("D: the project-root comparison is retained, and its outcome is not the pat
   assert.equal(cells.cwdObserved.status, "fail", "required/false must stay distinguished from missing");
   assert.match(cells.cwdObserved.reason, /not the project root/);
 });
+
+// --- #2807: the live 0.153.1 item result carries `_meta`, and it is schema-declared -----------
+// Measured against the pinned host schema
+// (openai/codex rust-v0.153.1, codex-rs/app-server-protocol/src/protocol/v2/mcp.rs):
+//
+//   pub struct McpToolCallResult {
+//       pub content: Vec<JsonValue>,
+//       pub structured_content: Option<JsonValue>,
+//       #[serde(rename = "_meta")] pub meta: Option<JsonValue>,
+//   }
+//
+// No field carries skip_serializing_if, so `structuredContent: null` AND `_meta: null` are both
+// always serialized. This is NOT CallToolResult and NOT McpServerToolCallResponse -- those declare
+// isError and DO skip None. The projection was missing `_meta`, so a schema-correct live record was
+// marked unexpected and the consumer refused it. The refusal was correct behaviour on an incomplete
+// allowed-field list, not a host fault.
+const LIVE_0153_RESULT = Object.freeze({
+  content: [{ type: "text", text: JSON.stringify({ allowed: true, reason: "Allowed by policy" }) }],
+  structuredContent: null,
+  _meta: null,
+});
+
+function liveToolEvent(result) {
+  return {
+    direction: "server",
+    method: "item/completed",
+    id: null,
+    params: {
+      completedAtMs: 5000,
+      threadId: "t-1",
+      turnId: "u-1",
+      item: {
+        type: "mcpToolCall",
+        id: "tool-1",
+        server: "assay",
+        tool: "assay_policy_decide",
+        status: "completed",
+        arguments: { tool: "install_surface_allowed_probe" },
+        result,
+      },
+    },
+  };
+}
+
+test("#2807: a schema-shaped 0.153.1 result with _meta:null is accepted, not marked unexpected", () => {
+  const projected = projectRetainedEvent(liveToolEvent(LIVE_0153_RESULT));
+  assert.equal(
+    Object.hasOwn(projected.params.item.result, "__unexpectedKeys"),
+    false,
+    "_meta is a declared field of McpToolCallResult and must not be marked unexpected",
+  );
+  assert.equal(
+    classifyStoredEvent(projected).type,
+    "server-notification",
+    "the live host record must be accepted by the consumer",
+  );
+});
+
+test("#2807: _meta is retained as presence only, never as metadata content", () => {
+  const projected = projectRetainedEvent(
+    liveToolEvent({
+      ...LIVE_0153_RESULT,
+      _meta: { traceId: "/Users/alice/.ssh/id_rsa?tok=META_SECRET_CANARY", depth: 3 },
+    }),
+  );
+  const raw = JSON.stringify(projected);
+  assert.equal(raw.includes("META_SECRET_CANARY"), false, "a metadata value must not be retained");
+  assert.equal(raw.includes("traceId"), false, "a metadata key NAME must not be retained either");
+  assert.equal(
+    projected.params.item.result._meta,
+    "[present]",
+    "a non-null _meta is recorded as presence",
+  );
+});
+
+test("#2807: null and present _meta stay distinguishable, and absent stays absent", () => {
+  const withNull = projectRetainedEvent(liveToolEvent(LIVE_0153_RESULT)).params.item.result;
+  const withValue = projectRetainedEvent(
+    liveToolEvent({ ...LIVE_0153_RESULT, _meta: { a: 1 } }),
+  ).params.item.result;
+  const { _meta, ...withoutMeta } = LIVE_0153_RESULT;
+  const absent = projectRetainedEvent(liveToolEvent(withoutMeta)).params.item.result;
+  assert.equal(withNull._meta, null, "a declared null must stay null, not become presence");
+  assert.equal(withValue._meta, "[present]");
+  assert.equal(Object.hasOwn(absent, "_meta"), false, "an absent field must stay absent");
+});
+
+test("#2807: admitting _meta does not admit an undeclared sibling", () => {
+  const projected = projectRetainedEvent(
+    liveToolEvent({ ...LIVE_0153_RESULT, hostExtension: { anything: 1 } }),
+  );
+  assert.equal(
+    projected.params.item.result.__unexpectedKeys,
+    "[present]",
+    "an undeclared sibling must still be marked",
+  );
+  assert.equal(
+    classifyStoredEvent(projected).type,
+    "unclassified",
+    "and the consumer must still refuse it -- this is not a blanket unknown-key allowance",
+  );
+});
+
+test("#2807: the live shape stays a re-projection fixed point", () => {
+  const once = projectRetainedEvent(liveToolEvent(LIVE_0153_RESULT));
+  assert.deepEqual(projectRetainedEvent(once), once);
+});
+
+test("#2807: admitting _meta still carries error and isError to the consumer", () => {
+  // LAYER, stated because I first asserted the wrong one: `classifyStoredEvent` judges event
+  // SHAPE, and it accepts these -- the refusal for `isError: true` and for a non-Boolean lives in
+  // `classifyToolResultEnvelope`, reached through `classifyRecord` as a cell judgement, and the
+  // existing driven tests pin it there. What THIS layer can establish, and what the retention of
+  // these fields is actually for, is that the projection carries them through at all: a field the
+  // producer dropped could never reach the check that refuses it.
+  const withIsError = projectRetainedEvent(
+    liveToolEvent({ ...LIVE_0153_RESULT, isError: true }),
+  ).params.item.result;
+  assert.equal(withIsError.isError, true, "isError must survive projection to reach its refusal");
+  assert.equal(
+    Object.hasOwn(withIsError, "__unexpectedKeys"),
+    false,
+    "isError is an allowed field, not an unexpected one",
+  );
+
+  const withError = projectRetainedEvent(
+    liveToolEvent({ ...LIVE_0153_RESULT, error: { message: "tool exploded" } }),
+  ).params.item.result;
+  assert.deepEqual(withError.error, { present: true }, "error survives as presence, not content");
+  assert.equal(
+    JSON.stringify(withError).includes("tool exploded"),
+    false,
+    "an error message must not be retained",
+  );
+});
+
+test("#2807: the producer's isError type barrier is the deciding check for a non-Boolean", () => {
+  // Pins the PRODUCER. Deleting the `typeof === "boolean"` conversion in projectToolResult
+  // previously changed nothing observable, because the consumer refuses a non-Boolean
+  // independently -- the same shape as the F-B durationMs/readOnlyHint gap. Asserting the
+  // projected bytes makes the barrier the deciding check.
+  assert.equal(
+    projectRetainedEvent(liveToolEvent({ ...LIVE_0153_RESULT, isError: "true" })).params.item.result
+      .isError,
+    "[invalid]",
+    "a non-Boolean isError must be converted by the producer, not carried verbatim",
+  );
+  // Control: a real Boolean must survive unchanged, or the conversion is a blanket rewrite.
+  assert.equal(
+    projectRetainedEvent(liveToolEvent({ ...LIVE_0153_RESULT, isError: false })).params.item.result
+      .isError,
+    false,
+  );
+});

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -6310,9 +6310,25 @@ test("#2807: admitting _meta does not admit an undeclared sibling", () => {
   );
 });
 
-test("#2807: the live shape stays a re-projection fixed point", () => {
-  const once = projectRetainedEvent(liveToolEvent(LIVE_0153_RESULT));
-  assert.deepEqual(projectRetainedEvent(once), once);
+test("#2807: both _meta branches stay re-projection fixed points", () => {
+  // The first version of this test used `_meta: null` only, so it never re-projected the PRESENT
+  // branch whose idempotence its own comment asserted -- a non-idempotent non-null branch survived
+  // it at 171/171. Both branches are exercised, because the null branch cannot discriminate the
+  // one that matters.
+  for (const [label, result] of [
+    ["null _meta", LIVE_0153_RESULT],
+    ["present _meta", { ...LIVE_0153_RESULT, _meta: { traceId: "x", nested: { deep: [1, 2] } } }],
+  ]) {
+    const once = projectRetainedEvent(liveToolEvent(result));
+    assert.deepEqual(projectRetainedEvent(once), once, `${label} must be a fixed point`);
+  }
+  // Control: the present branch must actually have reached PRESENT, or the loop above proved
+  // nothing about it.
+  assert.equal(
+    projectRetainedEvent(liveToolEvent({ ...LIVE_0153_RESULT, _meta: { a: 1 } })).params.item.result
+      ._meta,
+    "[present]",
+  );
 });
 
 test("#2807: admitting _meta still carries error and isError to the consumer", () => {


### PR DESCRIPTION
**Current head `5bd8af6b0f69c063d9fe9d00b6815990f93bd1f8`**, base `37e1a62e465dcc4b71d9cea7a4742ce2d068dd13`.
Two changed files, +232 / -0. Ready for review; current-head CI remains required before merge.

Independent final-head review at `986feb8fc590879326520c722c67993174afb11f` is revalidated solely for this upstream-only advance: [both AGENTS.md equivalence checks](https://github.com/Rul1an/assay/pull/2808#issuecomment-5552026626), [current machine record](https://github.com/Rul1an/assay/pull/2808#issuecomment-5552026715). Predicted and actual whole-tree hash `2996b873a574f44fbc82b00a49b154a546dd0a01`; reviewed-file/main-advance intersection empty. This is not a new reviewer execution.

The independent reviewer actually ran 171/171 Node tests on the reviewed pre-advance head, with no skips, including the non-null metadata fixed-point and privacy probes. Nonblocking wording/sampling notes are dispositioned in #2810. Any earlier writer test counts below describe initial `687ccf78e7f42d9478444e6834acdbb048453bdd`, not an additional test run on this head. No live host pass is claimed; leaves #2684 open.

> **Builder provenance.** Every commit records `author: Codex <codex@openai.com>` — the repository's
> configured git identity, not the builder. **The builder is Claude**, and the commit carries
> `Co-Authored-By: Claude Opus 5`. The author field is deliberately not rewritten: that would change
> the SHA and invalidate the review bound to this head.

## What happened

A live Codex 0.153.1 tool journey recorded a well-formed item result and the driver exited 1. The
retained record carried the `__unexpectedKeys` marker and the consumer refused it.

**The refusal was correct.** It is #2803's F4 check — refuse a projection violation wherever it sits
— meeting a real host for the first time and finding that *our* allowed-field list was incomplete.
It is not a host fault and not a regression.

## Why `_meta`, and how that was established

**This is a source-derived explanation, not a reading of the capture.** The original sanitized
capture did **not** retain unknown-key names — that is exactly the privacy property #2803 added — so
the failing field could not be identified from the proof bytes. It was identified by reading the
pinned host schema.

From `openai/codex` `rust-v0.153.1`, `codex-rs/app-server-protocol/src/protocol/v2/mcp.rs`:

```rust
pub struct McpToolCallResult {
    pub content: Vec<JsonValue>,
    pub structured_content: Option<JsonValue>,
    #[serde(rename = "_meta")] pub meta: Option<JsonValue>,
}
```

No field carries `skip_serializing_if`, so a live host serializes **both** `structuredContent: null`
and `_meta: null` rather than omitting them — which matches the observed capture shape.

This type is **not** `CallToolResult` and **not** `McpServerToolCallResponse`. Those declare
`isError` *and* skip `None`, so the two shapes differ in both directions; admitting a field here
says nothing about them.

## The repair

`_meta` is admitted **explicitly**, never blanket-allowed:

- absent stays absent;
- `null` stays `null`, because the schema declares it and absent must remain distinguishable from
  present-and-empty;
- any non-null value becomes **presence only** — no metadata key name and no metadata value is
  retained;
- idempotent, since the presence marker is itself non-null.

An undeclared sibling is still marked and still refused. There is no global unknown-key allowance.

`isError` and `error` are **kept**, and the reason was checked rather than assumed: existing refusal
tests depend on them, and a field the producer drops can never reach the check that refuses it.

**A correction inside this change.** A comment first claimed those tests pin the *producer's* type
barrier. They do not — they mutate already-projected events, so they pin the **consumer**. A control
deleting the producer's `typeof` check killed nothing until a test was added for it, the same shape
as the earlier F-B `durationMs`/`readOnlyHint` gap. The comment is corrected and the barrier is now
pinned separately.

Two of the new tests also first asserted at the wrong layer: `classifyStoredEvent` judges event
*shape* and accepts these, while the `isError` refusal is a **cell** judgement in
`classifyToolResultEnvelope` reached through `classifyRecord`. They now assert what each layer
actually decides.

## Verification

`node --test scripts/ci/test_codex_host_proof.mjs` → **171 tests, 171 pass, 0 fail, 0 skipped**
(164 → 171).

Must-bite controls, green no-op first, byte-exact sha256 restoration after each:

| Mutation | Result |
|---|---|
| remove the new `_meta` allowance | **2 fail** |
| retain the `_meta` value verbatim | **2 fail** |
| collapse `null` into presence | **1 fail** |
| globally ignore unknown keys | **3 fail** |
| drop the producer's `isError` type check | **1 fail** |
| no-op control | **0 fail** (required) |

## Claims and non-claims

- **No live-rerun PASS yet.** This change has not been validated by a fresh real tool journey. The
  measured evidence here is the focused synthetic suite plus the source schema; a live rerun on a
  fresh immutable kit is still required before any host-proof cell may be called `pass`.
- The failing field name was derived from the pinned schema, **not** recovered from the capture —
  the capture deliberately does not retain it.
- Retained failed-run packs are untouched and are not relabelled.
- Nothing here is a claim about `CallToolResult` or `McpServerToolCallResponse`.
- These tests and the code they exercise were written by the same author; an independent review of
  this exact head is running.

Refs #2807. **Leaves #2684 open** — its full DoD is not met by this change, and it must not be
auto-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

