### PR TITLE
fix(ci): preserve extractor failures without SIGPIPE

### DIFF
--- a/scripts/ci/test-cargo-plugin-versions-contract.sh
+++ b/scripts/ci/test-cargo-plugin-versions-contract.sh
@@ -75,7 +75,7 @@ install_cargo_audit_run() {
   local job
   # Materialize first: under pipefail, producer|early-exit-awk SIGPIPEs when the job
   # body continues after the Install step (#2809). Do not weaken pipefail.
-  job="$(deps_security_job "${wf}")"
+  job="$(deps_security_job "${wf}")" || return $?
   awk '
     function emit_active(line,    tmp) {
       tmp = line
@@ -577,6 +577,41 @@ if ( check_review_helper_cargo_deny "${deny_mut}" ) >/dev/null 2>&1; then
 fi
 ok "reverting review helper to cargo deny turns the contract red"
 
+
+
+echo "== helper: missing workflow must refuse with producer status (#2809) =="
+# Same if/command-substitution context as the coordinator discriminator. Not a full-gate claim.
+missing_rc=0
+if missing_out="$(install_cargo_audit_run /nonexistent-assay-workflow-2809.yml)"; then
+  fail "missing workflow left install_cargo_audit_run green (output=<${missing_out}>)"
+else
+  missing_rc=$?
+fi
+[[ "${missing_rc}" -eq 2 ]] \
+  || fail "missing workflow expected awk producer rc 2, got ${missing_rc}"
+ok "missing workflow refuses (rc ${missing_rc})"
+
+echo "== helper: failing deps_security_job status must propagate (#2809) =="
+failing_rc="$(
+  deps_security_job() { return 7; }
+  set +e
+  install_cargo_audit_run "${WORKFLOW}" >/dev/null
+  printf '%s' "$?"
+)"
+[[ "${failing_rc}" -eq 7 ]] \
+  || fail "failing deps_security_job expected rc 7, got ${failing_rc}"
+# Discriminator shape: if out="$(helper)"; then ... (errexit does not save you)
+disc_rc=0
+if disc_out="$(
+  deps_security_job() { return 7; }
+  install_cargo_audit_run "${WORKFLOW}"
+)"; then
+  fail "failing producer left install_cargo_audit_run green under if/command-substitution (output=<${disc_out}>)"
+else
+  disc_rc=$?
+fi
+[[ "${disc_rc}" -eq 7 ]]   || fail "failing producer under if/command-substitution expected rc 7, got ${disc_rc}"
+ok "failing deps_security_job status propagates (rc 7)"
 
 echo "== regression: large-tail job body must not SIGPIPE install extractor (#2809) =="
 # ~7 MiB after the *next* step name so the early-exit consumer closes while the job

--- a/scripts/ci/test-cargo-plugin-versions-contract.sh
+++ b/scripts/ci/test-cargo-plugin-versions-contract.sh
@@ -72,7 +72,11 @@ deps_security_job() {
 # source / --version / assert (#2317 review 4914059003). No shell comment parser.
 install_cargo_audit_run() {
   local wf="$1"
-  deps_security_job "${wf}" | awk '
+  local job
+  # Materialize first: under pipefail, producer|early-exit-awk SIGPIPEs when the job
+  # body continues after the Install step (#2809). Do not weaken pipefail.
+  job="$(deps_security_job "${wf}")"
+  awk '
     function emit_active(line,    tmp) {
       tmp = line
       sub(/^[[:space:]]+/, "", tmp)
@@ -90,7 +94,7 @@ install_cargo_audit_run() {
     }
     in_run && /^        [^[:space:]]/ { exit }
     in_run { emit_active($0) }
-  '
+  ' <<<"${job}"
 }
 
 # Complete active command lines only (optional leading/trailing blank). Trailing `# ghosts`
@@ -186,8 +190,9 @@ check_workflow "${WORKFLOW}"
 check_review_helper_cargo_deny "${REVIEW_HELPER}"
 ok "review helper uses direct cargo-deny"
 # Hook section: id line then files: must include the review script stem.
-grep -A8 '^[[:space:]]*- id:[[:space:]]*cargo-plugin-versions-contract-self-test[[:space:]]*$' "${PRECOMMIT}" \
-  | grep -qE '^[[:space:]]*files:.*review-dependency-perf-hygiene-pr4' \
+# Capture first: under pipefail, grep -A | grep -q can SIGPIPE on match (#2809).
+hook_snip="$(grep -A8 '^[[:space:]]*- id:[[:space:]]*cargo-plugin-versions-contract-self-test[[:space:]]*$' "${PRECOMMIT}")"
+grep -qE '^[[:space:]]*files:.*review-dependency-perf-hygiene-pr4' <<<"${hook_snip}" \
   || fail "cargo-plugin-versions-contract-self-test files: must watch review-dependency-perf-hygiene-pr4.sh"
 ok "D1 pre-commit hook watches the review helper"
 
@@ -571,6 +576,69 @@ if ( check_review_helper_cargo_deny "${deny_mut}" ) >/dev/null 2>&1; then
   fail "reverting review helper to cargo deny left the contract green"
 fi
 ok "reverting review helper to cargo deny turns the contract red"
+
+
+echo "== regression: large-tail job body must not SIGPIPE install extractor (#2809) =="
+# ~7 MiB after the *next* step name so the early-exit consumer closes while the job
+# producer would still be writing. Synthetic discriminator for the pipefail/SIGPIPE
+# mechanism — not a hosted-scheduler replay; hosted attribution stays inference.
+large_tail="$(mktemp "${SANDBOX_ROOT}/large-tail.XXXXXX.yml")"
+python3 - "${large_tail}" <<'PY'
+import pathlib, sys
+
+dst = pathlib.Path(sys.argv[1])
+pad = ("          # pad " + ("x" * 120) + "\n") * 55000
+body = (
+    "name: t\n"
+    "on: push\n"
+    "jobs:\n"
+    "  deps-security:\n"
+    "    runs-on: ubuntu-latest\n"
+    "    steps:\n"
+    "      - name: Install cargo-audit\n"
+    "        run: |\n"
+    '          source ./scripts/ci/cargo-plugin-versions.sh\n'
+    '          cargo install --locked --version "${CARGO_AUDIT_VERSION}" cargo-audit\n'
+    '          assert_cargo_plugin_version cargo-audit "${CARGO_AUDIT_VERSION}"\n'
+    "      - name: Later step\n"
+    "        run: |\n"
+    "          echo later\n"
+    + pad
+    + "  other:\n"
+    "    runs-on: ubuntu-latest\n"
+    "    steps:\n"
+    "      - run: true\n"
+)
+dst.write_text(body)
+if dst.stat().st_size < 6_000_000:
+    raise SystemExit(f"large-tail fixture too small: {dst.stat().st_size}")
+PY
+large_rc=0
+large_run="$(install_cargo_audit_run "${large_tail}")" || large_rc=$?
+[[ "${large_rc}" -eq 0 ]] \
+  || fail "large-tail install extractor aborted (exit ${large_rc}); producer|early-exit-awk under pipefail"
+active_source_line "${large_run}" \
+  || fail "large-tail lost the source line:
+${large_run}"
+active_pinned_install_line "${large_run}" \
+  || fail "large-tail lost the pinned install line:
+${large_run}"
+active_assert_line "${large_run}" \
+  || fail "large-tail lost the assert line:
+${large_run}"
+[[ "$(count_active_cargo_installs "${large_run}")" -eq 1 ]] \
+  || fail "large-tail expected one active cargo install; got:
+${large_run}"
+ok "large-tail install extraction survives (~7MiB post-step)"
+
+echo "== no-op: live workflow install extraction unchanged (#2809) =="
+noop_rc=0
+noop_run="$(install_cargo_audit_run "${WORKFLOW}")" || noop_rc=$?
+[[ "${noop_rc}" -eq 0 ]] || fail "noop install extractor aborted (exit ${noop_rc})"
+active_source_line "${noop_run}" || fail "noop lost the source line"
+active_pinned_install_line "${noop_run}" || fail "noop lost the pinned install line"
+active_assert_line "${noop_run}" || fail "noop lost the assert line"
+ok "noop: live workflow install extraction unchanged"
 
 ok "cargo-plugin-versions contract mutations bite"
 echo "PASS: cargo-plugin-versions contract"

--- a/scripts/ci/test-cargo-plugin-versions-contract.sh
+++ b/scripts/ci/test-cargo-plugin-versions-contract.sh
@@ -191,7 +191,8 @@ check_review_helper_cargo_deny "${REVIEW_HELPER}"
 ok "review helper uses direct cargo-deny"
 # Hook section: id line then files: must include the review script stem.
 # Capture first: under pipefail, grep -A | grep -q can SIGPIPE on match (#2809).
-hook_snip="$(grep -A8 '^[[:space:]]*- id:[[:space:]]*cargo-plugin-versions-contract-self-test[[:space:]]*$' "${PRECOMMIT}")"
+hook_snip="$(grep -A8 '^[[:space:]]*- id:[[:space:]]*cargo-plugin-versions-contract-self-test[[:space:]]*$' "${PRECOMMIT}")" \
+  || fail "cargo-plugin-versions-contract-self-test hook definition missing from ${PRECOMMIT#"${ROOT}"/}"
 grep -qE '^[[:space:]]*files:.*review-dependency-perf-hygiene-pr4' <<<"${hook_snip}" \
   || fail "cargo-plugin-versions-contract-self-test files: must watch review-dependency-perf-hygiene-pr4.sh"
 ok "D1 pre-commit hook watches the review helper"
@@ -578,7 +579,6 @@ fi
 ok "reverting review helper to cargo deny turns the contract red"
 
 
-
 echo "== helper: missing workflow must refuse with producer status (#2809) =="
 # Same if/command-substitution context as the coordinator discriminator. Not a full-gate claim.
 missing_rc=0
@@ -664,16 +664,18 @@ ${large_run}"
 [[ "$(count_active_cargo_installs "${large_run}")" -eq 1 ]] \
   || fail "large-tail expected one active cargo install; got:
 ${large_run}"
-ok "large-tail install extraction survives (~7MiB post-step)"
+! grep -qE '^[[:space:]]*echo[[:space:]]+later' <<<"${large_run}" \
+  || fail "large-tail install extractor leaked subsequent step into run block"
+ok "large-tail install extraction survives (~7MiB post-step) without step leakage"
 
-echo "== no-op: live workflow install extraction unchanged (#2809) =="
-noop_rc=0
-noop_run="$(install_cargo_audit_run "${WORKFLOW}")" || noop_rc=$?
-[[ "${noop_rc}" -eq 0 ]] || fail "noop install extractor aborted (exit ${noop_rc})"
-active_source_line "${noop_run}" || fail "noop lost the source line"
-active_pinned_install_line "${noop_run}" || fail "noop lost the pinned install line"
-active_assert_line "${noop_run}" || fail "noop lost the assert line"
-ok "noop: live workflow install extraction unchanged"
+echo "== baseline re-check: live workflow extraction unchanged (#2809) =="
+baseline_rc=0
+baseline_run="$(install_cargo_audit_run "${WORKFLOW}")" || baseline_rc=$?
+[[ "${baseline_rc}" -eq 0 ]] || fail "baseline install extractor aborted (exit ${baseline_rc})"
+active_source_line "${baseline_run}" || fail "baseline lost the source line"
+active_pinned_install_line "${baseline_run}" || fail "baseline lost the pinned install line"
+active_assert_line "${baseline_run}" || fail "baseline lost the assert line"
+ok "baseline re-check: live workflow extraction unchanged"
 
 ok "cargo-plugin-versions contract mutations bite"
 echo "PASS: cargo-plugin-versions contract"

--- a/scripts/ci/test-split-wave-plugin-versions-contract.sh
+++ b/scripts/ci/test-split-wave-plugin-versions-contract.sh
@@ -99,7 +99,7 @@ install_step_run() {
   local job
   # Materialize first: under pipefail, producer|early-exit-awk SIGPIPEs when the job
   # body continues after the named Install step (#2809). Do not weaken pipefail.
-  job="$("${job_fn}" "${wf}")"
+  job="$("${job_fn}" "${wf}")" || return $?
   awk -v step="${step_name}" '
     function emit_active(line,    tmp) {
       tmp = line
@@ -843,6 +843,36 @@ expect_stale_install_comment_red nobind "Install cargo-nextest and cargo-hack" <
       # is step-scoped for the install, while ordinary workspace cargo follows rust-toolchain.toml.
 EOF
 
+
+
+echo "== helper: missing workflow must refuse with producer status (#2809) =="
+missing_rc=0
+if missing_out="$(install_step_run /nonexistent-assay-workflow-2809.yml "Install cargo-nextest and cargo-hack" feature_matrix_job)"; then
+  fail "missing workflow left install_step_run green (output=<${missing_out}>)"
+else
+  missing_rc=$?
+fi
+[[ "${missing_rc}" -eq 2 ]] \
+  || fail "missing workflow expected awk producer rc 2, got ${missing_rc}"
+ok "missing workflow refuses (rc ${missing_rc})"
+
+echo "== helper: failing job producer status must propagate (#2809) =="
+failing_feature_matrix_job() { return 7; }
+failing_rc="$(
+  set +e
+  install_step_run "${WORKFLOW}" "Install cargo-nextest and cargo-hack" failing_feature_matrix_job >/dev/null
+  printf '%s' "$?"
+)"
+[[ "${failing_rc}" -eq 7 ]] \
+  || fail "failing job producer expected rc 7, got ${failing_rc}"
+disc_rc=0
+if disc_out="$(install_step_run "${WORKFLOW}" "Install cargo-nextest and cargo-hack" failing_feature_matrix_job)"; then
+  fail "failing producer left install_step_run green under if/command-substitution (output=<${disc_out}>)"
+else
+  disc_rc=$?
+fi
+[[ "${disc_rc}" -eq 7 ]]   || fail "failing producer under if/command-substitution expected rc 7, got ${disc_rc}"
+ok "failing job producer status propagates (rc 7)"
 
 echo "== regression: large-tail job body must not SIGPIPE install extractor (#2809) =="
 # Same producer|early-exit-awk discriminator as the cargo-plugin contract; feature-matrix

--- a/scripts/ci/test-split-wave-plugin-versions-contract.sh
+++ b/scripts/ci/test-split-wave-plugin-versions-contract.sh
@@ -844,7 +844,6 @@ expect_stale_install_comment_red nobind "Install cargo-nextest and cargo-hack" <
 EOF
 
 
-
 echo "== helper: missing workflow must refuse with producer status (#2809) =="
 missing_rc=0
 if missing_out="$(install_step_run /nonexistent-assay-workflow-2809.yml "Install cargo-nextest and cargo-hack" feature_matrix_job)"; then
@@ -923,16 +922,18 @@ ${large_run}"
 active_pinned_hack_install "${large_run}" \
   || fail "large-tail lost the pinned hack install:
 ${large_run}"
-ok "large-tail install extraction survives (~7MiB post-step)"
+! grep -qE '^[[:space:]]*echo[[:space:]]+later' <<<"${large_run}" \
+  || fail "large-tail install extractor leaked subsequent step into run block"
+ok "large-tail install extraction survives (~7MiB post-step) without step leakage"
 
-echo "== no-op: live workflow install extraction unchanged (#2809) =="
-noop_rc=0
-noop_run="$(install_step_run "${WORKFLOW}" "Install cargo-nextest and cargo-hack" feature_matrix_job)" || noop_rc=$?
-[[ "${noop_rc}" -eq 0 ]] || fail "noop install extractor aborted (exit ${noop_rc})"
-active_source_line "${noop_run}" || fail "noop lost the source line"
-active_pinned_nextest_install "${noop_run}" || fail "noop lost the pinned nextest install"
-active_pinned_hack_install "${noop_run}" || fail "noop lost the pinned hack install"
-ok "noop: live workflow install extraction unchanged"
+echo "== baseline re-check: live workflow extraction unchanged (#2809) =="
+baseline_rc=0
+baseline_run="$(install_step_run "${WORKFLOW}" "Install cargo-nextest and cargo-hack" feature_matrix_job)" || baseline_rc=$?
+[[ "${baseline_rc}" -eq 0 ]] || fail "baseline install extractor aborted (exit ${baseline_rc})"
+active_source_line "${baseline_run}" || fail "baseline lost the source line"
+active_pinned_nextest_install "${baseline_run}" || fail "baseline lost the pinned nextest install"
+active_pinned_hack_install "${baseline_run}" || fail "baseline lost the pinned hack install"
+ok "baseline re-check: live workflow extraction unchanged"
 
 ok "split-wave plugin-versions contract mutations bite"
 echo "PASS: split-wave plugin-versions contract"

--- a/scripts/ci/test-split-wave-plugin-versions-contract.sh
+++ b/scripts/ci/test-split-wave-plugin-versions-contract.sh
@@ -96,7 +96,11 @@ semver_public_job() {
 install_step_run() {
   local wf="$1" step_name="$2"
   local job_fn="$3"
-  "${job_fn}" "${wf}" | awk -v step="${step_name}" '
+  local job
+  # Materialize first: under pipefail, producer|early-exit-awk SIGPIPEs when the job
+  # body continues after the named Install step (#2809). Do not weaken pipefail.
+  job="$("${job_fn}" "${wf}")"
+  awk -v step="${step_name}" '
     function emit_active(line,    tmp) {
       tmp = line
       sub(/^[[:space:]]+/, "", tmp)
@@ -113,7 +117,7 @@ install_step_run() {
     }
     in_run && /^        [^[:space:]]/ { exit }
     in_run { emit_active($0) }
-  '
+  ' <<<"${job}"
 }
 
 active_source_line() {
@@ -838,6 +842,67 @@ expect_stale_install_comment_red nobind "Install cargo-nextest and cargo-hack" <
       # Pins live in scripts/ci/cargo-plugin-versions.sh (#2224 / CI-4D2). RUSTUP_TOOLCHAIN
       # is step-scoped for the install, while ordinary workspace cargo follows rust-toolchain.toml.
 EOF
+
+
+echo "== regression: large-tail job body must not SIGPIPE install extractor (#2809) =="
+# Same producer|early-exit-awk discriminator as the cargo-plugin contract; feature-matrix
+# job + nextest/hack install step. Synthetic only — hosted attribution stays inference.
+large_tail="$(mktemp "${SANDBOX_ROOT}/large-tail.XXXXXX.yml")"
+python3 - "${large_tail}" <<'PY'
+import pathlib, sys
+
+dst = pathlib.Path(sys.argv[1])
+pad = ("          # pad " + ("x" * 120) + "\n") * 55000
+body = (
+    "name: t\n"
+    "on: push\n"
+    "jobs:\n"
+    "  feature-matrix:\n"
+    "    runs-on: ubuntu-latest\n"
+    "    steps:\n"
+    "      - name: Install cargo-nextest and cargo-hack\n"
+    "        run: |\n"
+    '          source ./scripts/ci/cargo-plugin-versions.sh\n'
+    '          cargo install --locked --version "${CARGO_NEXTEST_VERSION}" cargo-nextest\n'
+    '          cargo install --locked --version "${CARGO_HACK_VERSION}" cargo-hack\n'
+    '          assert_cargo_plugin_version cargo-nextest "${CARGO_NEXTEST_VERSION}"\n'
+    '          assert_cargo_plugin_version cargo-hack "${CARGO_HACK_VERSION}"\n'
+    "      - name: Later step\n"
+    "        run: |\n"
+    "          echo later\n"
+    + pad
+    + "  other:\n"
+    "    runs-on: ubuntu-latest\n"
+    "    steps:\n"
+    "      - run: true\n"
+)
+dst.write_text(body)
+if dst.stat().st_size < 6_000_000:
+    raise SystemExit(f"large-tail fixture too small: {dst.stat().st_size}")
+PY
+large_rc=0
+large_run="$(install_step_run "${large_tail}" "Install cargo-nextest and cargo-hack" feature_matrix_job)" || large_rc=$?
+[[ "${large_rc}" -eq 0 ]] \
+  || fail "large-tail install extractor aborted (exit ${large_rc}); producer|early-exit-awk under pipefail"
+active_source_line "${large_run}" \
+  || fail "large-tail lost the source line:
+${large_run}"
+active_pinned_nextest_install "${large_run}" \
+  || fail "large-tail lost the pinned nextest install:
+${large_run}"
+active_pinned_hack_install "${large_run}" \
+  || fail "large-tail lost the pinned hack install:
+${large_run}"
+ok "large-tail install extraction survives (~7MiB post-step)"
+
+echo "== no-op: live workflow install extraction unchanged (#2809) =="
+noop_rc=0
+noop_run="$(install_step_run "${WORKFLOW}" "Install cargo-nextest and cargo-hack" feature_matrix_job)" || noop_rc=$?
+[[ "${noop_rc}" -eq 0 ]] || fail "noop install extractor aborted (exit ${noop_rc})"
+active_source_line "${noop_run}" || fail "noop lost the source line"
+active_pinned_nextest_install "${noop_run}" || fail "noop lost the pinned nextest install"
+active_pinned_hack_install "${noop_run}" || fail "noop lost the pinned hack install"
+ok "noop: live workflow install extraction unchanged"
 
 ok "split-wave plugin-versions contract mutations bite"
 echo "PASS: split-wave plugin-versions contract"


### PR DESCRIPTION
## Summary

- Materialize workflow job output before the early-exiting awk extractor; preserve pipefail and explicitly propagate producer failure.
- Exercise both contract scripts against a large trailing step, missing inputs/failing producers, step containment, and explicit missing-hook diagnostics.
- Label ordinary re-extraction as a baseline re-check, not a mutation control.

Fixes #2809. Leaves #2808 open.

## Scope / provenance

Writer Ruley; branch `ruley/2809-contract-sigpipe`; exact head `5148eacde8fd2edef1bfa2ac324ed9d1369c159e`; base `c88efe93d551c6fe7cd0ff940df127d6ac6c54b3`.
Only `scripts/ci/test-cargo-plugin-versions-contract.sh` and `scripts/ci/test-split-wave-plugin-versions-contract.sh` change. No product or workflow change.

Writer worktree: `/Users/roelschuurkes/assay/.ruley/worktrees/2809-contract-sigpipe`. Both focused contract suites and normal hooks passed, per writer execution. Normal push completed and Codex independently verified the remote head after the writer connection dropped. No push bypass or duplicate push.

## Independent verification

Antigravity independently reviewed the full base-to-head diff, authored neither this change nor its governing brief, and returned READY at the exact head. Its scratch execution used macOS Bash 3.2.57 and ran both contract suites with exit 0. Restoring the old producer/early-exit pipeline gave 141 on the synthetic large-tail case; missing input and failing producer preserved rc2/rc7; bypassed step termination and absent hook produced named failures. Full SHA-bound review is posted separately as a review artifact.

## Non-claims

Synthetic large-tail execution demonstrates the failure mechanism; it does not replay the historical hosted scheduler. No claim of a product failure or completed Codex host proof. Hosted CI on this PR still required before merge.
