### PR TITLE
refactor(ci): share terminal items-view validation rule

### DIFF
--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -655,6 +655,16 @@ export const ALLOWED_TURN_ITEMS_VIEWS = Object.freeze([
   "summary",
   "notLoaded",
 ]);
+
+export function turnItemsViewReason(view) {
+  if (
+    view !== undefined &&
+    (!isNonemptyString(view) || !ALLOWED_TURN_ITEMS_VIEWS.includes(view))
+  ) {
+    return "turn/completed itemsView must be full, summary, or notLoaded";
+  }
+  return null;
+}
 // A JSON-RPC method name is host-controlled text on every server-originated frame. Retaining an
 // unrecognised one verbatim puts host content in the proof, so only names this proof already
 // declares are kept; anything else becomes one constant. Known names must stay verbatim because
@@ -933,11 +943,9 @@ function retainedMethodParamsReason(method, params) {
       ) {
         return "turn/completed turn must have typed id, items, and status";
       }
-      if (
-        turn.itemsView !== undefined &&
-        (!isNonemptyString(turn.itemsView) || !ALLOWED_TURN_ITEMS_VIEWS.includes(turn.itemsView))
-      ) {
-        return "turn/completed itemsView must be full, summary, or notLoaded";
+      const viewReason = turnItemsViewReason(turn.itemsView);
+      if (viewReason) {
+        return viewReason;
       }
       for (const item of turn.items) {
         const itemReason = retainedItemReason(item, "turn/completed");
@@ -1754,11 +1762,9 @@ function classifyInvocation(calls, expected, threadId, turnId, topology) {
 
   const terminalTurn = terminal.params?.turn;
   const itemsView = terminalTurn?.itemsView;
-  if (
-    itemsView !== undefined &&
-    (!isNonemptyString(itemsView) || !ALLOWED_TURN_ITEMS_VIEWS.includes(itemsView))
-  ) {
-    return cell("fail", "turn/completed itemsView must be full, summary, or notLoaded");
+  const viewReason = turnItemsViewReason(itemsView);
+  if (viewReason) {
+    return cell("fail", viewReason);
   }
 
   const rawTerminalItems = Array.isArray(terminalTurn?.items) ? terminalTurn.items : null;

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -49,6 +49,20 @@ const FAKE = path.join(HERE, "fixtures/codex-host-proof/fake-app-server.mjs");
 const DRIVER_SRC = fs.readFileSync(path.join(HERE, "codex_host_proof.mjs"), "utf8");
 const VALIDATOR_SRC = fs.readFileSync(path.join(HERE, "codex_host_proof_validator.mjs"), "utf8");
 
+test("#2813: shared itemsView validation preserves the closed vocabulary and legacy absence", async () => {
+  const { turnItemsViewReason } = await import("./codex_host_proof_validator.mjs");
+  assert.equal(typeof turnItemsViewReason, "function");
+  for (const view of [undefined, "full", "summary", "notLoaded"]) {
+    assert.equal(turnItemsViewReason(view), null);
+  }
+  for (const view of [null, "", "partial", "Full", 0, false, [], {}, "PRIVATE_CANARY"]) {
+    assert.equal(
+      turnItemsViewReason(view),
+      "turn/completed itemsView must be full, summary, or notLoaded",
+    );
+  }
+});
+
 function scratch() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "assay-2684-"));
 }

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -27,6 +27,7 @@ import {
   HOST_SUBJECTS,
   KNOWN_ITEM_TYPES,
   KNOWN_METHODS,
+  classifyCells,
   classifyRecord,
   classifyStoredEvent,
   consumeJourneyTopology,
@@ -61,6 +62,31 @@ test("#2813: shared itemsView validation preserves the closed vocabulary and leg
       "turn/completed itemsView must be full, summary, or notLoaded",
     );
   }
+});
+
+test("#2813: invocation classification refuses an unknown itemsView in resolved topology", async () => {
+  const control = await drive("valid");
+  const topology = structuredClone(
+    consumeJourneyTopology(control.events, control.manifest.journey),
+  );
+  assert.equal(topology.ok, true);
+  const terminal = topology.notifications.find(
+    (event) => event.method === "turn/completed" && event.direction === "server",
+  );
+  assert.ok(terminal, "resolved topology must contain the canonical terminal");
+  terminal.params.turn.itemsView = "unknown_view";
+
+  const cells = classifyCells(
+    control.events,
+    control.manifest,
+    control.manifest.expected,
+    control.manifest.journey,
+    topology,
+  );
+  assert.deepEqual(cells.oneToolInvoked, {
+    status: "fail",
+    reason: "turn/completed itemsView must be full, summary, or notLoaded",
+  });
 });
 
 function scratch() {


### PR DESCRIPTION
## Purpose

Helper repair for draft PR #2813 after exact-head review found that deleting the invocation consumer of the shared closed-set `itemsView` rule left the full allowed Node suite green.

Parent head: `71fc605070389524cf47815e981ae87a59b159f5`
Helper head: `e332ca3eef2b97272f66328f0fe188ed8fed79bd`

## Scope

- extract one `turnItemsViewReason` function;
- call it from retained-event validation and invocation classification;
- preserve the full / summary / notLoaded / legacy-absent behavior and the value-free refusal string;
- pin the helper's accepted/refused values;
- behaviorally backstop the invocation consumer through `classifyCells` using an otherwise canonical, pre-resolved topology carrying an unknown `itemsView`.

Two changed files only. Leaves #2812 open and leaves #2684 open.

## Verification

- Pristine allowed suite: `node --test scripts/ci/test_codex_host_proof.mjs` -> 186 tests, 186 pass, 0 fail, 0 skipped, exit 0, 42918.190583 ms.
- Mutation: in an isolated copy, delete only the invocation block beginning `turnItemsViewReason(itemsView)`; the retained-event consumer and test oracle remain unchanged.
- Bounded full mutation run: 180-second process-tree timeout -> completed normally in 48394.237834 ms, exit 1, 186 tests, 185 pass, 1 fail, 0 skipped. The sole failure is the new invocation backstop: mutated `oneToolInvoked` returned `pass` instead of the constant closed-set refusal.
- Bounded focused mutation run: 20-second process-tree timeout -> completed normally in 531.563 ms, exit 1, 1 fail and 185 name-filter skips; the new invocation backstop is the failing test.
- A prior unbounded mutant run completed in 530238.742958 ms under severe host disk/swap contention. It is preserved but classified timeout/inconclusive, not as mutation evidence.
- `node --check scripts/ci/test_codex_host_proof.mjs` passed.
- `node --check scripts/ci/codex_host_proof_validator.mjs` passed.
- `git diff --check` passed.
- Normal commit hooks and normal push hooks passed, including the Codex host-proof Node contract, `cargo fmt --check`, workspace clippy with denied warnings, and the Linux cross-target gate.

## Non-claims

No live Codex host proof, authentication, model call, Docker run, or new user journey. The previously retained failed capture remains failed. The mutation uses synthetic fixture data and proves only that the invocation consumer deletion is caught. This draft is a handoff into #2813, not final release proof or merge readiness. The prior review is stale on this new head; a fresh independent exact-head review is required.
