### PR TITLE
conformance: bind registry authorship to report trailers

### DIFF
--- a/conformance/implementations.py
+++ b/conformance/implementations.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import re
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent / "adequacy"))
@@ -27,8 +28,6 @@ REPRODUCTION_MODES = frozenset((
     "commissioned_clean_room",
     "other_disclosed",
 ))
-AUTHORSHIP_KINDS = frozenset(("human", "agent-assisted", "agent-generated"))
-AGENT_KINDS = frozenset(("agent-assisted", "agent-generated"))
 HUMAN_AUTHORSHIP_FIELDS = ("kind",)
 AGENT_AUTHORSHIP_FIELDS = ("kind", "model", "prompt_strategy")
 SOURCE_PATTERN = r"^https?://[^/?#\s]+(?:[/?#][^\s]*)?$"
@@ -49,6 +48,23 @@ ID_RE = re.compile(r"\A[a-z][a-z0-9]*(?:-[a-z0-9]+)*\Z")
 IMAGE_RE = re.compile(IMAGE_PATTERN)
 COMMIT_RE = re.compile(r"\A[0-9a-f]{40}\Z")
 SOURCE_RE = re.compile(SOURCE_PATTERN)
+
+
+class AuthorshipRule(NamedTuple):
+    trailer: str
+    fields: tuple[str, ...]
+    value_field: str | None
+
+
+AUTHORSHIP_RULES = {
+    "human": AuthorshipRule("Authored-By", HUMAN_AUTHORSHIP_FIELDS, None),
+    "agent-assisted": AuthorshipRule("Assisted-By", AGENT_AUTHORSHIP_FIELDS, "model"),
+    "agent-generated": AuthorshipRule("Generated-By", AGENT_AUTHORSHIP_FIELDS, "model"),
+}
+AUTHORSHIP_KINDS = frozenset(AUTHORSHIP_RULES)
+AGENT_KINDS = frozenset(
+    kind for kind, rule in AUTHORSHIP_RULES.items() if rule.value_field == "model"
+)
 
 
 class ImplementationRegistryError(Exception):
@@ -94,21 +110,75 @@ def _require_text(value: object, field: str, ident: str) -> str:
     return value
 
 
+def _authorship_rule(kind: object, ident: str = "authorship") -> AuthorshipRule:
+    try:
+        return AUTHORSHIP_RULES[kind]
+    except (KeyError, TypeError) as exc:
+        raise ImplementationRegistryError(
+            "%s: unknown authorship kind %r" % (ident, kind)
+        ) from exc
+
+
 def _validate_authorship(value: object, ident: str) -> dict:
     if not isinstance(value, dict):
         raise ImplementationRegistryError("%s: authorship must be an object" % ident)
     kind = value.get("kind")
-    if kind == "human":
-        _reject_unknown_fields(value, HUMAN_AUTHORSHIP_FIELDS, what="%s authorship" % ident)
-        return value
-    if kind in AGENT_KINDS:
-        _reject_unknown_fields(
-            value, AGENT_AUTHORSHIP_FIELDS, what="%s authorship" % ident
+    rule = _authorship_rule(kind, ident)
+    _reject_unknown_fields(value, rule.fields, what="%s authorship" % ident)
+    for field in rule.fields:
+        if field != "kind":
+            _require_text(value[field], field, ident)
+    return value
+
+
+def authorship_trailer(value: object) -> str:
+    """Project canonical registry authorship to its documentary trailer."""
+    authorship = _validate_authorship(value, "authorship")
+    kind = authorship["kind"]
+    rule = _authorship_rule(kind)
+    trailer_value = kind if rule.value_field is None else authorship[rule.value_field]
+    return "%s: %s" % (rule.trailer, trailer_value)
+
+
+def _documentary_trailer(kind: str, rule: AuthorshipRule) -> str:
+    value = kind if rule.value_field is None else "<model disclosure>"
+    return "%s: %s" % (rule.trailer, value)
+
+
+def authorship_protocol_table() -> str:
+    """Render the protocol fragment checked against the canonical mapping."""
+    rows = ["| Registry kind | Documentary trailer |", "|---|---|"]
+    rows.extend(
+        "| `%s` | `%s` |" % (kind, _documentary_trailer(kind, rule))
+        for kind, rule in AUTHORSHIP_RULES.items()
+    )
+    return "\n".join(rows)
+
+
+def authorship_template_line() -> str:
+    """Render the report-template line checked against the canonical mapping."""
+    choices = " | ".join(
+        "%s -> %s" % (kind, _documentary_trailer(kind, rule))
+        for kind, rule in AUTHORSHIP_RULES.items()
+    )
+    return "- Authorship method: `%s`" % choices
+
+
+def _authorship_schema(kind: str, rule: AuthorshipRule) -> dict:
+    properties = {"kind": {"const": kind}}
+    for field in rule.fields:
+        if field != "kind":
+            properties[field] = {"type": "string", "minLength": 1}
+    if rule.value_field is not None:
+        properties[rule.value_field]["description"] = (
+            "Exact opaque disclosure string; no model or version normalization."
         )
-        _require_text(value.get("model"), "model", ident)
-        _require_text(value.get("prompt_strategy"), "prompt_strategy", ident)
-        return value
-    raise ImplementationRegistryError("%s: unknown authorship kind %r" % (ident, kind))
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": list(rule.fields),
+        "properties": properties,
+    }
 
 
 def _validate_row(row: object, seen: set[str]) -> dict:
@@ -185,22 +255,8 @@ def implementation_schema() -> dict:
                         "reproduction_mode": {"enum": sorted(REPRODUCTION_MODES)},
                         "authorship": {
                             "oneOf": [
-                                {
-                                    "type": "object",
-                                    "additionalProperties": False,
-                                    "required": list(HUMAN_AUTHORSHIP_FIELDS),
-                                    "properties": {"kind": {"const": "human"}},
-                                },
-                                {
-                                    "type": "object",
-                                    "additionalProperties": False,
-                                    "required": list(AGENT_AUTHORSHIP_FIELDS),
-                                    "properties": {
-                                        "kind": {"enum": sorted(AGENT_KINDS)},
-                                        "model": {"type": "string", "minLength": 1},
-                                        "prompt_strategy": {"type": "string", "minLength": 1},
-                                    },
-                                },
+                                _authorship_schema(kind, rule)
+                                for kind, rule in AUTHORSHIP_RULES.items()
                             ]
                         },
                     },

--- a/conformance/implementations.schema.json
+++ b/conformance/implementations.schema.json
@@ -89,14 +89,35 @@
                 ],
                 "properties": {
                   "kind": {
-                    "enum": [
-                      "agent-assisted",
-                      "agent-generated"
-                    ]
+                    "const": "agent-assisted"
                   },
                   "model": {
                     "type": "string",
+                    "minLength": 1,
+                    "description": "Exact opaque disclosure string; no model or version normalization."
+                  },
+                  "prompt_strategy": {
+                    "type": "string",
                     "minLength": 1
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "kind",
+                  "model",
+                  "prompt_strategy"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "agent-generated"
+                  },
+                  "model": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Exact opaque disclosure string; no model or version normalization."
                   },
                   "prompt_strategy": {
                     "type": "string",

--- a/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
+++ b/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
@@ -66,20 +66,21 @@ verify it.
 A second provenance axis, orthogonal to the mode above. The mode says what was read and when; this
 says what wrote it. Both are self-declared, neither is a score, and the scorer cannot verify either.
 
-The labels are not ours. They are the trailers open source projects already converged on, so a
-contributor does not learn a private vocabulary to report here:
+The registry `authorship` object is canonical. These documentary trailers are a one-way projection
+from its `kind`; they do not replace the structured registry disclosure:
 
-| Label | Meaning |
+| Registry kind | Documentary trailer |
 |---|---|
-| `Authored-By: human` | No generative assistance in the implementation. |
-| `Assisted-By: <system> <version>` | A human directed the work and used a generative system for part of it. |
-| `Generated-By: <system> <version>` | The implementation was produced end to end by a generative system from the profile text. |
+| `human` | `Authored-By: human` |
+| `agent-assisted` | `Assisted-By: <model disclosure>` |
+| `agent-generated` | `Generated-By: <model disclosure>` |
 
 `Assisted-By:` and `Generated-By:` sit at two points on an autonomy spectrum; Apache originated the
 generated form and OpenInfra added the assisted one and made disclosure mandatory. Where assistance
-was used, the report states the system and version, which parts of the implementation it produced,
-and how the output was checked. That is the shape IEEE asks for, plus the verification note that
-recent policy guidance adds, and it is the part a reader actually needs.
+was used, `model` is copied as an exact opaque disclosure string: the projection does not infer,
+invent, or normalize a model or version. Produced-parts and checking-method details remain in the
+report. That is the shape IEEE asks for, plus the verification note that recent policy guidance adds,
+and it is the part a reader actually needs.
 
 ### Why this axis exists here
 

--- a/conformance/privileged-mcp-action-v0/IMPLEMENTATION-REPORT.template.md
+++ b/conformance/privileged-mcp-action-v0/IMPLEMENTATION-REPORT.template.md
@@ -18,7 +18,7 @@
 - Materials first read after the implementation was frozen:
 - Prior relationship to the profile authors:
 - Funding or compensation, including whether payment depended on the result:
-- Authorship method: `Authored-By: human | Assisted-By: <system> <version> | Generated-By: <system> <version>`
+- Authorship method: `human -> Authored-By: human | agent-assisted -> Assisted-By: <model disclosure> | agent-generated -> Generated-By: <model disclosure>`
 - If assisted or generated: which parts of the implementation, and how the output was checked:
 
 ## Pinned inputs

--- a/conformance/tests/test_implementations.py
+++ b/conformance/tests/test_implementations.py
@@ -50,6 +50,16 @@ ASSISTED_AUTHORSHIP = {
     "model": "claude-opus",
     "prompt_strategy": "spec-then-conformance",
 }
+GENERATED_AUTHORSHIP = {
+    "kind": "agent-generated",
+    "model": "generator/model-v1+BUILD.7",
+    "prompt_strategy": "profile-only",
+}
+PROTOCOL = REPO / "conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md"
+REPORT_TEMPLATE = (
+    REPO
+    / "conformance/privileged-mcp-action-v0/IMPLEMENTATION-REPORT.template.md"
+)
 
 
 def _scope_job(text: str) -> str:
@@ -198,6 +208,27 @@ class PositiveFixtureAndHostileMatrix(unittest.TestCase):
             ) as ctx:
                 self.module.load_implementations(path)
             self.assertIn("authorship", str(ctx.exception).lower())
+
+    def test_all_agent_kinds_require_current_structured_metadata(self):
+        for kind in ("agent-assisted", "agent-generated"):
+            complete = {
+                "kind": kind,
+                "model": "opaque/model-v1+BUILD.7",
+                "prompt_strategy": "spec-first",
+            }
+            path = self._write(_doc([_valid_row(id=kind, authorship=complete)]))
+            loaded = self.module.load_implementations(path)
+            self.assertEqual(loaded["implementations"][0]["authorship"], complete)
+            for field in ("model", "prompt_strategy"):
+                incomplete = dict(complete)
+                del incomplete[field]
+                path = self._write(
+                    _doc([_valid_row(id="%s-no-%s" % (kind, field), authorship=incomplete)])
+                )
+                with self.subTest(kind=kind, field=field), self.assertRaises(
+                    self.module.ImplementationRegistryError
+                ):
+                    self.module.load_implementations(path)
 
     def test_whitespace_in_source_url_is_rejected(self):
         path = self._write(_doc([_valid_row(source="https://exa mple.com/a")]))
@@ -464,20 +495,165 @@ class OneRuleNoNetwork(unittest.TestCase):
         self.assertEqual(frozenset(modes), frozenset(module.REPRODUCTION_MODES))
         authorship = items["properties"]["authorship"]
         branches = authorship["oneOf"]
-        self.assertEqual(len(branches), 2)
-        human = next(branch for branch in branches if branch["properties"]["kind"].get("const") == "human")
-        agent = next(branch for branch in branches if "enum" in branch["properties"]["kind"])
-        self.assertIs(human["additionalProperties"], False)
-        self.assertEqual(frozenset(human["required"]), frozenset(module.HUMAN_AUTHORSHIP_FIELDS))
-        self.assertEqual(frozenset(human["properties"]), frozenset(module.HUMAN_AUTHORSHIP_FIELDS))
-        self.assertNotIn("model", human["properties"])
-        self.assertNotIn("prompt_strategy", human["properties"])
-        self.assertIs(agent["additionalProperties"], False)
-        self.assertEqual(frozenset(agent["required"]), frozenset(module.AGENT_AUTHORSHIP_FIELDS))
-        self.assertEqual(frozenset(agent["properties"]), frozenset(module.AGENT_AUTHORSHIP_FIELDS))
-        self.assertEqual(frozenset(agent["properties"]["kind"]["enum"]), frozenset(module.AGENT_KINDS))
+        self.assertEqual(len(branches), len(module.AUTHORSHIP_RULES))
+        for branch, (kind, rule) in zip(branches, module.AUTHORSHIP_RULES.items()):
+            self.assertIs(branch["additionalProperties"], False)
+            self.assertEqual(branch["properties"]["kind"], {"const": kind})
+            self.assertEqual(frozenset(branch["required"]), frozenset(rule.fields))
+            self.assertEqual(frozenset(branch["properties"]), frozenset(rule.fields))
         self.assertEqual(items["properties"]["source"]["pattern"], module.SOURCE_PATTERN)
         self.assertEqual(items["properties"]["image"]["pattern"], module.IMAGE_PATTERN)
+
+
+class AuthorshipProjectionContract(unittest.TestCase):
+    EXPECTED_TRAILERS = {
+        "human": "Authored-By",
+        "agent-assisted": "Assisted-By",
+        "agent-generated": "Generated-By",
+    }
+
+    def setUp(self) -> None:
+        self.module = _require_module()
+
+    def _assert_unknown_is_rejected(self) -> None:
+        with self.assertRaises(self.module.ImplementationRegistryError):
+            self.module.authorship_trailer({"kind": "unknown"})
+
+    def _assert_document_parity(self, protocol: str, template: str) -> None:
+        self.assertEqual(protocol.count(self.module.authorship_protocol_table()), 1)
+        self.assertEqual(template.count(self.module.authorship_template_line()), 1)
+
+    def test_mapping_is_exact_and_exhaustive(self) -> None:
+        self.assertEqual(
+            {kind: rule.trailer for kind, rule in self.module.AUTHORSHIP_RULES.items()},
+            self.EXPECTED_TRAILERS,
+        )
+
+    def test_projection_is_exact_and_model_is_opaque(self) -> None:
+        self.assertEqual(
+            self.module.authorship_trailer(HUMAN_AUTHORSHIP),
+            "Authored-By: human",
+        )
+        cases = (
+            (ASSISTED_AUTHORSHIP, "Assisted-By: claude-opus"),
+            (GENERATED_AUTHORSHIP, "Generated-By: generator/model-v1+BUILD.7"),
+            (
+                {
+                    "kind": "agent-assisted",
+                    "model": "  Grok Bot/version? undisclosed  ",
+                    "prompt_strategy": "compatibility probe",
+                },
+                "Assisted-By:   Grok Bot/version? undisclosed  ",
+            ),
+        )
+        for authorship, expected in cases:
+            with self.subTest(kind=authorship["kind"], model=authorship["model"]):
+                self.assertEqual(self.module.authorship_trailer(authorship), expected)
+
+    def test_unknown_kind_has_no_fallback(self) -> None:
+        self._assert_unknown_is_rejected()
+
+    def test_schema_has_one_exact_branch_per_mapping_member(self) -> None:
+        branches = self.module.implementation_schema()["properties"]["implementations"][
+            "items"
+        ]["properties"]["authorship"]["oneOf"]
+        self.assertEqual(len(branches), len(self.module.AUTHORSHIP_RULES))
+        self.assertEqual(
+            [branch["properties"]["kind"]["const"] for branch in branches],
+            list(self.module.AUTHORSHIP_RULES),
+        )
+
+    def test_protocol_and_template_match_the_runtime_projection(self) -> None:
+        self._assert_document_parity(
+            PROTOCOL.read_text(encoding="utf-8"),
+            REPORT_TEMPLATE.read_text(encoding="utf-8"),
+        )
+
+    def test_mapping_mutations_break_document_parity(self) -> None:
+        protocol = PROTOCOL.read_text(encoding="utf-8")
+        template = REPORT_TEMPLATE.read_text(encoding="utf-8")
+        original = self.module.AUTHORSHIP_RULES
+        mutations = {}
+
+        deleted = dict(original)
+        del deleted["agent-generated"]
+        mutations["deleted"] = deleted
+
+        renamed = dict(original)
+        renamed["agent-created"] = renamed.pop("agent-generated")
+        mutations["renamed"] = renamed
+
+        swapped = dict(original)
+        assisted = swapped["agent-assisted"]
+        generated = swapped["agent-generated"]
+        swapped["agent-assisted"] = assisted._replace(trailer=generated.trailer)
+        swapped["agent-generated"] = generated._replace(trailer=assisted.trailer)
+        mutations["swapped"] = swapped
+
+        for name, mutation in mutations.items():
+            with self.subTest(mutation=name), mock.patch.object(
+                self.module, "AUTHORSHIP_RULES", mutation
+            ), self.assertRaises(AssertionError):
+                self._assert_document_parity(protocol, template)
+
+    def test_unknown_fallback_mutation_is_caught(self) -> None:
+        human_rule = self.module.AUTHORSHIP_RULES["human"]
+        with mock.patch.object(
+            self.module, "_authorship_rule", return_value=human_rule
+        ), self.assertRaises(AssertionError):
+            self._assert_unknown_is_rejected()
+
+    def test_missing_agent_metadata_mutation_is_caught(self) -> None:
+        original = self.module.AUTHORSHIP_RULES
+        mutation = dict(original)
+        mutation["agent-assisted"] = mutation["agent-assisted"]._replace(
+            fields=("kind",), value_field=None
+        )
+        with mock.patch.object(self.module, "AUTHORSHIP_RULES", mutation):
+            with self.assertRaises(AssertionError):
+                with self.assertRaises(self.module.ImplementationRegistryError):
+                    self.module._validate_authorship(
+                        {"kind": "agent-assisted"}, "missing-agent-metadata"
+                    )
+
+    def test_agent_only_metadata_on_human_mutation_is_caught(self) -> None:
+        original = self.module.AUTHORSHIP_RULES
+        mutation = dict(original)
+        mutation["human"] = mutation["human"]._replace(
+            fields=("kind", "model", "prompt_strategy"), value_field="model"
+        )
+        value = {
+            "kind": "human",
+            "model": "should-not-be-accepted",
+            "prompt_strategy": "should-not-be-accepted",
+        }
+        with mock.patch.object(self.module, "AUTHORSHIP_RULES", mutation):
+            with self.assertRaises(AssertionError):
+                with self.assertRaises(self.module.ImplementationRegistryError):
+                    self.module._validate_authorship(value, "human-agent-fields")
+
+    def test_model_normalization_mutation_is_caught(self) -> None:
+        original = self.module.authorship_trailer
+
+        def normalized(value: object) -> str:
+            return original(value).strip().lower()
+
+        value = {
+            "kind": "agent-assisted",
+            "model": "  Grok Bot/version? undisclosed  ",
+            "prompt_strategy": "compatibility probe",
+        }
+        with mock.patch.object(self.module, "authorship_trailer", normalized):
+            with self.assertRaises(AssertionError):
+                self.assertEqual(
+                    self.module.authorship_trailer(value),
+                    "Assisted-By:   Grok Bot/version? undisclosed  ",
+                )
+
+    def test_comment_only_control_stays_green(self) -> None:
+        protocol = PROTOCOL.read_text(encoding="utf-8") + "\n<!-- control comment -->\n"
+        template = REPORT_TEMPLATE.read_text(encoding="utf-8")
+        self._assert_document_parity(protocol, template)
 
 
 class PublicImageValidator(unittest.TestCase):

--- a/conformance/tests/test_pma_v0_registration.py
+++ b/conformance/tests/test_pma_v0_registration.py
@@ -83,6 +83,7 @@ class CheckedInRow(unittest.TestCase):
         auth = row["authorship"]
         self.assertEqual(auth["kind"], "agent-assisted")
         self.assertEqual(auth["model"], MODEL)
+        self.assertEqual(implementations.authorship_trailer(auth), "Assisted-By: Grok Bot")
         strategy = auth["prompt_strategy"]
         self.assertIn(FREEZE_COMMIT, strategy)
         self.assertIn("other_disclosed", strategy)

--- a/conformance/tests/test_pma_v0_registration.py
+++ b/conformance/tests/test_pma_v0_registration.py
@@ -14,6 +14,7 @@ import re
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "conformance"))
@@ -98,6 +99,47 @@ class CheckedInRow(unittest.TestCase):
             "certified conformant",
         ):
             self.assertNotIn(forbidden, blob)
+
+
+class RegistrationConsumerProjectsAuthorship(unittest.TestCase):
+    """Behavioral guard: the checked-in row must call authorship_trailer.
+
+    Line 86 is the only checked-in registry consumer of authorship_trailer for
+    the Grok row. Mapping-suite coverage alone stays green if that call is
+    deleted; this test runs the real consumer under a wrapped projector.
+    """
+
+    EXPECTED_TRAILER = "Assisted-By: Grok Bot"
+
+    def _run_checked_in_row(self) -> None:
+        CheckedInRow("test_row_pins_measured_facts").test_row_pins_measured_facts()
+
+    def test_checked_in_row_invokes_projector_with_grok_authorship(self) -> None:
+        calls: list[tuple[object, str]] = []
+        original = implementations.authorship_trailer
+
+        def wrapped(auth: object) -> str:
+            result = original(auth)
+            calls.append((auth, result))
+            return result
+
+        with mock.patch.object(implementations, "authorship_trailer", wrapped):
+            self._run_checked_in_row()
+
+        self.assertEqual(len(calls), 1, "checked-in row must invoke authorship_trailer once")
+        auth, result = calls[0]
+        self.assertIsInstance(auth, dict)
+        self.assertEqual(auth["kind"], "agent-assisted")
+        self.assertEqual(auth["model"], MODEL)
+        self.assertEqual(result, self.EXPECTED_TRAILER)
+
+    def test_wrong_projected_trailer_fails_checked_in_row(self) -> None:
+        def wrong(_auth: object) -> str:
+            return "Assisted-By: not-the-checked-in-grok-row"
+
+        with mock.patch.object(implementations, "authorship_trailer", wrong):
+            with self.assertRaises(AssertionError):
+                self._run_checked_in_row()
 
 
 class RequiredCi(unittest.TestCase):


### PR DESCRIPTION
## Upstream Advance (Current Head)

Current integration head `d30b59baa0b8644dd6f0cf5715a9728c703e49dc` merges main `76463e12bb45e63d392e84704b0b723f930bee5f` into the reviewed head below. Whole-tree merge equivalence is `c1428c894fd4044d68fcece9ba4631727d6e2c76`; none of the six reviewed paths changed. Review is carried by the two recorded AGENTS checks, not claimed as a new review. Hosted CI reruns on this integration head.

## Original Review Target

Head `87a1f32d21a0da58d9c30187517db018000e3f49`; true merge-base `4e4a3b4e880536a2dace44263f71268c23169c79`. On this head, `/usr/bin/python3 -W error::ResourceWarning`: `test_implementations.py` 48 passed and `test_pma_v0_registration.py` 4 passed, in `/Users/roelschuurkes/wt-codex-2818-authorship-vocabulary`. Historical results below are explicitly labelled. The projector has test callers, not a production trailer emitter. Leaves #2818 open for Slice B.

## Description

Part of #2818. This is Slice A only.

- Makes conformance/implementations.py own one exhaustive registry-authorship to documentary-trailer rule for human, agent-assisted, and agent-generated.
- Derives runtime validation and the checked-in JSON Schema from that rule.
- Checks CONFORMANCE-PROTOCOL.md and IMPLEMENTATION-REPORT.template.md against renderers derived from the same rule.
- Rejects incomplete agent metadata and agent-only fields on human authorship.
- Projects model byte-for-byte as an opaque disclosure string; the current Grok Bot row remains Assisted-By: Grok Bot.

### Base and head

- Authored parent: 4e4a3b4e880536a2dace44263f71268c23169c79
- Reviewed head: 87a1f32d21a0da58d9c30187517db018000e3f49
- Worktree: /Users/roelschuurkes/wt-codex-2818-authorship-vocabulary
- Branch: codex/2818-authorship-vocabulary
- Current main when opened: b9c8ac6ebbbe88adc46cb66629fb29dc8542735a
- 4e4a3b4e..b9c8ac6e changes only:
  - scripts/ci/codex_host_proof_validator.mjs
  - scripts/ci/fixtures/codex-host-proof/fake-app-server.mjs
  - scripts/ci/test_codex_host_proof.mjs
- Intersection with this PR's six changed paths: empty. No rebase or merge was performed.

### RED first

Before production edits:

- python3 -W error::ResourceWarning conformance/tests/test_implementations.py
  - RED: 48 tests run, 11 errors because the mapping/projection/parity API did not exist.
- python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py
  - RED: 2 tests run, 1 error because the Grok compatibility projection did not exist.

### Mutation matrix

Retained tests demonstrate that these mutations fail:

- deleted mapping member;
- renamed mapping member;
- swapped assisted/generated trailers;
- unknown-kind fallback;
- missing agent metadata;
- agent-only metadata accepted on human;
- model/version normalization.

A comment-only protocol control remains green.

## Historical Verification (ac6b5f4)

Measured on committed SHA ac6b5f425620b968d349b4152129aa509d02bd5e in /Users/roelschuurkes/wt-codex-2818-authorship-vocabulary with /usr/bin/python3:

- [x] python3 -W error::ResourceWarning conformance/tests/test_implementations.py - 48 passed.
- [x] python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py - 2 passed.
- [x] python3 conformance/implementations.py
- [x] python3 -m json.tool conformance/implementations.schema.json
- [x] Runtime/schema parity check.
- [x] git diff-tree --check HEAD^ HEAD
- [ ] cargo check - not part of the focused Slice A verification.
- [ ] cargo test - not part of the focused Slice A verification.
- [ ] Demo suite - not applicable.

The repository commit/push hooks passed. They automatically ran their configured formatting, clippy, and cross-target compile checks; these are hook observations, not substituted for the focused evidence above.

## Non-claims and deferred scope

This change normalizes self-declared disclosure syntax and prevents runtime/schema/document drift. It does not authenticate authorship, prove model or version provenance, prove independence, measure quality, create a trust score, or verify provider outcomes.

Slice B remains open in #2818: this PR does not change OCI capture, capture schema, run-record validation/schema, legacy run handling, or public-run projection.

## Type of Change

- [x] New feature
- [x] Documentation update
- [ ] Breaking change
- [ ] Refactor
- [ ] Bug fix

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.


## Current-head repair and verification (2026-09-06)

Current head: `87a1f32d21a0da58d9c30187517db018000e3f49`. The `ac6b5f4` results above are historical. Ruley's bounded helper adds the checked-in registration-test regression guard (not a production runtime consumer) in `conformance/tests/test_pma_v0_registration.py`; Codex integrated it by fast-forward, without editing the other Ruley worktree.

Re-measured by Codex on this exact HEAD in `/Users/roelschuurkes/wt-codex-2818-authorship-vocabulary` with `/usr/bin/python3`: `test_implementations.py` 48 passed; `test_pma_v0_registration.py` 4 passed; `git diff --check` clean and tracked worktree clean. These focused suites do not substitute for independent review. Earlier BLOCKED review stays historical; fresh full-diff non-building review is required. Leaves #2818 open for the deferred Slice B scope.
