### PR TITLE
fix(review): separate reviewer identity from relay publisher

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,6 +91,12 @@ repos:
   # Assay-Runner proof consumer: runs on PR-head via pre-commit/Kernel Matrix lint.
   - repo: local
     hooks:
+      - id: review-relay-protocol-tests
+        name: Review relay protocol tests
+        entry: python3 -m unittest discover -s scripts/review -p test_*.py
+        language: system
+        pass_filenames: false
+        files: ^(scripts/review/.*|scripts/ci/assay_review_record_check\.py|\.pre-commit-config\.yaml)$
       - id: assay-review-record-self-test
         name: Review-record checker self-test
         entry: python3 scripts/ci/assay_review_record_check.py --self-test

--- a/scripts/ci/assay_review_record_check.py
+++ b/scripts/ci/assay_review_record_check.py
@@ -16,6 +16,7 @@ CHECKER = "scripts/ci/assay_review_record_check.py"
 HOOK_ID = "assay-review-record-self-test"
 PREFIXES = frozenset({"codex", "claude", "cursor", "ruley"})
 HEX40 = re.compile(r"^[0-9a-f]{40}$")
+IDENTITY_COMPONENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}$")
 FENCE = re.compile(r"^```(?:json)?\n(.*)\n```$", re.S)
 HTTP_TIMEOUT_S = 30
 MAX_RESPONSE_BYTES = 8 * 1024 * 1024
@@ -106,10 +107,15 @@ def _need(obj: dict[str, Any], key: str, typ: type) -> Any:
 def _pair(obj: Any, label: str) -> tuple[str, str]:
     if not isinstance(obj, dict):
         raise GateError("missing_field", label)
-    return _need(obj, "agent", str), _need(obj, "instance", str)
+    agent, instance = _need(obj, "agent", str), _need(obj, "instance", str)
+    if not IDENTITY_COMPONENT.fullmatch(agent) or not IDENTITY_COMPONENT.fullmatch(instance):
+        raise GateError("malformed_record", label)
+    return agent, instance
 
 
-def validate_record(record: dict[str, Any], *, live_sha: str, branch_ref: str) -> None:
+def validate_record(
+    record: dict[str, Any], *, live_sha: str, branch_ref: str, require_ready: bool = True
+) -> None:
     if record.get("schema") != SCHEMA:
         raise GateError("missing_field", "schema")
     sha = _need(record, "head_sha", str).lower()
@@ -148,7 +154,7 @@ def validate_record(record: dict[str, Any], *, live_sha: str, branch_ref: str) -
     _need(reviewer, "github_login", str)
     if (builder_agent, builder_instance) == (reviewer_agent, reviewer_instance):
         raise GateError("identical_writer_reviewer", builder_instance)
-    if verdict != "READY":
+    if require_ready and verdict != "READY":
         raise GateError("blocked", verdict)
 
 

--- a/scripts/review/README.md
+++ b/scripts/review/README.md
@@ -19,6 +19,11 @@ an agent identity. Direct human review can use the same login for both options o
 when it is not the PR author's login and the record names `agent: human` and that
 login as `instance`.
 
+Reviewer agent and instance components use a closed, single-line identifier syntax
+before they enter either JSON or human-readable output. A record cannot use control
+characters or Markdown delimiters to add apparent conclusions to the readiness
+report.
+
 The evidence must be an existing `assay.review-record.v0` JSON record in a comment
 on this exact PR. It must declare a completed READY review on the current head and
 both non-building and non-governing-spec authorship. The helper does not follow

--- a/scripts/review/README.md
+++ b/scripts/review/README.md
@@ -33,6 +33,13 @@ adapter. Do not rewrite somebody else's review, invent an identity, or generate 
 synthetic approval to satisfy this format. Unsupported records need an explicitly
 reviewed adapter, not a bypass.
 
+Record parsing and validation are imported from
+`scripts/ci/assay_review_record_check.py`; the landing helper does not maintain a
+second interpretation of the schema. A malformed current-head machine carrier is
+reported as BLOCKED rather than discarded. Dismissed GitHub reviews do not count,
+and a current-head `CHANGES_REQUESTED` review is a blocker even without verdict
+prose.
+
 This verifies the retrieved declaration, not the actual agent's independence or
 identity. The operator still disposes actionable findings. `pr_landing_readiness.py`
 is only a candidate report: its old candidate extraction alone is not merge
@@ -42,7 +49,7 @@ calling `gh pr merge --match-head-commit`. The old `--reviewer` and
 reinterpreted.
 
 Evidence retrieval is limited to a constructed GitHub API comment endpoint on the
-selected PR, with a 30-second timeout and a 256-KiB JSON materialization ceiling.
+selected PR, with a 30-second timeout and an 8-MiB JSON materialization ceiling.
 Subprocess output goes to temporary files; this is not a disk-quota guarantee.
 No evidence contents are executed. GitHub comments remain editable; this is not an
 immutable attestation or protection against subsequent evidence edits.
@@ -60,6 +67,11 @@ python3 scripts/review/test_review_relay.py
 python3 scripts/review/test_safe_merge_protocol.py
 python3 scripts/review/test_pr_landing_readiness.py
 ```
+
+The `review-relay-protocol-tests` pre-commit hook runs the complete set on the PR
+head through Kernel Matrix CI whenever this surface changes. The trusted-base
+`review-record-check` workflow continues to execute only the base checker and is
+not weakened to run pull-request code with its token.
 
 Deployment into the local skill requires independent review and an explicit
 byte-verified copy of these helpers together, plus updating the skill usage examples.

--- a/scripts/review/README.md
+++ b/scripts/review/README.md
@@ -1,0 +1,55 @@
+# Review identity and relay
+
+Tracked source for the previously local `assay-stacked-pr-ops` landing helpers.
+The initial import comes from the installed skill; this directory is not automatically
+installed into `~/.codex/skills` and does not change a repository's required checks.
+
+```
+bash scripts/review/safe_merge.sh PR --repo OWNER/REPO \
+  --record-author GITHUB_LOGIN \
+  --reviewer-identity AGENT/INSTANCE \
+  --review-evidence-url https://github.com/OWNER/REPO/pull/PR#issuecomment-ID \
+  --confirm-findings-disposed --merge
+```
+
+The record author is its GitHub publisher, not necessarily its reviewer. A relayed
+agent is named by the existing review record's `reviewer.agent/instance`. The v0
+`reviewer.github_login` field is checked as the publishing account, not promoted to
+an agent identity. Direct human review can use the same login for both options only
+when it is not the PR author's login and the record names `agent: human` and that
+login as `instance`.
+
+The evidence must be an existing `assay.review-record.v0` JSON record in a comment
+on this exact PR. It must declare a completed READY review on the current head and
+both non-building and non-governing-spec authorship. The helper does not follow
+nested links; a READY relay pointing only to itself is not a review record. Prose-only
+reviews remain valid under AGENTS.md, but are not machine-supported by this bounded
+adapter. Do not rewrite somebody else's review, invent an identity, or generate a
+synthetic approval to satisfy this format. Unsupported records need an explicitly
+reviewed adapter, not a bypass.
+
+This verifies the retrieved declaration, not the actual agent's independence or
+identity. The operator still disposes actionable findings. `pr_landing_readiness.py`
+is only a candidate report: its old candidate extraction alone is not merge
+authorization. `safe_merge.sh` additionally validates the linked evidence before
+calling `gh pr merge --match-head-commit`. The old `--reviewer` and
+`--confirm-independent` interface is intentionally refused, rather than silently
+reinterpreted.
+
+Evidence retrieval is limited to a constructed GitHub API comment endpoint on the
+selected PR, with a 30-second timeout and a 256-KiB JSON materialization ceiling.
+Subprocess output goes to temporary files; this is not a disk-quota guarantee.
+No evidence contents are executed. GitHub comments remain editable; this is not an
+immutable attestation or protection against subsequent evidence edits.
+
+Run synthetic tests (fake gh, no live merges):
+
+```
+python3 scripts/review/test_review_relay.py
+python3 scripts/review/test_safe_merge_protocol.py
+python3 scripts/review/test_pr_landing_readiness.py
+```
+
+Deployment into the local skill requires independent review and an explicit
+byte-verified copy of these helpers together, plus updating the skill usage examples.
+Until then the old local helper must not be used for relay merges.

--- a/scripts/review/README.md
+++ b/scripts/review/README.md
@@ -47,6 +47,12 @@ Subprocess output goes to temporary files; this is not a disk-quota guarantee.
 No evidence contents are executed. GitHub comments remain editable; this is not an
 immutable attestation or protection against subsequent evidence edits.
 
+The broader readiness queries accept only the fixed `gh pr` and `gh api` command
+families used by the reporter, validate repository and branch path components, and
+apply a 30-second timeout plus an 8-MiB JSON ceiling before parsing. Human-readable
+output JSON-escapes every API-provided scalar; it is a display, never a second
+machine-readable verdict channel.
+
 Run synthetic tests (fake gh, no live merges):
 
 ```

--- a/scripts/review/pr_landing_readiness.py
+++ b/scripts/review/pr_landing_readiness.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+import subprocess
+import sys
+from urllib.parse import quote
+
+
+SHA_RE = re.compile(r"(?<![0-9a-f])[0-9a-f]{40}(?![0-9a-f])", re.IGNORECASE)
+REVIEW_RECORD_MARKER = "<!-- assay-review-record -->"
+REVIEW_RECORD_FENCE = re.compile(r"^```(?:json)?\n(.*)\n```$", re.S)
+
+
+def run_json(args, allowed_returncodes=(0,)):
+    result = subprocess.run(args, check=False, capture_output=True, text=True)
+    if result.returncode not in allowed_returncodes:
+        raise SystemExit(result.stderr.strip() or result.stdout.strip())
+    if not result.stdout.strip():
+        raise SystemExit(result.stderr.strip() or "command returned no JSON")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"command returned invalid JSON: {error}") from error
+
+
+def verdict(text):
+    upper = text.upper()
+    unavailable = (
+        "UNABLE TO REVIEW",
+        "COULD NOT REVIEW",
+        "REVIEW RATE LIMITED",
+        "RATE LIMIT",
+        "QUOTA LIMIT",
+        "QUOTA EXCEEDED",
+    )
+    if any(marker in upper for marker in unavailable):
+        return None
+    blocked = re.search(r"(?m)^\s*(?:#{1,6}\s*)?(?:\*\*)?(?:VERDICT\s*:\s*)?BLOCKED(?:\*\*)?\s*[.!]?\s*$", upper)
+    ready = re.search(r"(?m)^\s*(?:#{1,6}\s*)?(?:\*\*)?(?:VERDICT\s*:\s*)?READY(?:\*\*)?\s*[.!]?\s*$", upper)
+    if blocked:
+        return "BLOCKED"
+    if "NOT READY" not in upper and ready:
+        return "READY"
+    return None
+
+
+def machine_review_candidate(body, author):
+    stripped = body.strip()
+    if not stripped.startswith(REVIEW_RECORD_MARKER):
+        return None
+    fenced = stripped[len(REVIEW_RECORD_MARKER):].strip()
+    match = REVIEW_RECORD_FENCE.fullmatch(fenced)
+    if match is None or fenced.count("```") != 2:
+        return None
+    try:
+        record = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(record, dict) or record.get("schema") != "assay.review-record.v0":
+        return None
+    bound = record.get("head_sha")
+    result = record.get("verdict")
+    reviewer = record.get("reviewer")
+    independence = record.get("independence")
+    if (
+        not isinstance(bound, str)
+        or SHA_RE.fullmatch(bound) is None
+        or result not in {"READY", "BLOCKED"}
+        or record.get("review_completed") is not True
+        or not isinstance(reviewer, dict)
+        or reviewer.get("github_login") != author
+        or not isinstance(independence, dict)
+        or independence.get("did_not_build") is not True
+        or independence.get("did_not_author_governing_spec") is not True
+    ):
+        return None
+    return {"verdict": result, "bound_sha": bound}
+
+
+def review_candidates(pr, head):
+    rows = []
+    for review in pr.get("reviews", []):
+        body = review.get("body") or ""
+        bound = (review.get("commit") or {}).get("oid") or next(iter(SHA_RE.findall(body)), None)
+        result = verdict(body)
+        if result:
+            rows.append({
+                "author": review.get("author", {}).get("login"),
+                "verdict": result,
+                "bound_sha": bound,
+                "current_head": bound == head,
+                "source": "review",
+            })
+    for comment in pr.get("comments", []):
+        body = comment.get("body") or ""
+        author = comment.get("author", {}).get("login")
+        machine = machine_review_candidate(body, author)
+        if machine:
+            rows.append({
+                "author": author,
+                "verdict": machine["verdict"],
+                "bound_sha": machine["bound_sha"],
+                "current_head": machine["bound_sha"] == head,
+                "source": "machine-comment",
+            })
+            continue
+        result = verdict(body)
+        shas = SHA_RE.findall(body)
+        if result and shas:
+            rows.append({
+                "author": author,
+                "verdict": result,
+                "bound_sha": shas[0],
+                "current_head": shas[0] == head,
+                "source": "comment",
+            })
+    return rows
+
+
+def missing_required_contexts(reported, expected):
+    reported_names = {check.get("name") for check in reported}
+    return sorted(set(expected) - reported_names)
+
+
+def required_contexts(repo, branch):
+    owner, name = repo.split("/", 1)
+    response = run_json([
+        "gh", "api", "graphql", "-f",
+        "query=query($owner:String!,$name:String!,$ref:String!){repository(owner:$owner,name:$name){ref(qualifiedName:$ref){branchProtectionRule{requiredStatusCheckContexts}}}}",
+        "-f", f"owner={owner}", "-f", f"name={name}", "-f", f"ref=refs/heads/{branch}",
+    ])
+    try:
+        if response.get("errors"):
+            raise ValueError("GraphQL errors")
+        classic = response["data"]["repository"]["ref"]["branchProtectionRule"]
+        contexts = [] if classic is None else classic["requiredStatusCheckContexts"]
+        if not isinstance(contexts, list):
+            raise ValueError("invalid classic contexts")
+        contexts = list(contexts)
+        pages = run_json(["gh", "api", f"repos/{repo}/rules/branches/{quote(branch, safe='')}",
+                          "--paginate", "--slurp"])
+        if not isinstance(pages, list) or not pages:
+            raise ValueError("invalid rule pages")
+        for page in pages:
+            if not isinstance(page, list):
+                raise ValueError("invalid rule page")
+            for rule in page:
+                if not isinstance(rule, dict) or not isinstance(rule.get("type"), str):
+                    raise ValueError("invalid rule")
+                if rule["type"] == "required_status_checks":
+                    checks = rule["parameters"]["required_status_checks"]
+                    if not isinstance(checks, list):
+                        raise ValueError("invalid required checks")
+                    contexts.extend(check["context"] for check in checks)
+        if not contexts or any(not isinstance(c, str) or not c.strip() for c in contexts):
+            raise ValueError("no valid enforced check policy")
+        return sorted(set(contexts))
+    except (KeyError, TypeError, ValueError, AttributeError) as error:
+        raise SystemExit(f"cannot establish required check policy: {error}") from error
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Read-only Assay PR final-head readiness report")
+    parser.add_argument("pr", type=int)
+    parser.add_argument("--repo", default="Rul1an/assay")
+    parser.add_argument("--format", choices=("md", "json"), default="md")
+    parser.add_argument("--unprotected-require-check", action="append", default=[], metavar="NAME",
+                        help="Explicit check policy, only for a verified unprotected base with no active rules")
+    args = parser.parse_args()
+
+    pr = run_json([
+        "gh", "pr", "view", str(args.pr), "--repo", args.repo, "--json",
+        "number,title,url,state,author,isDraft,mergeable,mergeStateStatus,headRefName,headRefOid,baseRefName,baseRefOid,body,reviews,comments",
+    ])
+    # gh exits 8 for pending checks and 1 for failed checks while still emitting
+    # the JSON needed to report their actual state.
+    explicit_checks = args.unprotected_require_check
+    if explicit_checks:
+        if any(not name.strip() for name in explicit_checks):
+            raise SystemExit("check names must not be empty")
+        branch = run_json(["gh", "api", f"repos/{args.repo}/branches/{pr['baseRefName']}"])
+        rules = run_json(["gh", "api", f"repos/{args.repo}/rules/branches/{pr['baseRefName']}"])
+        if not isinstance(branch, dict) or branch.get("protected") is not False or rules != []:
+            raise SystemExit("explicit policy requires an unprotected branch and an empty active-rule list")
+    required = run_json([
+        "gh", "pr", "checks", str(args.pr), "--repo", args.repo,
+        *([] if explicit_checks else ["--required"]), "--json",
+        "name,state,bucket,link,workflow,event",
+    ], allowed_returncodes=(0, 1, 8))
+    if explicit_checks:
+        expected_required = sorted(set(explicit_checks))
+    else:
+        expected_required = required_contexts(args.repo, pr["baseRefName"])
+    missing_required = missing_required_contexts(required, expected_required)
+    head = pr["headRefOid"]
+    body_shas = SHA_RE.findall(pr.get("body") or "")
+    body_mentions_head = head in body_shas
+    candidates = review_candidates(pr, head)
+    current_ready = [row for row in candidates if row["current_head"] and row["verdict"] == "READY"]
+    current_blocked = [row for row in candidates if row["current_head"] and row["verdict"] == "BLOCKED"]
+    failing = [check for check in required if check.get("bucket") == "fail"]
+    pending = [check for check in required if check.get("bucket") in {"pending", "cancel"}]
+    required_green = bool(expected_required) and not missing_required and not failing and not pending
+    if explicit_checks:
+        required_green = required_green and all(
+            check.get("state") == "SUCCESS" and check.get("bucket") == "pass"
+            for check in required if check.get("name") in expected_required
+        )
+    blockers = []
+    if pr.get("state") != "OPEN":
+        blockers.append(f"PR state is {pr.get('state')}")
+    if pr.get("isDraft"):
+        blockers.append("PR is draft")
+    if pr.get("mergeable") != "MERGEABLE":
+        blockers.append(f"mergeable={pr.get('mergeable')}")
+    if not required_green:
+        blockers.append("required checks are not all green")
+    if missing_required:
+        blockers.append(f"required contexts not reported: {', '.join(missing_required)}")
+    if not current_ready:
+        blockers.append("no READY review candidate bound to current head")
+    if current_blocked:
+        blockers.append("current-head BLOCKED review exists")
+    if not body_mentions_head:
+        blockers.append("PR body does not mention current head SHA")
+
+    payload = {
+        "pr": {key: pr.get(key) for key in ("number", "title", "url", "state", "author", "isDraft", "mergeable", "mergeStateStatus", "headRefName", "headRefOid", "baseRefName", "baseRefOid")},
+        "required_checks": required,
+        "expected_required_contexts": expected_required,
+        "missing_required_contexts": missing_required,
+        "required_green": required_green,
+        "check_policy": "explicit-unprotected" if explicit_checks else "classic-and-active-rulesets",
+        "review_candidates": candidates,
+        "body_mentions_head": body_mentions_head,
+        "blockers": blockers,
+        "landing_candidate": not blockers,
+        "non_claim": "Reviewer independence and actionable-finding disposition require human verification.",
+    }
+    if args.format == "json":
+        json.dump(payload, sys.stdout, indent=2)
+        print()
+        return
+
+    print(f"# PR #{pr['number']} landing readiness")
+    print(f"- head: `{head}`")
+    print(f"- base: `{pr['baseRefOid']}`")
+    print(f"- draft: `{pr['isDraft']}`; mergeable: `{pr['mergeable']}`")
+    print(f"- required green: `{required_green}`")
+    for check in required:
+        print(f"  - `{check['name']}`: `{check['state']}` ({check['bucket']})")
+    if missing_required:
+        print(f"  - not reported: `{', '.join(missing_required)}`")
+    print(f"- PR body names current head: `{body_mentions_head}`")
+    print("- review candidates:")
+    if not candidates:
+        print("  - none")
+    for row in candidates:
+        print(f"  - `{row['verdict']}` by `{row['author']}` on `{row['bound_sha']}`; current=`{row['current_head']}` ({row['source']})")
+    print("- blockers:")
+    if not blockers:
+        print("  - none from machine-verifiable state")
+    for blocker in blockers:
+        print(f"  - {blocker}")
+    print("- non-claim: reviewer independence and finding disposition still require human verification")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/review/pr_landing_readiness.py
+++ b/scripts/review/pr_landing_readiness.py
@@ -10,6 +10,7 @@ from urllib.parse import quote
 SHA_RE = re.compile(r"(?<![0-9a-f])[0-9a-f]{40}(?![0-9a-f])", re.IGNORECASE)
 REVIEW_RECORD_MARKER = "<!-- assay-review-record -->"
 REVIEW_RECORD_FENCE = re.compile(r"^```(?:json)?\n(.*)\n```$", re.S)
+IDENTITY_COMPONENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}")
 
 
 def run_json(args, allowed_returncodes=(0,)):
@@ -45,6 +46,17 @@ def verdict(text):
     return None
 
 
+def declared_reviewer_identity(reviewer):
+    if not isinstance(reviewer, dict):
+        return None
+    agent = reviewer.get("agent")
+    instance = reviewer.get("instance")
+    if (not isinstance(agent, str) or IDENTITY_COMPONENT_RE.fullmatch(agent) is None
+            or not isinstance(instance, str) or IDENTITY_COMPONENT_RE.fullmatch(instance) is None):
+        return None
+    return f"{agent}/{instance}"
+
+
 def machine_review_candidate(body, author):
     stripped = body.strip()
     if not stripped.startswith(REVIEW_RECORD_MARKER):
@@ -63,12 +75,13 @@ def machine_review_candidate(body, author):
     result = record.get("verdict")
     reviewer = record.get("reviewer")
     independence = record.get("independence")
+    identity = declared_reviewer_identity(reviewer)
     if (
         not isinstance(bound, str)
         or SHA_RE.fullmatch(bound) is None
         or result not in {"READY", "BLOCKED"}
         or record.get("review_completed") is not True
-        or not isinstance(reviewer, dict)
+        or identity is None
         or reviewer.get("github_login") != author
         or not isinstance(independence, dict)
         or independence.get("did_not_build") is not True
@@ -78,7 +91,7 @@ def machine_review_candidate(body, author):
     return {
         "verdict": result,
         "bound_sha": bound,
-        "reviewer_identity": f"{reviewer.get('agent')}/{reviewer.get('instance')}",
+        "reviewer_identity": identity,
     }
 
 

--- a/scripts/review/pr_landing_readiness.py
+++ b/scripts/review/pr_landing_readiness.py
@@ -75,7 +75,11 @@ def machine_review_candidate(body, author):
         or independence.get("did_not_author_governing_spec") is not True
     ):
         return None
-    return {"verdict": result, "bound_sha": bound}
+    return {
+        "verdict": result,
+        "bound_sha": bound,
+        "reviewer_identity": f"{reviewer.get('agent')}/{reviewer.get('instance')}",
+    }
 
 
 def review_candidates(pr, head):
@@ -86,7 +90,8 @@ def review_candidates(pr, head):
         result = verdict(body)
         if result:
             rows.append({
-                "author": review.get("author", {}).get("login"),
+                "record_author": review.get("author", {}).get("login"),
+                "reviewer_identity": None,
                 "verdict": result,
                 "bound_sha": bound,
                 "current_head": bound == head,
@@ -98,7 +103,8 @@ def review_candidates(pr, head):
         machine = machine_review_candidate(body, author)
         if machine:
             rows.append({
-                "author": author,
+                "record_author": author,
+                "reviewer_identity": machine["reviewer_identity"],
                 "verdict": machine["verdict"],
                 "bound_sha": machine["bound_sha"],
                 "current_head": machine["bound_sha"] == head,
@@ -109,7 +115,8 @@ def review_candidates(pr, head):
         shas = SHA_RE.findall(body)
         if result and shas:
             rows.append({
-                "author": author,
+                "record_author": author,
+                "reviewer_identity": None,
                 "verdict": result,
                 "bound_sha": shas[0],
                 "current_head": shas[0] == head,
@@ -257,7 +264,8 @@ def main():
     if not candidates:
         print("  - none")
     for row in candidates:
-        print(f"  - `{row['verdict']}` by `{row['author']}` on `{row['bound_sha']}`; current=`{row['current_head']}` ({row['source']})")
+        identity = row["reviewer_identity"] or "not declared"
+        print(f"  - `{row['verdict']}` record by `{row['record_author']}`; reviewer `{identity}` on `{row['bound_sha']}`; current=`{row['current_head']}` ({row['source']})")
     print("- blockers:")
     if not blockers:
         print("  - none from machine-verifiable state")

--- a/scripts/review/pr_landing_readiness.py
+++ b/scripts/review/pr_landing_readiness.py
@@ -52,7 +52,8 @@ def run_json(args, allowed_returncodes=(0,)):
     try:
         with tempfile.TemporaryFile() as out, tempfile.TemporaryFile() as err:
             # argv is list-based and its command family is closed above; no shell is involved.
-            result = subprocess.run(  # lgtm[py/command-line-injection]
+            # codeql[py/command-line-injection]
+            result = subprocess.run(
                 args, check=False, stdout=out, stderr=err,
                 timeout=COMMAND_TIMEOUT_SECONDS,
             )

--- a/scripts/review/pr_landing_readiness.py
+++ b/scripts/review/pr_landing_readiness.py
@@ -5,13 +5,19 @@ import re
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
 from urllib.parse import quote, unquote
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+from assay_review_record_check import (  # noqa: E402
+    GateError,
+    MARKER as REVIEW_RECORD_MARKER,
+    _loose_object,
+    extract_record,
+    validate_record,
+)
 
 SHA_RE = re.compile(r"(?<![0-9a-f])[0-9a-f]{40}(?![0-9a-f])", re.IGNORECASE)
-REVIEW_RECORD_MARKER = "<!-- assay-review-record -->"
-REVIEW_RECORD_FENCE = re.compile(r"^```(?:json)?\n(.*)\n```$", re.S)
-IDENTITY_COMPONENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}")
 REPO_COMPONENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,99}")
 MAX_JSON_BYTES = 8 * 1024 * 1024
 COMMAND_TIMEOUT_SECONDS = 30
@@ -77,6 +83,13 @@ def validate_gh_command(args):
               and parts[3:5] == ["rules", "branches"]):
             encoded = parts[5]
             allowed_tail = ["--paginate", "--slurp"]
+        elif (len(parts) == 6 and parts[0] == "repos"
+              and parts[3:5] == ["issues", "comments"]
+              and parts[5].isdigit() and int(parts[5]) > 0):
+            parse_repo(f"{parts[1]}/{parts[2]}")
+            if args[3:]:
+                raise SystemExit("unsupported GitHub command shape")
+            return
         else:
             raise SystemExit("unsupported GitHub command shape")
         parse_repo(f"{parts[1]}/{parts[2]}")
@@ -127,79 +140,67 @@ def verdict(text):
         "QUOTA LIMIT",
         "QUOTA EXCEEDED",
     )
-    if any(marker in upper for marker in unavailable):
-        return None
     blocked = re.search(r"(?m)^\s*(?:#{1,6}\s*)?(?:\*\*)?(?:VERDICT\s*:\s*)?BLOCKED(?:\*\*)?\s*[.!]?\s*$", upper)
     ready = re.search(r"(?m)^\s*(?:#{1,6}\s*)?(?:\*\*)?(?:VERDICT\s*:\s*)?READY(?:\*\*)?\s*[.!]?\s*$", upper)
     if blocked:
         return "BLOCKED"
+    if any(marker in upper for marker in unavailable):
+        return None
     if ready:
         return "READY"
     return None
 
 
-def declared_reviewer_identity(reviewer):
-    if not isinstance(reviewer, dict):
-        return None
-    agent = reviewer.get("agent")
-    instance = reviewer.get("instance")
-    if (not isinstance(agent, str) or IDENTITY_COMPONENT_RE.fullmatch(agent) is None
-            or not isinstance(instance, str) or IDENTITY_COMPONENT_RE.fullmatch(instance) is None):
-        return None
-    return f"{agent}/{instance}"
-
-
-def machine_review_candidate(body, author):
-    stripped = body.strip()
-    if not stripped.startswith(REVIEW_RECORD_MARKER):
-        return None
-    fenced = stripped[len(REVIEW_RECORD_MARKER):].strip()
-    match = REVIEW_RECORD_FENCE.fullmatch(fenced)
-    if match is None or fenced.count("```") != 2:
+def machine_review_candidate(body, author, head=None, branch_ref=""):
+    if REVIEW_RECORD_MARKER not in body:
         return None
     try:
-        record = json.loads(match.group(1))
-    except json.JSONDecodeError:
+        record = extract_record(body)
+    except GateError as error:
+        loose = _loose_object(body)
+        bound = (loose or {}).get("head_sha")
+        if head and (bound == head or head.lower() in body.lower()):
+            return {
+                "verdict": "BLOCKED", "bound_sha": head,
+                "reviewer_identity": None, "validation_error": error.reason,
+            }
         return None
-    if not isinstance(record, dict) or record.get("schema") != "assay.review-record.v0":
+    if record is None:
         return None
     bound = record.get("head_sha")
-    result = record.get("verdict")
-    reviewer = record.get("reviewer")
-    independence = record.get("independence")
-    identity = declared_reviewer_identity(reviewer)
-    if (isinstance(bound, str) and SHA_RE.fullmatch(bound) is not None
-            and result == "BLOCKED" and record.get("review_completed") is True):
-        return {
-            "verdict": result,
-            "bound_sha": bound,
-            "reviewer_identity": identity,
-        }
-    if (
-        not isinstance(bound, str)
-        or SHA_RE.fullmatch(bound) is None
-        or result not in {"READY", "BLOCKED"}
-        or record.get("review_completed") is not True
-        or identity is None
-        or reviewer.get("github_login") != author
-        or not isinstance(independence, dict)
-        or independence.get("did_not_build") is not True
-        or independence.get("did_not_author_governing_spec") is not True
-    ):
+    if head and (not isinstance(bound, str) or bound.lower() != head.lower()):
+        return None
+    live_sha = head or bound
+    try:
+        validate_record(record, live_sha=live_sha, branch_ref=branch_ref, require_ready=False)
+        reviewer = record["reviewer"]
+        if reviewer.get("github_login") != author:
+            raise GateError("login_mismatch", str(author))
+    except (GateError, KeyError, TypeError) as error:
+        if head and isinstance(bound, str) and bound.lower() == head.lower():
+            reason = error.reason if isinstance(error, GateError) else "malformed_record"
+            return {
+                "verdict": "BLOCKED", "bound_sha": head,
+                "reviewer_identity": None, "validation_error": reason,
+            }
         return None
     return {
-        "verdict": result,
+        "verdict": record["verdict"],
         "bound_sha": bound,
-        "reviewer_identity": identity,
+        "reviewer_identity": f"{reviewer['agent']}/{reviewer['instance']}",
+        "validation_error": None,
     }
 
 
 def review_candidates(pr, head):
     rows = []
     for review in pr.get("reviews", []):
+        state = review.get("state")
+        if state == "DISMISSED":
+            continue
         body = review.get("body") or ""
         bound = (review.get("commit") or {}).get("oid") or next(iter(SHA_RE.findall(body)), None)
-        result = verdict(body)
+        result = "BLOCKED" if state == "CHANGES_REQUESTED" else verdict(body)
         if result:
             rows.append({
                 "record_author": review.get("author", {}).get("login"),
@@ -212,7 +213,7 @@ def review_candidates(pr, head):
     for comment in pr.get("comments", []):
         body = comment.get("body") or ""
         author = comment.get("author", {}).get("login")
-        machine = machine_review_candidate(body, author)
+        machine = machine_review_candidate(body, author, head, pr.get("headRefName") or "")
         if machine:
             rows.append({
                 "record_author": author,
@@ -220,7 +221,7 @@ def review_candidates(pr, head):
                 "verdict": machine["verdict"],
                 "bound_sha": machine["bound_sha"],
                 "current_head": machine["bound_sha"] == head,
-                "source": "machine-comment",
+                "source": "machine-comment" if machine["validation_error"] is None else "invalid-machine-comment",
             })
             continue
         if body.strip().startswith(REVIEW_RECORD_MARKER):
@@ -325,12 +326,13 @@ def main():
     current_blocked = [row for row in candidates if row["current_head"] and row["verdict"] == "BLOCKED"]
     failing = [check for check in required if check.get("bucket") == "fail"]
     pending = [check for check in required if check.get("bucket") in {"pending", "cancel"}]
-    required_green = bool(expected_required) and not missing_required and not failing and not pending
-    if explicit_checks:
-        required_green = required_green and all(
-            check.get("state") == "SUCCESS" and check.get("bucket") == "pass"
-            for check in required if check.get("name") in expected_required
-        )
+    required_green = (
+        bool(expected_required) and not missing_required and not failing and not pending
+        and all(any(
+            check.get("name") == name and check.get("state") == "SUCCESS"
+            and check.get("bucket") == "pass" for check in required
+        ) for name in expected_required)
+    )
     blockers = []
     if pr.get("state") != "OPEN":
         blockers.append(f"PR state is {pr.get('state')}")
@@ -367,7 +369,7 @@ def main():
         print()
         return
 
-    print(f"# PR #{pr['number']} landing readiness")
+    print(f"# PR #{markdown_atom(pr['number'])} landing readiness")
     print(f"- head: {markdown_atom(head)}")
     print(f"- base: {markdown_atom(pr['baseRefOid'])}")
     print(f"- draft: {markdown_atom(pr['isDraft'])}; mergeable: {markdown_atom(pr['mergeable'])}")

--- a/scripts/review/pr_landing_readiness.py
+++ b/scripts/review/pr_landing_readiness.py
@@ -4,6 +4,7 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 from urllib.parse import quote
 
 
@@ -11,16 +12,66 @@ SHA_RE = re.compile(r"(?<![0-9a-f])[0-9a-f]{40}(?![0-9a-f])", re.IGNORECASE)
 REVIEW_RECORD_MARKER = "<!-- assay-review-record -->"
 REVIEW_RECORD_FENCE = re.compile(r"^```(?:json)?\n(.*)\n```$", re.S)
 IDENTITY_COMPONENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}")
+REPO_COMPONENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,99}")
+MAX_JSON_BYTES = 8 * 1024 * 1024
+COMMAND_TIMEOUT_SECONDS = 30
+
+
+def parse_repo(repo):
+    if not isinstance(repo, str) or repo.count("/") != 1:
+        raise SystemExit("repository must be OWNER/REPO")
+    owner, name = repo.split("/", 1)
+    if REPO_COMPONENT_RE.fullmatch(owner) is None or REPO_COMPONENT_RE.fullmatch(name) is None:
+        raise SystemExit("repository must be OWNER/REPO")
+    return owner, name
+
+
+def encoded_branch(branch):
+    forbidden = ("..", "@{", "//")
+    if (not isinstance(branch, str) or not branch or branch.startswith(("/", ".", "-"))
+            or branch.endswith(("/", ".", ".lock"))
+            or any(token in branch for token in forbidden)
+            or any(ord(char) < 32 or char in " ~^:?*[\\" for char in branch)):
+        raise SystemExit("branch name is not a supported Git ref")
+    return quote(branch, safe="")
+
+
+def validate_gh_command(args):
+    if (not isinstance(args, list) or len(args) < 3
+            or any(not isinstance(arg, str) or "\x00" in arg for arg in args)
+            or args[0] != "gh"):
+        raise SystemExit("unsupported GitHub command shape")
+    shape = tuple(args[1:3])
+    if shape not in {("pr", "view"), ("pr", "checks"), ("api", "graphql")}:
+        if args[1] != "api" or not args[2].startswith("repos/"):
+            raise SystemExit("unsupported GitHub command shape")
 
 
 def run_json(args, allowed_returncodes=(0,)):
-    result = subprocess.run(args, check=False, capture_output=True, text=True)
-    if result.returncode not in allowed_returncodes:
-        raise SystemExit(result.stderr.strip() or result.stdout.strip())
-    if not result.stdout.strip():
-        raise SystemExit(result.stderr.strip() or "command returned no JSON")
+    validate_gh_command(args)
     try:
-        return json.loads(result.stdout)
+        with tempfile.TemporaryFile() as out, tempfile.TemporaryFile() as err:
+            # argv is list-based and its command family is closed above; no shell is involved.
+            result = subprocess.run(  # lgtm[py/command-line-injection]
+                args, check=False, stdout=out, stderr=err,
+                timeout=COMMAND_TIMEOUT_SECONDS,
+            )
+            if out.tell() > MAX_JSON_BYTES:
+                raise SystemExit("command output exceeds byte limit")
+            err.seek(0)
+            error_text = err.read(262144).decode("utf-8", errors="replace").strip()
+            out.seek(0)
+            output = out.read().decode("utf-8", errors="strict")
+    except subprocess.TimeoutExpired as error:
+        raise SystemExit("GitHub command timed out") from error
+    except UnicodeDecodeError as error:
+        raise SystemExit("command returned non-UTF-8 output") from error
+    if result.returncode not in allowed_returncodes:
+        raise SystemExit(error_text or output.strip())
+    if not output.strip():
+        raise SystemExit(error_text or "command returned no JSON")
+    try:
+        return json.loads(output)
     except json.JSONDecodeError as error:
         raise SystemExit(f"command returned invalid JSON: {error}") from error
 
@@ -41,7 +92,7 @@ def verdict(text):
     ready = re.search(r"(?m)^\s*(?:#{1,6}\s*)?(?:\*\*)?(?:VERDICT\s*:\s*)?READY(?:\*\*)?\s*[.!]?\s*$", upper)
     if blocked:
         return "BLOCKED"
-    if "NOT READY" not in upper and ready:
+    if ready:
         return "READY"
     return None
 
@@ -76,6 +127,13 @@ def machine_review_candidate(body, author):
     reviewer = record.get("reviewer")
     independence = record.get("independence")
     identity = declared_reviewer_identity(reviewer)
+    if (isinstance(bound, str) and SHA_RE.fullmatch(bound) is not None
+            and result == "BLOCKED" and record.get("review_completed") is True):
+        return {
+            "verdict": result,
+            "bound_sha": bound,
+            "reviewer_identity": identity,
+        }
     if (
         not isinstance(bound, str)
         or SHA_RE.fullmatch(bound) is None
@@ -124,6 +182,8 @@ def review_candidates(pr, head):
                 "source": "machine-comment",
             })
             continue
+        if body.strip().startswith(REVIEW_RECORD_MARKER):
+            continue
         result = verdict(body)
         shas = SHA_RE.findall(body)
         if result and shas:
@@ -144,7 +204,8 @@ def missing_required_contexts(reported, expected):
 
 
 def required_contexts(repo, branch):
-    owner, name = repo.split("/", 1)
+    owner, name = parse_repo(repo)
+    branch_path = encoded_branch(branch)
     response = run_json([
         "gh", "api", "graphql", "-f",
         "query=query($owner:String!,$name:String!,$ref:String!){repository(owner:$owner,name:$name){ref(qualifiedName:$ref){branchProtectionRule{requiredStatusCheckContexts}}}}",
@@ -158,7 +219,7 @@ def required_contexts(repo, branch):
         if not isinstance(contexts, list):
             raise ValueError("invalid classic contexts")
         contexts = list(contexts)
-        pages = run_json(["gh", "api", f"repos/{repo}/rules/branches/{quote(branch, safe='')}",
+        pages = run_json(["gh", "api", f"repos/{repo}/rules/branches/{branch_path}",
                           "--paginate", "--slurp"])
         if not isinstance(pages, list) or not pages:
             raise ValueError("invalid rule pages")
@@ -188,6 +249,7 @@ def main():
     parser.add_argument("--unprotected-require-check", action="append", default=[], metavar="NAME",
                         help="Explicit check policy, only for a verified unprotected base with no active rules")
     args = parser.parse_args()
+    parse_repo(args.repo)
 
     pr = run_json([
         "gh", "pr", "view", str(args.pr), "--repo", args.repo, "--json",
@@ -199,8 +261,9 @@ def main():
     if explicit_checks:
         if any(not name.strip() for name in explicit_checks):
             raise SystemExit("check names must not be empty")
-        branch = run_json(["gh", "api", f"repos/{args.repo}/branches/{pr['baseRefName']}"])
-        rules = run_json(["gh", "api", f"repos/{args.repo}/rules/branches/{pr['baseRefName']}"])
+        branch_path = encoded_branch(pr["baseRefName"])
+        branch = run_json(["gh", "api", f"repos/{args.repo}/branches/{branch_path}"])
+        rules = run_json(["gh", "api", f"repos/{args.repo}/rules/branches/{branch_path}"])
         if not isinstance(branch, dict) or branch.get("protected") is not False or rules != []:
             raise SystemExit("explicit policy requires an unprotected branch and an empty active-rule list")
     required = run_json([
@@ -264,27 +327,35 @@ def main():
         return
 
     print(f"# PR #{pr['number']} landing readiness")
-    print(f"- head: `{head}`")
-    print(f"- base: `{pr['baseRefOid']}`")
-    print(f"- draft: `{pr['isDraft']}`; mergeable: `{pr['mergeable']}`")
-    print(f"- required green: `{required_green}`")
+    print(f"- head: {markdown_atom(head)}")
+    print(f"- base: {markdown_atom(pr['baseRefOid'])}")
+    print(f"- draft: {markdown_atom(pr['isDraft'])}; mergeable: {markdown_atom(pr['mergeable'])}")
+    print(f"- required green: {markdown_atom(required_green)}")
     for check in required:
-        print(f"  - `{check['name']}`: `{check['state']}` ({check['bucket']})")
+        print(f"  - {markdown_atom(check.get('name'))}: {markdown_atom(check.get('state'))} ({markdown_atom(check.get('bucket'))})")
     if missing_required:
-        print(f"  - not reported: `{', '.join(missing_required)}`")
-    print(f"- PR body names current head: `{body_mentions_head}`")
+        print(f"  - not reported: {markdown_atom(', '.join(missing_required))}")
+    print(f"- PR body names current head: {markdown_atom(body_mentions_head)}")
     print("- review candidates:")
     if not candidates:
         print("  - none")
     for row in candidates:
         identity = row["reviewer_identity"] or "not declared"
-        print(f"  - `{row['verdict']}` record by `{row['record_author']}`; reviewer `{identity}` on `{row['bound_sha']}`; current=`{row['current_head']}` ({row['source']})")
+        print(f"  - {markdown_atom(row['verdict'])} record by {markdown_atom(row['record_author'])}; reviewer {markdown_atom(identity)} on {markdown_atom(row['bound_sha'])}; current={markdown_atom(row['current_head'])} ({markdown_atom(row['source'])})")
     print("- blockers:")
     if not blockers:
         print("  - none from machine-verifiable state")
     for blocker in blockers:
-        print(f"  - {blocker}")
+        print(f"  - {markdown_atom(blocker)}")
     print("- non-claim: reviewer independence and finding disposition still require human verification")
+
+
+def markdown_atom(value):
+    """Render untrusted scalar data as one JSON-escaped Markdown-safe line."""
+    rendered = json.dumps(value, ensure_ascii=True, separators=(",", ":"))
+    for delimiter in "`*_[]<>":
+        rendered = rendered.replace(delimiter, f"\\u{ord(delimiter):04x}")
+    return rendered
 
 
 if __name__ == "__main__":

--- a/scripts/review/pr_landing_readiness.py
+++ b/scripts/review/pr_landing_readiness.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 import sys
 import tempfile
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 
 SHA_RE = re.compile(r"(?<![0-9a-f])[0-9a-f]{40}(?![0-9a-f])", re.IGNORECASE)
@@ -15,6 +15,9 @@ IDENTITY_COMPONENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}")
 REPO_COMPONENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,99}")
 MAX_JSON_BYTES = 8 * 1024 * 1024
 COMMAND_TIMEOUT_SECONDS = 30
+PR_VIEW_FIELDS = "number,title,url,state,author,isDraft,mergeable,mergeStateStatus,headRefName,headRefOid,baseRefName,baseRefOid,body,reviews,comments"
+PR_CHECK_FIELDS = "name,state,bucket,link,workflow,event"
+REQUIRED_CONTEXT_QUERY = "query($owner:String!,$name:String!,$ref:String!){repository(owner:$owner,name:$name){ref(qualifiedName:$ref){branchProtectionRule{requiredStatusCheckContexts}}}}"
 
 
 def parse_repo(repo):
@@ -42,9 +45,46 @@ def validate_gh_command(args):
             or args[0] != "gh"):
         raise SystemExit("unsupported GitHub command shape")
     shape = tuple(args[1:3])
-    if shape not in {("pr", "view"), ("pr", "checks"), ("api", "graphql")}:
-        if args[1] != "api" or not args[2].startswith("repos/"):
+    if shape == ("pr", "view"):
+        if (len(args) != 8 or not args[3].isdigit() or args[4] != "--repo"
+                or args[6:] != ["--json", PR_VIEW_FIELDS]):
             raise SystemExit("unsupported GitHub command shape")
+        parse_repo(args[5])
+        return
+    if shape == ("pr", "checks"):
+        if (len(args) not in {8, 9} or not args[3].isdigit() or args[4] != "--repo"):
+            raise SystemExit("unsupported GitHub command shape")
+        parse_repo(args[5])
+        if args[6:] not in (["--json", PR_CHECK_FIELDS],
+                            ["--required", "--json", PR_CHECK_FIELDS]):
+            raise SystemExit("unsupported GitHub command shape")
+        return
+    if shape == ("api", "graphql"):
+        if (len(args) != 11 or args[3::2] != ["-f", "-f", "-f", "-f"]
+                or args[4] != f"query={REQUIRED_CONTEXT_QUERY}"
+                or not args[6].startswith("owner=") or not args[8].startswith("name=")
+                or not args[10].startswith("ref=refs/heads/")):
+            raise SystemExit("unsupported GitHub command shape")
+        parse_repo(f"{args[6][6:]}/{args[8][5:]}")
+        encoded_branch(args[10][len("ref=refs/heads/"):])
+        return
+    if args[1] == "api":
+        parts = args[2].split("/")
+        if len(parts) == 5 and parts[0] == "repos" and parts[3] == "branches":
+            encoded = parts[4]
+            allowed_tail = []
+        elif (len(parts) == 6 and parts[0] == "repos"
+              and parts[3:5] == ["rules", "branches"]):
+            encoded = parts[5]
+            allowed_tail = ["--paginate", "--slurp"]
+        else:
+            raise SystemExit("unsupported GitHub command shape")
+        parse_repo(f"{parts[1]}/{parts[2]}")
+        if (encoded_branch(unquote(encoded)) != encoded
+                or args[3:] not in ([], allowed_tail)):
+            raise SystemExit("unsupported GitHub command shape")
+        return
+    raise SystemExit("unsupported GitHub command shape")
 
 
 def run_json(args, allowed_returncodes=(0,)):
@@ -209,7 +249,7 @@ def required_contexts(repo, branch):
     branch_path = encoded_branch(branch)
     response = run_json([
         "gh", "api", "graphql", "-f",
-        "query=query($owner:String!,$name:String!,$ref:String!){repository(owner:$owner,name:$name){ref(qualifiedName:$ref){branchProtectionRule{requiredStatusCheckContexts}}}}",
+        f"query={REQUIRED_CONTEXT_QUERY}",
         "-f", f"owner={owner}", "-f", f"name={name}", "-f", f"ref=refs/heads/{branch}",
     ])
     try:
@@ -254,7 +294,7 @@ def main():
 
     pr = run_json([
         "gh", "pr", "view", str(args.pr), "--repo", args.repo, "--json",
-        "number,title,url,state,author,isDraft,mergeable,mergeStateStatus,headRefName,headRefOid,baseRefName,baseRefOid,body,reviews,comments",
+        PR_VIEW_FIELDS,
     ])
     # gh exits 8 for pending checks and 1 for failed checks while still emitting
     # the JSON needed to report their actual state.
@@ -270,7 +310,7 @@ def main():
     required = run_json([
         "gh", "pr", "checks", str(args.pr), "--repo", args.repo,
         *([] if explicit_checks else ["--required"]), "--json",
-        "name,state,bucket,link,workflow,event",
+        PR_CHECK_FIELDS,
     ], allowed_returncodes=(0, 1, 8))
     if explicit_checks:
         expected_required = sorted(set(explicit_checks))

--- a/scripts/review/safe_merge.sh
+++ b/scripts/review/safe_merge.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="Rul1an/assay"
+method=""
+record_author=""
+reviewer_identity=""
+review_evidence_url=""
+confirm_findings=false
+policy_args=(--format json)
+
+usage() {
+  echo "usage: $0 PR --record-author LOGIN --reviewer-identity AGENT/INSTANCE --review-evidence-url URL --confirm-findings-disposed [--repo OWNER/REPO] (--merge|--rebase|--squash)" >&2
+  exit 2
+}
+
+[[ $# -ge 1 ]] || usage
+pr="$1"
+shift
+
+while (($#)); do
+  case "$1" in
+    --repo) repo="${2:?}"; shift 2 ;;
+    --record-author) record_author="${2:?}"; shift 2 ;;
+    --reviewer-identity) reviewer_identity="${2:?}"; shift 2 ;;
+    --review-evidence-url) review_evidence_url="${2:?}"; shift 2 ;;
+    --unprotected-require-check) policy_args+=("$1" "${2:?}"); shift 2 ;;
+    --confirm-findings-disposed) confirm_findings=true; shift ;;
+    --merge|--rebase|--squash) method="$1"; shift ;;
+    *) usage ;;
+  esac
+done
+
+[[ -n "$record_author" && -n "$reviewer_identity" && -n "$review_evidence_url" ]] || usage
+[[ -n "$method" ]] || usage
+[[ "$confirm_findings" == true ]] || usage
+
+readiness="$(dirname "$0")/pr_landing_readiness.py"
+report="$($readiness "$pr" --repo "$repo" "${policy_args[@]}")"
+
+if [[ "$(jq -r '.landing_candidate' <<<"$report")" != "true" ]]; then
+  jq -r '.blockers[] | "BLOCKED: " + .' <<<"$report" >&2
+  exit 1
+fi
+
+if ! jq -e --arg record_author "$record_author" '
+  any(.review_candidates[];
+      .author == $record_author and .verdict == "READY" and .current_head == true)
+' <<<"$report" >/dev/null; then
+  echo "BLOCKED: no current-head READY record by declared record author '$record_author'" >&2
+  exit 1
+fi
+
+head="$(jq -r '.pr.headRefOid' <<<"$report")"
+python3 "$(dirname "$0")/verify_review_identity.py" \
+  --repo "$repo" --pr "$pr" --head "$head" \
+  --record-author "$record_author" --reviewer-identity "$reviewer_identity" \
+  --review-evidence-url "$review_evidence_url" \
+  --pr-author "$(jq -er '.pr.author.login' <<<"$report")"
+printf 'Landing PR #%s at exact head %s\n' "$pr" "$head"
+printf 'Check policy: %s\n' "$(jq -r '.check_policy' <<<"$report")"
+printf 'Operator confirms actionable findings are disposed; reviewer declaration is linked above.\n'
+gh pr merge "$pr" --repo "$repo" "$method" --match-head-commit "$head"

--- a/scripts/review/safe_merge.sh
+++ b/scripts/review/safe_merge.sh
@@ -47,6 +47,7 @@ if ! jq -e --arg record_author "$record_author" --arg reviewer_identity "$review
   any(.review_candidates[];
       .record_author == $record_author and
       .reviewer_identity == $reviewer_identity and
+      .verdict == "READY" and
       .current_head == true)
 ' <<<"$report" >/dev/null; then
   echo "BLOCKED: no matching current-head machine READY record for the declared author and reviewer" >&2
@@ -56,6 +57,7 @@ fi
 head="$(jq -r '.pr.headRefOid' <<<"$report")"
 python3 "$(dirname "$0")/verify_review_identity.py" \
   --repo "$repo" --pr "$pr" --head "$head" \
+  --branch-ref "$(jq -er '.pr.headRefName' <<<"$report")" \
   --record-author "$record_author" --reviewer-identity "$reviewer_identity" \
   --review-evidence-url "$review_evidence_url" \
   --pr-author "$(jq -er '.pr.author.login' <<<"$report")"

--- a/scripts/review/safe_merge.sh
+++ b/scripts/review/safe_merge.sh
@@ -43,11 +43,13 @@ if [[ "$(jq -r '.landing_candidate' <<<"$report")" != "true" ]]; then
   exit 1
 fi
 
-if ! jq -e --arg record_author "$record_author" '
+if ! jq -e --arg record_author "$record_author" --arg reviewer_identity "$reviewer_identity" '
   any(.review_candidates[];
-      .record_author == $record_author and .verdict == "READY" and .current_head == true)
+      .record_author == $record_author and
+      .reviewer_identity == $reviewer_identity and
+      .current_head == true)
 ' <<<"$report" >/dev/null; then
-  echo "BLOCKED: no current-head READY record by declared record author '$record_author'" >&2
+  echo "BLOCKED: no matching current-head machine READY record for the declared author and reviewer" >&2
   exit 1
 fi
 

--- a/scripts/review/safe_merge.sh
+++ b/scripts/review/safe_merge.sh
@@ -45,7 +45,7 @@ fi
 
 if ! jq -e --arg record_author "$record_author" '
   any(.review_candidates[];
-      .author == $record_author and .verdict == "READY" and .current_head == true)
+      .record_author == $record_author and .verdict == "READY" and .current_head == true)
 ' <<<"$report" >/dev/null; then
   echo "BLOCKED: no current-head READY record by declared record author '$record_author'" >&2
   exit 1

--- a/scripts/review/test_pr_landing_readiness.py
+++ b/scripts/review/test_pr_landing_readiness.py
@@ -85,6 +85,26 @@ class CandidateBindingTests(unittest.TestCase):
             "source": "machine-comment",
         }])
 
+    def test_reviewer_identity_cannot_inject_human_read_output(self):
+        current = "b" * 40
+        record = {
+            "schema": "assay.review-record.v0",
+            "head_sha": current,
+            "review_completed": True,
+            "verdict": "READY",
+            "reviewer": {
+                "agent": "claude",
+                "instance": "x`; **INDEPENDENCE VERIFIED**\n- blockers:\n  - none",
+                "github_login": "owner",
+            },
+            "independence": {
+                "did_not_build": True,
+                "did_not_author_governing_spec": True,
+            },
+        }
+        body = "<!-- assay-review-record -->\n```json\n" + json.dumps(record) + "\n```"
+        self.assertIsNone(MODULE.machine_review_candidate(body, "owner"))
+
 
 class RequiredContextTests(unittest.TestCase):
     def test_missing_required_context_is_reported(self):
@@ -139,13 +159,17 @@ class RulesetPolicyTests(unittest.TestCase):
 
 
 class UnprotectedPolicyTests(unittest.TestCase):
-    def run_report(self, *, explicit=True, protected=False, rules=None, checks=None, review=True):
+    def run_report(self, *, explicit=True, protected=False, rules=None, checks=None,
+                   review=True, blocked=False):
         head = "b" * 40
         pr = dict(number=30, title="test", state="OPEN", isDraft=False,
                   mergeable="MERGEABLE", headRefOid=head, baseRefOid="a" * 40,
                   baseRefName="main", body=head, reviews=[], comments=[])
         if review:
             pr["comments"] = [{"author": {"login": "reviewer"}, "body": f"READY\n{head}"}]
+        if blocked:
+            pr["comments"].append(
+                {"author": {"login": "blocker"}, "body": f"BLOCKED\n{head}"})
         calls = []
         def api(args, **kwargs):
             calls.append(args)
@@ -179,6 +203,11 @@ class UnprotectedPolicyTests(unittest.TestCase):
         self.assertFalse(any("--required" in c for c in calls))
         report, _ = self.run_report(review=False)
         self.assertFalse(report["landing_candidate"])
+
+    def test_current_head_blocked_review_overrides_ready(self):
+        report, _ = self.run_report(blocked=True)
+        self.assertFalse(report["landing_candidate"])
+        self.assertIn("current-head BLOCKED review exists", report["blockers"])
 
     def test_default_does_not_turn_absent_policy_into_unprotected(self):
         with self.assertRaisesRegex(SystemExit, "cannot establish required check policy"):

--- a/scripts/review/test_pr_landing_readiness.py
+++ b/scripts/review/test_pr_landing_readiness.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import pathlib
+import unittest
+import io
+from unittest.mock import patch
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("pr_landing_readiness.py")
+SPEC = importlib.util.spec_from_file_location("pr_landing_readiness", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class VerdictTests(unittest.TestCase):
+    def test_exact_ready(self):
+        self.assertEqual(MODULE.verdict("## Verdict\n\n**READY**"), "READY")
+
+    def test_exact_blocked_wins(self):
+        self.assertEqual(MODULE.verdict("READY\n\nBLOCKED"), "BLOCKED")
+
+    def test_not_ready_is_not_ready(self):
+        self.assertIsNone(MODULE.verdict("Verdict: NOT READY"))
+
+    def test_quota_comment_is_not_a_review(self):
+        body = "Review rate limited; unable to review. Mark READY when quota resets."
+        self.assertIsNone(MODULE.verdict(body))
+
+    def test_ready_in_prose_is_not_a_verdict(self):
+        self.assertIsNone(MODULE.verdict("The branch may be ready after CI."))
+
+
+class CandidateBindingTests(unittest.TestCase):
+    def test_stale_and_current_sha_are_distinguished(self):
+        current = "b" * 40
+        stale = "a" * 40
+        pr = {
+            "reviews": [],
+            "comments": [
+                {"author": {"login": "old"}, "body": f"READY\n{stale}"},
+                {"author": {"login": "current"}, "body": f"READY\n{current}"},
+            ],
+        }
+        rows = MODULE.review_candidates(pr, current)
+        self.assertFalse(rows[0]["current_head"])
+        self.assertTrue(rows[1]["current_head"])
+
+    def test_canonical_machine_record_is_a_ready_candidate(self):
+        current = "b" * 40
+        record = {
+            "schema": "assay.review-record.v0",
+            "head_sha": current,
+            "builder": {"agent": "ruley", "instance": "writer"},
+            "reviewer": {
+                "agent": "claude",
+                "instance": "reviewer",
+                "github_login": "Rul1an",
+            },
+            "review_completed": True,
+            "verdict": "READY",
+            "findings": [],
+            "no_findings": True,
+            "independence": {
+                "did_not_build": True,
+                "did_not_author_governing_spec": True,
+            },
+        }
+        pr = {
+            "reviews": [],
+            "comments": [{
+                "author": {"login": "Rul1an"},
+                "body": "<!-- assay-review-record -->\n```json\n"
+                + json.dumps(record)
+                + "\n```",
+            }],
+        }
+
+        self.assertEqual(MODULE.review_candidates(pr, current), [{
+            "author": "Rul1an",
+            "verdict": "READY",
+            "bound_sha": current,
+            "current_head": True,
+            "source": "machine-comment",
+        }])
+
+
+class RequiredContextTests(unittest.TestCase):
+    def test_missing_required_context_is_reported(self):
+        reported = [
+            {"name": "host-capability-check", "bucket": "pass"},
+            {"name": "lane-check/proof", "bucket": "pass"},
+        ]
+        expected = ["CI", "host-capability-check", "lane-check/proof"]
+
+        self.assertEqual(MODULE.missing_required_contexts(reported, expected), ["CI"])
+
+
+class RulesetPolicyTests(unittest.TestCase):
+    def policy(self, classic=None, pages=None):
+        response = {"data": {"repository": {"ref": {"branchProtectionRule": classic}}}}
+        with patch.object(MODULE, "run_json", side_effect=[response, pages]) as api:
+            result = MODULE.required_contexts("example/repo", "main")
+        self.assertIn("--paginate", api.call_args_list[1].args[0])
+        self.assertIn("--slurp", api.call_args_list[1].args[0])
+        return result
+
+    def rule(self, name):
+        return {"type": "required_status_checks", "parameters": {
+            "required_status_checks": [{"context": name, "integration_id": 15368}]}}
+
+    def test_ruleset_only_and_multiple_pages(self):
+        self.assertEqual(self.policy(pages=[[self.rule("linux")], [self.rule("windows")]]),
+                         ["linux", "windows"])
+
+    def test_union_never_drops_classic_requirements(self):
+        self.assertEqual(self.policy({"requiredStatusCheckContexts": ["CI", "linux"]},
+                                     [[self.rule("linux")]]), ["CI", "linux"])
+
+    def test_classic_only(self):
+        self.assertEqual(self.policy({"requiredStatusCheckContexts": ["CI"]}, [[]]), ["CI"])
+
+    def test_malformed_or_empty_policy_refuses(self):
+        for pages in [None, {}, [None], [[{}]], [[{"type": "required_status_checks"}]],
+                      [[self.rule("")]], [[]]]:
+            with self.subTest(pages=pages), self.assertRaises(SystemExit):
+                self.policy(pages=pages)
+
+    def test_api_failure_refuses(self):
+        with patch.object(MODULE, "run_json", side_effect=SystemExit("403")):
+            with self.assertRaisesRegex(SystemExit, "403"):
+                MODULE.required_contexts("example/repo", "main")
+
+    def test_missing_branch_is_not_absent_classic_rule(self):
+        with patch.object(MODULE, "run_json", return_value={"data": {"repository": {"ref": None}}}):
+            with self.assertRaises(SystemExit):
+                MODULE.required_contexts("example/repo", "main")
+
+
+class UnprotectedPolicyTests(unittest.TestCase):
+    def run_report(self, *, explicit=True, protected=False, rules=None, checks=None, review=True):
+        head = "b" * 40
+        pr = dict(number=30, title="test", state="OPEN", isDraft=False,
+                  mergeable="MERGEABLE", headRefOid=head, baseRefOid="a" * 40,
+                  baseRefName="main", body=head, reviews=[], comments=[])
+        if review:
+            pr["comments"] = [{"author": {"login": "reviewer"}, "body": f"READY\n{head}"}]
+        calls = []
+        def api(args, **kwargs):
+            calls.append(args)
+            if args[1:3] == ["pr", "view"]:
+                return pr
+            if args[1:3] == ["pr", "checks"]:
+                return checks if checks is not None else [dict(name="reproduce", state="SUCCESS", bucket="pass")]
+            if args[-1].endswith("/protection/required_status_checks"):
+                raise SystemExit("HTTP 404")
+            if args[1:3] == ["api", "graphql"]:
+                return {"data": {"repository": {"ref": {"branchProtectionRule": None}}}}
+            if "--slurp" in args:
+                return [[] if rules is None else rules]
+            if "/rules/branches/" in args[-1]:
+                return [] if rules is None else rules
+            if args[-1].endswith("/branches/main"):
+                return {"protected": protected}
+            raise AssertionError(args)
+        argv = ["readiness", "30", "--repo", "example/repo", "--format", "json"]
+        if explicit:
+            argv += ["--unprotected-require-check", "reproduce"]
+        output = io.StringIO()
+        with patch.object(MODULE, "run_json", side_effect=api), patch("sys.argv", argv), patch("sys.stdout", output):
+            MODULE.main()
+        return json.loads(output.getvalue()), calls
+
+    def test_explicit_policy_requires_success_and_review(self):
+        report, calls = self.run_report()
+        self.assertTrue(report["landing_candidate"])
+        self.assertTrue(any("/rules/branches/" in c[-1] for c in calls))
+        self.assertFalse(any("--required" in c for c in calls))
+        report, _ = self.run_report(review=False)
+        self.assertFalse(report["landing_candidate"])
+
+    def test_default_does_not_turn_absent_policy_into_unprotected(self):
+        with self.assertRaisesRegex(SystemExit, "cannot establish required check policy"):
+            self.run_report(explicit=False)
+
+    def test_default_ruleset_policy_is_used_by_main(self):
+        rule = {"type": "required_status_checks", "parameters": {
+            "required_status_checks": [{"context": "reproduce"}]}}
+        report, calls = self.run_report(explicit=False, protected=True, rules=[rule])
+        self.assertTrue(report["landing_candidate"])
+        self.assertEqual(report["check_policy"], "classic-and-active-rulesets")
+        report, _ = self.run_report(explicit=False, protected=True, rules=[rule], checks=[])
+        self.assertFalse(report["landing_candidate"])
+
+    def test_protection_and_unknown_state_refused(self):
+        for protected, rules in [(True, []), (None, []), (False, [{}]), (False, {})]:
+            with self.subTest(protected=protected, rules=rules), self.assertRaises(SystemExit):
+                self.run_report(protected=protected, rules=rules)
+
+    def test_missing_or_non_success_checks_refused(self):
+        for state, bucket in [("FAILURE", "fail"), ("PENDING", "pending"), ("SKIPPED", "pass"), ("NEUTRAL", "pass"), ("SUCCESS", "unknown")]:
+            with self.subTest(state=state, bucket=bucket):
+                report, _ = self.run_report(checks=[dict(name="reproduce", state=state, bucket=bucket)])
+                self.assertFalse(report["landing_candidate"])
+        report, _ = self.run_report(checks=[])
+        self.assertFalse(report["landing_candidate"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/review/test_pr_landing_readiness.py
+++ b/scripts/review/test_pr_landing_readiness.py
@@ -163,14 +163,31 @@ class GitHubCommandBoundaryTests(unittest.TestCase):
                 MODULE.encoded_branch(branch)
 
     def test_run_json_refuses_unknown_command_shape_before_execution(self):
-        with patch.object(MODULE.subprocess, "run") as run, self.assertRaises(SystemExit):
-            MODULE.run_json(["python3", "-c", "print('not gh')"])
-        run.assert_not_called()
+        MODULE.validate_gh_command([
+            "gh", "api", "repos/example/repo/rules/branches/codex%2Freview-fix",
+        ])
+        commands = (
+            ["python3", "-c", "print('not gh')"],
+            ["gh", "api", "repos/../x"],
+            ["gh", "api", "repos/onlyone"],
+            ["gh", "api", "repos/example/repo/branches/main", "--method", "DELETE"],
+            ["gh", "api", "graphql", "-f", "query=mutation{deleteRepository}"],
+            ["gh", "pr", "view", "30", "--repo", "example/repo", "--json", "url", "--web"],
+        )
+        for command in commands:
+            with self.subTest(command=command), patch.object(MODULE.subprocess, "run") as run:
+                with self.assertRaises(SystemExit):
+                    MODULE.run_json(command)
+                run.assert_not_called()
 
     def test_run_json_timeout_and_output_ceiling_fail_closed(self):
+        command = [
+            "gh", "api", "graphql", "-f", f"query={MODULE.REQUIRED_CONTEXT_QUERY}",
+            "-f", "owner=example", "-f", "name=repo", "-f", "ref=refs/heads/main",
+        ]
         with patch.object(MODULE.subprocess, "run", side_effect=subprocess.TimeoutExpired("gh", 30)):
             with self.assertRaisesRegex(SystemExit, "timed out"):
-                MODULE.run_json(["gh", "api", "graphql"])
+                MODULE.run_json(command)
 
         def oversized(*args, **kwargs):
             kwargs["stdout"].write(b"x" * (MODULE.MAX_JSON_BYTES + 1))
@@ -178,7 +195,7 @@ class GitHubCommandBoundaryTests(unittest.TestCase):
 
         with patch.object(MODULE.subprocess, "run", side_effect=oversized):
             with self.assertRaisesRegex(SystemExit, "byte limit"):
-                MODULE.run_json(["gh", "api", "graphql"])
+                MODULE.run_json(command)
 
 
 class RequiredContextTests(unittest.TestCase):

--- a/scripts/review/test_pr_landing_readiness.py
+++ b/scripts/review/test_pr_landing_readiness.py
@@ -4,6 +4,7 @@ import json
 import pathlib
 import unittest
 import io
+import subprocess
 from unittest.mock import patch
 
 
@@ -24,7 +25,7 @@ class VerdictTests(unittest.TestCase):
         self.assertIsNone(MODULE.verdict("Verdict: NOT READY"))
 
     def test_quota_comment_is_not_a_review(self):
-        body = "Review rate limited; unable to review. Mark READY when quota resets."
+        body = "Review rate limited; unable to review.\nREADY"
         self.assertIsNone(MODULE.verdict(body))
 
     def test_ready_in_prose_is_not_a_verdict(self):
@@ -105,6 +106,80 @@ class CandidateBindingTests(unittest.TestCase):
         body = "<!-- assay-review-record -->\n```json\n" + json.dumps(record) + "\n```"
         self.assertIsNone(MODULE.machine_review_candidate(body, "owner"))
 
+    def machine_body(self, verdict, instance):
+        record = {
+            "schema": "assay.review-record.v0",
+            "head_sha": "b" * 40,
+            "review_completed": True,
+            "verdict": verdict,
+            "reviewer": {
+                "agent": "claude",
+                "instance": instance,
+                "github_login": "owner",
+            },
+            "independence": {
+                "did_not_build": True,
+                "did_not_author_governing_spec": True,
+            },
+        }
+        return "<!-- assay-review-record -->\n```json\n" + json.dumps(record) + "\n```"
+
+    def test_invalid_identity_does_not_erase_a_blocked_record(self):
+        body = self.machine_body("BLOCKED", "session 42")
+        rows = MODULE.review_candidates({
+            "reviews": [],
+            "comments": [{"author": {"login": "owner"}, "body": body}],
+        }, "b" * 40)
+
+        self.assertEqual(rows[0]["verdict"], "BLOCKED")
+        self.assertTrue(rows[0]["current_head"])
+        self.assertIsNone(rows[0]["reviewer_identity"])
+
+    def test_invalid_machine_ready_cannot_fall_back_to_prose(self):
+        body = self.machine_body("READY", "session 42") + "\nREADY\n" + "b" * 40
+        rows = MODULE.review_candidates({
+            "reviews": [],
+            "comments": [{"author": {"login": "owner"}, "body": body}],
+        }, "b" * 40)
+
+        self.assertEqual(rows, [])
+
+    def test_markdown_atom_escapes_control_and_delimiter_characters(self):
+        rendered = MODULE.markdown_atom("CI`\n- blockers:\n  - none")
+        self.assertNotIn("\n", rendered)
+        self.assertNotIn("`", rendered)
+        self.assertIn("\\n", rendered)
+
+
+class GitHubCommandBoundaryTests(unittest.TestCase):
+    def test_repository_and_branch_inputs_are_validated(self):
+        self.assertEqual(MODULE.parse_repo("example/repo"), ("example", "repo"))
+        self.assertEqual(MODULE.encoded_branch("codex/review-fix"), "codex%2Freview-fix")
+        for repo in ("owner/repo/extra", "-owner/repo", "owner/repo\n--help"):
+            with self.subTest(repo=repo), self.assertRaises(SystemExit):
+                MODULE.parse_repo(repo)
+        for branch in ("../main", "refs//heads", "topic@{1}", "topic\n--help"):
+            with self.subTest(branch=branch), self.assertRaises(SystemExit):
+                MODULE.encoded_branch(branch)
+
+    def test_run_json_refuses_unknown_command_shape_before_execution(self):
+        with patch.object(MODULE.subprocess, "run") as run, self.assertRaises(SystemExit):
+            MODULE.run_json(["python3", "-c", "print('not gh')"])
+        run.assert_not_called()
+
+    def test_run_json_timeout_and_output_ceiling_fail_closed(self):
+        with patch.object(MODULE.subprocess, "run", side_effect=subprocess.TimeoutExpired("gh", 30)):
+            with self.assertRaisesRegex(SystemExit, "timed out"):
+                MODULE.run_json(["gh", "api", "graphql"])
+
+        def oversized(*args, **kwargs):
+            kwargs["stdout"].write(b"x" * (MODULE.MAX_JSON_BYTES + 1))
+            return subprocess.CompletedProcess(args[0], 0)
+
+        with patch.object(MODULE.subprocess, "run", side_effect=oversized):
+            with self.assertRaisesRegex(SystemExit, "byte limit"):
+                MODULE.run_json(["gh", "api", "graphql"])
+
 
 class RequiredContextTests(unittest.TestCase):
     def test_missing_required_context_is_reported(self):
@@ -160,11 +235,13 @@ class RulesetPolicyTests(unittest.TestCase):
 
 class UnprotectedPolicyTests(unittest.TestCase):
     def run_report(self, *, explicit=True, protected=False, rules=None, checks=None,
-                   review=True, blocked=False):
+                   review=True, blocked=False, state="OPEN", draft=False,
+                   mergeable="MERGEABLE", body_current=True):
         head = "b" * 40
-        pr = dict(number=30, title="test", state="OPEN", isDraft=False,
-                  mergeable="MERGEABLE", headRefOid=head, baseRefOid="a" * 40,
-                  baseRefName="main", body=head, reviews=[], comments=[])
+        pr = dict(number=30, title="test", state=state, isDraft=draft,
+                  mergeable=mergeable, headRefOid=head, baseRefOid="a" * 40,
+                  baseRefName="main", body=head if body_current else "no pinned head",
+                  reviews=[], comments=[])
         if review:
             pr["comments"] = [{"author": {"login": "reviewer"}, "body": f"READY\n{head}"}]
         if blocked:
@@ -208,6 +285,19 @@ class UnprotectedPolicyTests(unittest.TestCase):
         report, _ = self.run_report(blocked=True)
         self.assertFalse(report["landing_candidate"])
         self.assertIn("current-head BLOCKED review exists", report["blockers"])
+
+    def test_pr_state_draft_mergeability_and_body_pin_each_block(self):
+        cases = (
+            ({"state": "CLOSED"}, "PR state is CLOSED"),
+            ({"draft": True}, "PR is draft"),
+            ({"mergeable": "CONFLICTING"}, "mergeable=CONFLICTING"),
+            ({"body_current": False}, "PR body does not mention current head SHA"),
+        )
+        for kwargs, blocker in cases:
+            with self.subTest(kwargs=kwargs):
+                report, _ = self.run_report(**kwargs)
+                self.assertFalse(report["landing_candidate"])
+                self.assertIn(blocker, report["blockers"])
 
     def test_default_does_not_turn_absent_policy_into_unprotected(self):
         with self.assertRaisesRegex(SystemExit, "cannot establish required check policy"):

--- a/scripts/review/test_pr_landing_readiness.py
+++ b/scripts/review/test_pr_landing_readiness.py
@@ -28,6 +28,10 @@ class VerdictTests(unittest.TestCase):
         body = "Review rate limited; unable to review.\nREADY"
         self.assertIsNone(MODULE.verdict(body))
 
+    def test_quota_words_do_not_erase_a_blocked_verdict(self):
+        self.assertEqual(MODULE.verdict("BLOCKED\nA quota limit affected a secondary check."),
+                         "BLOCKED")
+
     def test_ready_in_prose_is_not_a_verdict(self):
         self.assertIsNone(MODULE.verdict("The branch may be ready after CI."))
 
@@ -110,6 +114,7 @@ class CandidateBindingTests(unittest.TestCase):
         record = {
             "schema": "assay.review-record.v0",
             "head_sha": "b" * 40,
+            "builder": {"agent": "ruley", "instance": "writer"},
             "review_completed": True,
             "verdict": verdict,
             "reviewer": {
@@ -121,6 +126,8 @@ class CandidateBindingTests(unittest.TestCase):
                 "did_not_build": True,
                 "did_not_author_governing_spec": True,
             },
+            "findings": [],
+            "no_findings": True,
         }
         return "<!-- assay-review-record -->\n```json\n" + json.dumps(record) + "\n```"
 
@@ -142,7 +149,51 @@ class CandidateBindingTests(unittest.TestCase):
             "comments": [{"author": {"login": "owner"}, "body": body}],
         }, "b" * 40)
 
-        self.assertEqual(rows, [])
+        self.assertEqual(rows[0]["verdict"], "BLOCKED")
+        self.assertTrue(rows[0]["current_head"])
+
+    def test_current_machine_carrier_with_invalid_contract_blocks(self):
+        current = "b" * 40
+        cases = (
+            self.machine_body("READY", "reviewer").replace('"builder": {"agent": "ruley", "instance": "writer"}, ', ""),
+            self.machine_body("blocked", "reviewer"),
+            "<!-- assay-review-record -->\n```json\n{\"head_sha\": \"" + current + "\",\n```",
+        )
+        for body in cases:
+            with self.subTest(body=body):
+                rows = MODULE.review_candidates({
+                    "headRefName": "codex/review-fix",
+                    "reviews": [],
+                    "comments": [{"author": {"login": "owner"}, "body": body}],
+                }, current)
+                self.assertEqual(rows[0]["verdict"], "BLOCKED")
+                self.assertTrue(rows[0]["current_head"])
+
+    def test_machine_blocked_is_not_erased_by_unavailable_words(self):
+        body = self.machine_body("BLOCKED", "reviewer").replace(
+            "\n```", "\n```\nquota limit prevented a second check")
+        rows = MODULE.review_candidates({
+            "headRefName": "codex/review-fix",
+            "reviews": [],
+            "comments": [{"author": {"login": "owner"}, "body": body}],
+        }, "b" * 40)
+        self.assertEqual(rows[0]["verdict"], "BLOCKED")
+
+    def test_review_state_is_part_of_the_verdict(self):
+        head = "b" * 40
+        pr = {
+            "reviews": [
+                {"state": "DISMISSED", "author": {"login": "old"},
+                 "commit": {"oid": head}, "body": f"READY\n{head}"},
+                {"state": "CHANGES_REQUESTED", "author": {"login": "blocker"},
+                 "commit": {"oid": head}, "body": "Please repair this."},
+            ],
+            "comments": [],
+        }
+        rows = MODULE.review_candidates(pr, head)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["verdict"], "BLOCKED")
+        self.assertEqual(rows[0]["record_author"], "blocker")
 
     def test_markdown_atom_escapes_control_and_delimiter_characters(self):
         rendered = MODULE.markdown_atom("CI`\n- blockers:\n  - none")
@@ -168,11 +219,14 @@ class GitHubCommandBoundaryTests(unittest.TestCase):
         ])
         commands = (
             ["python3", "-c", "print('not gh')"],
+            ["not-gh", "api", "graphql", "-f", f"query={MODULE.REQUIRED_CONTEXT_QUERY}",
+             "-f", "owner=example", "-f", "name=repo", "-f", "ref=refs/heads/main"],
             ["gh", "api", "repos/../x"],
             ["gh", "api", "repos/onlyone"],
             ["gh", "api", "repos/example/repo/branches/main", "--method", "DELETE"],
             ["gh", "api", "graphql", "-f", "query=mutation{deleteRepository}"],
             ["gh", "pr", "view", "30", "--repo", "example/repo", "--json", "url", "--web"],
+            ["gh", "pr", "checks", "30", "--repo", "example/repo", "--required", "--json", MODULE.PR_CHECK_FIELDS, "--watch"],
         )
         for command in commands:
             with self.subTest(command=command), patch.object(MODULE.subprocess, "run") as run:
@@ -185,7 +239,11 @@ class GitHubCommandBoundaryTests(unittest.TestCase):
             "gh", "api", "graphql", "-f", f"query={MODULE.REQUIRED_CONTEXT_QUERY}",
             "-f", "owner=example", "-f", "name=repo", "-f", "ref=refs/heads/main",
         ]
-        with patch.object(MODULE.subprocess, "run", side_effect=subprocess.TimeoutExpired("gh", 30)):
+        def times_out(*args, **kwargs):
+            self.assertEqual(kwargs.get("timeout"), MODULE.COMMAND_TIMEOUT_SECONDS)
+            raise subprocess.TimeoutExpired("gh", 30)
+
+        with patch.object(MODULE.subprocess, "run", side_effect=times_out):
             with self.assertRaisesRegex(SystemExit, "timed out"):
                 MODULE.run_json(command)
 
@@ -253,11 +311,13 @@ class RulesetPolicyTests(unittest.TestCase):
 class UnprotectedPolicyTests(unittest.TestCase):
     def run_report(self, *, explicit=True, protected=False, rules=None, checks=None,
                    review=True, blocked=False, state="OPEN", draft=False,
-                   mergeable="MERGEABLE", body_current=True):
+                   mergeable="MERGEABLE", body_current=True, number=30,
+                   output_format="json"):
         head = "b" * 40
-        pr = dict(number=30, title="test", state=state, isDraft=draft,
+        pr = dict(number=number, title="test", state=state, isDraft=draft,
                   mergeable=mergeable, headRefOid=head, baseRefOid="a" * 40,
-                  baseRefName="main", body=head if body_current else "no pinned head",
+                  baseRefName="main", headRefName="codex/review-fix",
+                  body=head if body_current else "no pinned head",
                   reviews=[], comments=[])
         if review:
             pr["comments"] = [{"author": {"login": "reviewer"}, "body": f"READY\n{head}"}]
@@ -282,13 +342,14 @@ class UnprotectedPolicyTests(unittest.TestCase):
             if args[-1].endswith("/branches/main"):
                 return {"protected": protected}
             raise AssertionError(args)
-        argv = ["readiness", "30", "--repo", "example/repo", "--format", "json"]
+        argv = ["readiness", "30", "--repo", "example/repo", "--format", output_format]
         if explicit:
             argv += ["--unprotected-require-check", "reproduce"]
         output = io.StringIO()
         with patch.object(MODULE, "run_json", side_effect=api), patch("sys.argv", argv), patch("sys.stdout", output):
             MODULE.main()
-        return json.loads(output.getvalue()), calls
+        rendered = output.getvalue()
+        return (json.loads(rendered) if output_format == "json" else rendered), calls
 
     def test_explicit_policy_requires_success_and_review(self):
         report, calls = self.run_report()
@@ -328,6 +389,16 @@ class UnprotectedPolicyTests(unittest.TestCase):
         self.assertEqual(report["check_policy"], "classic-and-active-rulesets")
         report, _ = self.run_report(explicit=False, protected=True, rules=[rule], checks=[])
         self.assertFalse(report["landing_candidate"])
+        report, _ = self.run_report(
+            explicit=False, protected=True, rules=[rule],
+            checks=[dict(name="reproduce", state="SKIPPED", bucket="pass")],
+        )
+        self.assertFalse(report["landing_candidate"])
+
+    def test_markdown_title_contains_untrusted_pr_number(self):
+        report, _ = self.run_report(number="30\n## VERDICT\nREADY", output_format="md")
+        self.assertNotIn("\n## VERDICT\nREADY", report)
+        self.assertIn("\\n", report.splitlines()[0])
 
     def test_protection_and_unknown_state_refused(self):
         for protected, rules in [(True, []), (None, []), (False, [{}]), (False, {})]:

--- a/scripts/review/test_pr_landing_readiness.py
+++ b/scripts/review/test_pr_landing_readiness.py
@@ -77,7 +77,8 @@ class CandidateBindingTests(unittest.TestCase):
         }
 
         self.assertEqual(MODULE.review_candidates(pr, current), [{
-            "author": "Rul1an",
+            "record_author": "Rul1an",
+            "reviewer_identity": "claude/reviewer",
             "verdict": "READY",
             "bound_sha": current,
             "current_head": True,

--- a/scripts/review/test_review_relay.py
+++ b/scripts/review/test_review_relay.py
@@ -27,7 +27,8 @@ if case=='carrier-only': body='READY\\n'+head+'\\nRelay: '+os.environ['URL']
 if args[:2]==['pr','view']:
  print(json.dumps(dict(number=30,author={'login':'owner'},state='OPEN',isDraft=False,
  mergeable='MERGEABLE',headRefOid=head,baseRefOid='a'*40,baseRefName='main',body=head,
- comments=[{'author':{'login':'owner'},'body':'READY\\n'+head}])))
+ comments=[{'author':{'login':'other' if case=='candidate-author-mismatch' else 'owner'},
+            'body':'READY\\n'+head}])))
 elif args[:2]==['pr','checks']:
  print(json.dumps([dict(name='CI',state='SUCCESS',bucket='pass')]))
 elif args[:2]==['pr','merge']:
@@ -48,7 +49,8 @@ class RelayProtocol(unittest.TestCase):
     def test_relay_acceptance_and_fail_closed_matrix(self):
         for case in ('valid', 'wrong-head', 'blocked', 'incomplete',
                      'no-independence', 'wrong-identity', 'carrier-only',
-                     'unavailable', 'wrong-author', 'missing-url', 'ambiguous'):
+                     'unavailable', 'wrong-author', 'missing-url', 'ambiguous',
+                     'candidate-author-mismatch'):
             with self.subTest(case=case), tempfile.TemporaryDirectory() as directory:
                 root = pathlib.Path(directory)
                 gh = root / 'gh'

--- a/scripts/review/test_review_relay.py
+++ b/scripts/review/test_review_relay.py
@@ -1,0 +1,75 @@
+"""Synthetic protocol tests only: gh is replaced; no real merge is possible."""
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parent
+HEAD = 'b' * 40
+URL = 'https://github.com/example/repo/pull/30#issuecomment-123'
+
+GH = '''#!/usr/bin/env python3
+import json, os, sys
+args=sys.argv[1:]; case=os.environ['CASE']; head='b'*40
+record={'schema':'assay.review-record.v0','head_sha':head,'review_completed':True,
+ 'verdict':'READY','reviewer':{'agent':'claude','instance':'independent-123','github_login':'owner'},
+ 'independence':{'did_not_build':True,'did_not_author_governing_spec':True},
+ 'findings':[], 'no_findings':True}
+if case=='wrong-head': record['head_sha']='a'*40
+if case=='blocked': record['verdict']='BLOCKED'
+if case=='incomplete': record['review_completed']=False
+if case=='no-independence': record.pop('independence')
+if case=='wrong-identity': record['reviewer']['instance']='other'
+body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(record)+'\\n```'
+if case=='carrier-only': body='READY\\n'+head+'\\nRelay: '+os.environ['URL']
+if args[:2]==['pr','view']:
+ print(json.dumps(dict(number=30,author={'login':'owner'},state='OPEN',isDraft=False,
+ mergeable='MERGEABLE',headRefOid=head,baseRefOid='a'*40,baseRefName='main',body=head,
+ comments=[{'author':{'login':'owner'},'body':'READY\\n'+head}])))
+elif args[:2]==['pr','checks']:
+ print(json.dumps([dict(name='CI',state='SUCCESS',bucket='pass')]))
+elif args[:2]==['pr','merge']:
+ pathlib_missing=None
+ open(os.environ['MERGE_LOG'],'w').write(json.dumps(args))
+elif args[:2]==['api','graphql']:
+ print(json.dumps({'data':{'repository':{'ref':{'branchProtectionRule':{'requiredStatusCheckContexts':['CI']}}}}}))
+elif '--slurp' in args: print('[[]]')
+elif args[:2]==['api','repos/example/repo/issues/comments/123']:
+ if case=='unavailable': sys.exit(1)
+ print(json.dumps({'id':123,'html_url':os.environ['URL'],
+ 'issue_url':'https://api.github.com/repos/example/repo/issues/30',
+ 'user':{'login':'other' if case=='wrong-author' else 'owner'},'body':body}))
+else: sys.exit('unexpected gh argv: '+repr(args))
+'''
+
+class RelayProtocol(unittest.TestCase):
+    def test_relay_acceptance_and_fail_closed_matrix(self):
+        for case in ('valid', 'wrong-head', 'blocked', 'incomplete',
+                     'no-independence', 'wrong-identity', 'carrier-only',
+                     'unavailable', 'wrong-author', 'missing-url', 'ambiguous'):
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as directory:
+                root = pathlib.Path(directory)
+                gh = root / 'gh'
+                gh.write_text(GH)
+                gh.chmod(0o755)
+                log = root / 'merge.json'
+                env = dict(os.environ, PATH=str(root)+os.pathsep+os.environ['PATH'],
+                           CASE=case, MERGE_LOG=str(log), URL=URL)
+                cmd = ['bash', str(ROOT/'safe_merge.sh'), '30', '--repo', 'example/repo',
+                       '--record-author', 'owner', '--reviewer-identity',
+                       'owner' if case=='ambiguous' else 'claude/independent-123',
+                       '--confirm-findings-disposed', '--merge']
+                if case != 'missing-url': cmd += ['--review-evidence-url', URL]
+                result = subprocess.run(cmd, env=env, text=True, capture_output=True, timeout=15)
+                self.assertEqual(result.returncode == 0, case == 'valid', result.stderr)
+                self.assertEqual(log.exists(), case == 'valid', result.stdout)
+                if case == 'valid':
+                    self.assertIn('Record author: owner', result.stdout)
+                    self.assertIn('Reviewing identity: claude/independent-123', result.stdout)
+                    self.assertIn('declares', result.stdout)
+                    self.assertNotIn('attests reviewer owner is independent', result.stdout)
+                    self.assertEqual(json.loads(log.read_text())[-2:], ['--match-head-commit', HEAD])
+
+if __name__ == '__main__': unittest.main()

--- a/scripts/review/test_review_relay.py
+++ b/scripts/review/test_review_relay.py
@@ -14,6 +14,7 @@ GH = '''#!/usr/bin/env python3
 import json, os, sys
 args=sys.argv[1:]; case=os.environ['CASE']; head='b'*40
 record={'schema':'assay.review-record.v0','head_sha':head,'review_completed':True,
+ 'builder':{'agent':'codex','instance':'writer'},
  'verdict':'READY','reviewer':{'agent':'claude','instance':'independent-123','github_login':'owner'},
  'independence':{'did_not_build':True,'did_not_author_governing_spec':True},
  'findings':[], 'no_findings':True}
@@ -22,7 +23,17 @@ if case=='blocked': record['verdict']='BLOCKED'
 if case=='incomplete': record['review_completed']=False
 if case=='no-independence': record.pop('independence')
 if case=='wrong-identity': record['reviewer']['instance']='other'
+if case=='same-builder': record['reviewer']={'agent':'codex','instance':'writer','github_login':'owner'}
+if case=='missing-builder': record.pop('builder')
 body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(record)+'\\n```'
+fetched_body=body
+if case in ('fetched-blocked','fetched-stale','fetched-identity-mismatch','fetched-login-mismatch'):
+ fetched=dict(record)
+ if case=='fetched-blocked': fetched['verdict']='BLOCKED'
+ if case=='fetched-stale': fetched['head_sha']='a'*40
+ if case=='fetched-identity-mismatch': fetched['reviewer']=dict(record['reviewer'],instance='other')
+ if case=='fetched-login-mismatch': fetched['reviewer']=dict(record['reviewer'],github_login='other')
+ fetched_body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(fetched)+'\\n```'
 if case=='carrier-only': body='READY\\n'+head+'\\nRelay: '+os.environ['URL']
 if args[:2]==['pr','view']:
  candidate_body=body
@@ -46,7 +57,7 @@ if args[:2]==['pr','view']:
   helper_body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(helper)+'\\n```'
   comments.append({'author':{'login':'helper'},'body':helper_body})
  print(json.dumps(dict(number=30,author={'login':'owner'},state='OPEN',isDraft=False,
- mergeable='MERGEABLE',headRefOid=head,baseRefOid='a'*40,baseRefName='main',body=head,
+ mergeable='MERGEABLE',headRefOid=head,headRefName='codex/review-fix',baseRefOid='a'*40,baseRefName='main',body=head,
  comments=comments)))
 elif args[:2]==['pr','checks']:
  print(json.dumps([dict(name='CI',state='SUCCESS',bucket='pass')]))
@@ -60,7 +71,7 @@ elif args[:2]==['api','repos/example/repo/issues/comments/123']:
  if case=='unavailable': sys.exit(1)
  print(json.dumps({'id':123,'html_url':os.environ['URL'],
  'issue_url':'https://api.github.com/repos/example/repo/issues/30',
- 'user':{'login':'other' if case=='wrong-author' else 'owner'},'body':body}))
+ 'user':{'login':'other' if case=='wrong-author' else 'owner'},'body':fetched_body}))
 else: sys.exit('unexpected gh argv: '+repr(args))
 '''
 
@@ -70,20 +81,28 @@ class RelayProtocol(unittest.TestCase):
                      'no-independence', 'wrong-identity', 'carrier-only',
                      'unavailable', 'wrong-author', 'missing-url', 'ambiguous',
                      'candidate-author-mismatch', 'candidate-blocked',
-                     'candidate-stale', 'candidate-identity-mismatch'):
+                     'candidate-stale', 'candidate-identity-mismatch',
+                     'same-builder', 'missing-builder', 'wrong-repo-url',
+                     'url-query', 'no-confirm', 'fetched-blocked',
+                     'fetched-stale', 'fetched-identity-mismatch',
+                     'fetched-login-mismatch'):
             with self.subTest(case=case), tempfile.TemporaryDirectory() as directory:
                 root = pathlib.Path(directory)
                 gh = root / 'gh'
                 gh.write_text(GH)
                 gh.chmod(0o755)
                 log = root / 'merge.json'
+                url = URL
+                if case == 'wrong-repo-url': url = 'https://github.com/other/repo/pull/30#issuecomment-123'
+                if case == 'url-query': url = URL.replace('#', '?x=1#')
                 env = dict(os.environ, PATH=str(root)+os.pathsep+os.environ['PATH'],
-                           CASE=case, MERGE_LOG=str(log), URL=URL)
+                           CASE=case, MERGE_LOG=str(log), URL=url)
                 cmd = ['bash', str(ROOT/'safe_merge.sh'), '30', '--repo', 'example/repo',
                        '--record-author', 'owner', '--reviewer-identity',
                        'owner' if case=='ambiguous' else 'claude/independent-123',
-                       '--confirm-findings-disposed', '--merge']
-                if case != 'missing-url': cmd += ['--review-evidence-url', URL]
+                       '--merge']
+                if case != 'no-confirm': cmd.insert(-1, '--confirm-findings-disposed')
+                if case != 'missing-url': cmd += ['--review-evidence-url', url]
                 result = subprocess.run(cmd, env=env, text=True, capture_output=True, timeout=15)
                 self.assertEqual(result.returncode == 0, case == 'valid', result.stderr)
                 self.assertEqual(log.exists(), case == 'valid', result.stdout)

--- a/scripts/review/test_review_relay.py
+++ b/scripts/review/test_review_relay.py
@@ -25,10 +25,29 @@ if case=='wrong-identity': record['reviewer']['instance']='other'
 body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(record)+'\\n```'
 if case=='carrier-only': body='READY\\n'+head+'\\nRelay: '+os.environ['URL']
 if args[:2]==['pr','view']:
+ candidate_body=body
+ if case=='candidate-blocked':
+  candidate_record=dict(record); candidate_record['verdict']='BLOCKED'
+  candidate_body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(candidate_record)+'\\n```'
+ if case=='candidate-stale':
+  candidate_record=dict(record); candidate_record['head_sha']='a'*40
+  candidate_body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(candidate_record)+'\\n```'
+ if case=='candidate-identity-mismatch':
+  candidate_record=dict(record); candidate_record['reviewer']=dict(record['reviewer'],instance='other')
+  candidate_body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(candidate_record)+'\\n```'
+ candidate_author='owner'
+ if case=='candidate-author-mismatch':
+  candidate_record=dict(record); candidate_record['reviewer']=dict(record['reviewer'],github_login='other')
+  candidate_body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(candidate_record)+'\\n```'
+  candidate_author='other'
+ comments=[{'author':{'login':candidate_author},'body':candidate_body}]
+ if case=='candidate-stale':
+  helper=dict(record); helper['reviewer']=dict(record['reviewer'],instance='helper',github_login='helper')
+  helper_body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(helper)+'\\n```'
+  comments.append({'author':{'login':'helper'},'body':helper_body})
  print(json.dumps(dict(number=30,author={'login':'owner'},state='OPEN',isDraft=False,
  mergeable='MERGEABLE',headRefOid=head,baseRefOid='a'*40,baseRefName='main',body=head,
- comments=[{'author':{'login':'other' if case=='candidate-author-mismatch' else 'owner'},
-            'body':'READY\\n'+head}])))
+ comments=comments)))
 elif args[:2]==['pr','checks']:
  print(json.dumps([dict(name='CI',state='SUCCESS',bucket='pass')]))
 elif args[:2]==['pr','merge']:
@@ -50,7 +69,8 @@ class RelayProtocol(unittest.TestCase):
         for case in ('valid', 'wrong-head', 'blocked', 'incomplete',
                      'no-independence', 'wrong-identity', 'carrier-only',
                      'unavailable', 'wrong-author', 'missing-url', 'ambiguous',
-                     'candidate-author-mismatch'):
+                     'candidate-author-mismatch', 'candidate-blocked',
+                     'candidate-stale', 'candidate-identity-mismatch'):
             with self.subTest(case=case), tempfile.TemporaryDirectory() as directory:
                 root = pathlib.Path(directory)
                 gh = root / 'gh'

--- a/scripts/review/test_safe_merge_protocol.py
+++ b/scripts/review/test_safe_merge_protocol.py
@@ -2,8 +2,14 @@ import json, os, pathlib, shutil, subprocess, tempfile
 source = pathlib.Path(__file__).resolve().parent
 with tempfile.TemporaryDirectory(prefix='safe-merge-protocol-') as d:
     root = pathlib.Path(d)
+    review = root / 'scripts' / 'review'
+    ci = root / 'scripts' / 'ci'
+    review.mkdir(parents=True)
+    ci.mkdir(parents=True)
     for name in ('safe_merge.sh', 'pr_landing_readiness.py', 'verify_review_identity.py'):
-        shutil.copy2(source / name, root / name)
+        shutil.copy2(source / name, review / name)
+    shutil.copy2(source.parent / 'ci' / 'assay_review_record_check.py',
+                 ci / 'assay_review_record_check.py')
     gh = root / 'gh'
     gh.write_text('''#!/usr/bin/env python3
 import json,os,sys
@@ -11,15 +17,15 @@ args=sys.argv[1:]
 head='b'*40
 case=os.environ['CASE']
 if args[:2]==['pr','view']:
- record=dict(schema='assay.review-record.v0',head_sha='a'*40 if case=='stale' else head,review_completed=True,verdict='BLOCKED' if case=='blocked' else 'READY',reviewer=dict(agent='claude',instance='other' if case=='identity-mismatch' else 'reviewer',github_login='reviewer'),independence=dict(did_not_build=True,did_not_author_governing_spec=True))
+ record=dict(schema='assay.review-record.v0',head_sha='a'*40 if case=='stale' else head,review_completed=True,verdict='BLOCKED' if case=='blocked' else 'READY',builder=dict(agent='codex',instance='writer'),reviewer=dict(agent='claude',instance='other' if case=='identity-mismatch' else 'reviewer',github_login='reviewer'),independence=dict(did_not_build=True,did_not_author_governing_spec=True),findings=[],no_findings=True)
  body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(record)+'\\n```'
- print(json.dumps(dict(number=30,author=dict(login='owner'),state='OPEN',isDraft=False,mergeable='MERGEABLE',headRefOid=head,baseRefOid='a'*40,baseRefName='main',body=head,comments=[] if case=='no-review' else [dict(author=dict(login='reviewer'),body=body)])))
+ print(json.dumps(dict(number=30,author=dict(login='owner'),state='OPEN',isDraft=False,mergeable='MERGEABLE',headRefOid=head,headRefName='codex/review-fix',baseRefOid='a'*40,baseRefName='main',body=head,comments=[] if case=='no-review' else [dict(author=dict(login='reviewer'),body=body)])))
 elif args[:2]==['pr','checks']:
  print(json.dumps([dict(name='reproduce',state='SKIPPED' if case=='skipped' else 'SUCCESS',bucket='pass')]))
 elif args[:2]==['pr','merge']:
  open(os.environ['MERGE_LOG'],'w').write(json.dumps(args))
 elif args[:2]==['api','repos/example/repo/issues/comments/123']:
- record=dict(schema='assay.review-record.v0',head_sha=head,review_completed=True,verdict='READY',reviewer=dict(agent='claude',instance='reviewer',github_login='reviewer'),independence=dict(did_not_build=True,did_not_author_governing_spec=True))
+ record=dict(schema='assay.review-record.v0',head_sha=head,review_completed=True,verdict='READY',builder=dict(agent='codex',instance='writer'),reviewer=dict(agent='claude',instance='reviewer',github_login='reviewer'),independence=dict(did_not_build=True,did_not_author_governing_spec=True),findings=[],no_findings=True)
  print(json.dumps(dict(html_url='https://github.com/example/repo/pull/30#issuecomment-123',issue_url='https://api.github.com/repos/example/repo/issues/30',user=dict(login='reviewer'),body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(record)+'\\n```')))
 elif args[:2]==['api','graphql']:
  print(json.dumps(dict(data=dict(repository=dict(ref=dict(branchProtectionRule=None if case=='ruleset' else dict(requiredStatusCheckContexts=['reproduce'])))))))
@@ -36,7 +42,7 @@ else: raise SystemExit('unexpected gh arguments: '+repr(args))
         log=root/'merge.json'
         log.unlink(missing_ok=True)
         env=dict(os.environ, PATH=str(root)+':'+os.environ['PATH'], CASE=case, MERGE_LOG=str(log))
-        args=['/bin/bash', str(root/'safe_merge.sh'), '30','--repo','example/repo','--record-author','reviewer','--reviewer-identity','claude/reviewer','--review-evidence-url','https://github.com/example/repo/pull/30#issuecomment-123','--confirm-findings-disposed','--merge']
+        args=['/bin/bash', str(review/'safe_merge.sh'), '30','--repo','example/repo','--record-author','reviewer','--reviewer-identity','claude/reviewer','--review-evidence-url','https://github.com/example/repo/pull/30#issuecomment-123','--confirm-findings-disposed','--merge']
         if explicit: args += ['--unprotected-require-check','reproduce']
         p=subprocess.run(args,env=env,text=True,capture_output=True)
         expected=case in ('protected','ruleset','unprotected')

--- a/scripts/review/test_safe_merge_protocol.py
+++ b/scripts/review/test_safe_merge_protocol.py
@@ -11,7 +11,9 @@ args=sys.argv[1:]
 head='b'*40
 case=os.environ['CASE']
 if args[:2]==['pr','view']:
- print(json.dumps(dict(number=30,author=dict(login='owner'),state='OPEN',isDraft=False,mergeable='MERGEABLE',headRefOid=head,baseRefOid='a'*40,baseRefName='main',body=head,comments=[] if case=='no-review' else [dict(author=dict(login='reviewer'),body='READY\\n'+head)])))
+ record=dict(schema='assay.review-record.v0',head_sha='a'*40 if case=='stale' else head,review_completed=True,verdict='BLOCKED' if case=='blocked' else 'READY',reviewer=dict(agent='claude',instance='other' if case=='identity-mismatch' else 'reviewer',github_login='reviewer'),independence=dict(did_not_build=True,did_not_author_governing_spec=True))
+ body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(record)+'\\n```'
+ print(json.dumps(dict(number=30,author=dict(login='owner'),state='OPEN',isDraft=False,mergeable='MERGEABLE',headRefOid=head,baseRefOid='a'*40,baseRefName='main',body=head,comments=[] if case=='no-review' else [dict(author=dict(login='reviewer'),body=body)])))
 elif args[:2]==['pr','checks']:
  print(json.dumps([dict(name='reproduce',state='SKIPPED' if case=='skipped' else 'SUCCESS',bucket='pass')]))
 elif args[:2]==['pr','merge']:
@@ -30,7 +32,7 @@ elif args[-1].endswith('/branches/main'): print('{"protected":false}')
 else: raise SystemExit('unexpected gh arguments: '+repr(args))
 ''')
     gh.chmod(0o755)
-    for case, explicit in [('protected',False),('ruleset',False),('unprotected',True),('no-review',True),('skipped',True)]:
+    for case, explicit in [('protected',False),('ruleset',False),('unprotected',True),('no-review',True),('skipped',True),('blocked',True),('stale',True),('identity-mismatch',True)]:
         log=root/'merge.json'
         log.unlink(missing_ok=True)
         env=dict(os.environ, PATH=str(root)+':'+os.environ['PATH'], CASE=case, MERGE_LOG=str(log))

--- a/scripts/review/test_safe_merge_protocol.py
+++ b/scripts/review/test_safe_merge_protocol.py
@@ -1,0 +1,47 @@
+import json, os, pathlib, shutil, subprocess, tempfile
+source = pathlib.Path(__file__).resolve().parent
+with tempfile.TemporaryDirectory(prefix='safe-merge-protocol-') as d:
+    root = pathlib.Path(d)
+    for name in ('safe_merge.sh', 'pr_landing_readiness.py', 'verify_review_identity.py'):
+        shutil.copy2(source / name, root / name)
+    gh = root / 'gh'
+    gh.write_text('''#!/usr/bin/env python3
+import json,os,sys
+args=sys.argv[1:]
+head='b'*40
+case=os.environ['CASE']
+if args[:2]==['pr','view']:
+ print(json.dumps(dict(number=30,author=dict(login='owner'),state='OPEN',isDraft=False,mergeable='MERGEABLE',headRefOid=head,baseRefOid='a'*40,baseRefName='main',body=head,comments=[] if case=='no-review' else [dict(author=dict(login='reviewer'),body='READY\\n'+head)])))
+elif args[:2]==['pr','checks']:
+ print(json.dumps([dict(name='reproduce',state='SKIPPED' if case=='skipped' else 'SUCCESS',bucket='pass')]))
+elif args[:2]==['pr','merge']:
+ open(os.environ['MERGE_LOG'],'w').write(json.dumps(args))
+elif args[:2]==['api','repos/example/repo/issues/comments/123']:
+ record=dict(schema='assay.review-record.v0',head_sha=head,review_completed=True,verdict='READY',reviewer=dict(agent='claude',instance='reviewer',github_login='reviewer'),independence=dict(did_not_build=True,did_not_author_governing_spec=True))
+ print(json.dumps(dict(html_url='https://github.com/example/repo/pull/30#issuecomment-123',issue_url='https://api.github.com/repos/example/repo/issues/30',user=dict(login='reviewer'),body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(record)+'\\n```')))
+elif args[:2]==['api','graphql']:
+ print(json.dumps(dict(data=dict(repository=dict(ref=dict(branchProtectionRule=None if case=='ruleset' else dict(requiredStatusCheckContexts=['reproduce'])))))))
+elif '--slurp' in args:
+ print(json.dumps([[dict(type='required_status_checks',parameters=dict(required_status_checks=[dict(context='reproduce')]))]] if case=='ruleset' else [[]]))
+elif args[-1].endswith('/protection/required_status_checks'):
+ print(json.dumps(dict(contexts=['reproduce'])))
+elif '/rules/branches/' in args[-1]: print('[]')
+elif args[-1].endswith('/branches/main'): print('{"protected":false}')
+else: raise SystemExit('unexpected gh arguments: '+repr(args))
+''')
+    gh.chmod(0o755)
+    for case, explicit in [('protected',False),('ruleset',False),('unprotected',True),('no-review',True),('skipped',True)]:
+        log=root/'merge.json'
+        log.unlink(missing_ok=True)
+        env=dict(os.environ, PATH=str(root)+':'+os.environ['PATH'], CASE=case, MERGE_LOG=str(log))
+        args=['/bin/bash', str(root/'safe_merge.sh'), '30','--repo','example/repo','--record-author','reviewer','--reviewer-identity','claude/reviewer','--review-evidence-url','https://github.com/example/repo/pull/30#issuecomment-123','--confirm-findings-disposed','--merge']
+        if explicit: args += ['--unprotected-require-check','reproduce']
+        p=subprocess.run(args,env=env,text=True,capture_output=True)
+        expected=case in ('protected','ruleset','unprotected')
+        assert (p.returncode==0)==expected,(case,p.stderr)
+        assert log.exists()==expected,case
+        if expected:
+            command=json.loads(log.read_text())
+            assert command[-2:]==['--match-head-commit','b'*40],command
+            assert '--admin' not in command
+        print(case, p.returncode, 'merge-called='+str(log.exists()))

--- a/scripts/review/verify_review_identity.py
+++ b/scripts/review/verify_review_identity.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Validate a linked review declaration; does not authenticate agent identity."""
+import argparse
+import json
+import re
+import subprocess
+import tempfile
+from urllib.parse import urlsplit
+
+from pr_landing_readiness import REVIEW_RECORD_FENCE, REVIEW_RECORD_MARKER
+
+
+def verify(repo, pr, head, record_author, identity, evidence_url, pr_author):
+    url = urlsplit(evidence_url)
+    expected_path = f'/{repo}/pull/{pr}'
+    if (url.scheme != 'https' or url.netloc != 'github.com'
+            or url.path != expected_path or url.query
+            or not re.fullmatch(r'issuecomment-[1-9][0-9]*', url.fragment)):
+        raise ValueError('evidence must be a GitHub comment on this repository and PR')
+    if not identity.strip() or (record_author == pr_author and identity == record_author):
+        raise ValueError('reviewing identity must be explicit and distinct from record author')
+    comment_id = url.fragment.split('-', 1)[1]
+    # Construct a fixed API endpoint, never fetch the caller-supplied URL.
+    with tempfile.TemporaryFile() as out, tempfile.TemporaryFile() as err:
+        result = subprocess.run(
+            ['gh', 'api', f'repos/{repo}/issues/comments/{comment_id}'],
+            stdout=out, stderr=err, timeout=30, check=False,
+        )
+        if result.returncode != 0:
+            raise ValueError('review evidence unavailable')
+        if out.tell() > 262144:
+            raise ValueError('review evidence exceeds byte limit')
+        out.seek(0)
+        comment = json.load(out)
+    if (comment.get('html_url') != evidence_url
+            or comment.get('issue_url') != f'https://api.github.com/repos/{repo}/issues/{pr}'
+            or comment.get('user', {}).get('login') != record_author):
+        raise ValueError('review evidence publisher or PR does not match')
+    body = comment.get('body', '').strip()
+    if not body.startswith(REVIEW_RECORD_MARKER):
+        raise ValueError('evidence is not a completed structured review record')
+    match = REVIEW_RECORD_FENCE.fullmatch(body[len(REVIEW_RECORD_MARKER):].strip())
+    if match is None:
+        raise ValueError('review record envelope is malformed')
+    record = json.loads(match.group(1))
+    reviewer = record.get('reviewer', {})
+    independence = record.get('independence', {})
+    agent_identity = f"{reviewer.get('agent')}/{reviewer.get('instance')}"
+    direct_human = (
+        identity == record_author and record_author != pr_author
+        and reviewer.get('agent') == 'human'
+        and reviewer.get('instance') == record_author
+    )
+    if (record.get('schema') != 'assay.review-record.v0'
+            or record.get('head_sha') != head
+            or record.get('verdict') != 'READY'
+            or record.get('review_completed') is not True
+            or reviewer.get('github_login') != record_author
+            or not isinstance(reviewer.get('agent'), str)
+            or not reviewer.get('agent', '').strip()
+            or not isinstance(reviewer.get('instance'), str)
+            or not reviewer.get('instance', '').strip()
+            or not (agent_identity == identity or direct_human)
+            or independence.get('did_not_build') is not True
+            or independence.get('did_not_author_governing_spec') is not True):
+        raise ValueError('review identity, head, verdict or independence declaration mismatch')
+    builder = record.get('builder', {})
+    if (builder.get('agent'), builder.get('instance')) == (reviewer.get('agent'), reviewer.get('instance')):
+        raise ValueError('reviewer is also the declared builder')
+    print(f'Record author: {record_author}')
+    print(f'Reviewing identity: {identity}')
+    print(f'Review evidence: {evidence_url}')
+    print('The linked record declares a completed non-building review; agent identity is not authenticated by this check.')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    for name in ('repo', 'pr', 'head', 'record-author', 'reviewer-identity', 'review-evidence-url', 'pr-author'):
+        parser.add_argument('--' + name, required=True)
+    args = parser.parse_args()
+    try:
+        verify(args.repo, args.pr, args.head, args.record_author,
+               args.reviewer_identity, args.review_evidence_url, args.pr_author)
+    except (ValueError, TypeError, AttributeError, OSError, subprocess.TimeoutExpired) as error:
+        parser.exit(1, f'BLOCKED: {error}\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/review/verify_review_identity.py
+++ b/scripts/review/verify_review_identity.py
@@ -7,7 +7,11 @@ import subprocess
 import tempfile
 from urllib.parse import urlsplit
 
-from pr_landing_readiness import REVIEW_RECORD_FENCE, REVIEW_RECORD_MARKER
+from pr_landing_readiness import (
+    REVIEW_RECORD_FENCE,
+    REVIEW_RECORD_MARKER,
+    declared_reviewer_identity,
+)
 
 
 def verify(repo, pr, head, record_author, identity, evidence_url, pr_author):
@@ -45,7 +49,7 @@ def verify(repo, pr, head, record_author, identity, evidence_url, pr_author):
     record = json.loads(match.group(1))
     reviewer = record.get('reviewer', {})
     independence = record.get('independence', {})
-    agent_identity = f"{reviewer.get('agent')}/{reviewer.get('instance')}"
+    agent_identity = declared_reviewer_identity(reviewer)
     direct_human = (
         identity == record_author and record_author != pr_author
         and reviewer.get('agent') == 'human'
@@ -56,10 +60,7 @@ def verify(repo, pr, head, record_author, identity, evidence_url, pr_author):
             or record.get('verdict') != 'READY'
             or record.get('review_completed') is not True
             or reviewer.get('github_login') != record_author
-            or not isinstance(reviewer.get('agent'), str)
-            or not reviewer.get('agent', '').strip()
-            or not isinstance(reviewer.get('instance'), str)
-            or not reviewer.get('instance', '').strip()
+            or agent_identity is None
             or not (agent_identity == identity or direct_human)
             or independence.get('did_not_build') is not True
             or independence.get('did_not_author_governing_spec') is not True):

--- a/scripts/review/verify_review_identity.py
+++ b/scripts/review/verify_review_identity.py
@@ -1,21 +1,18 @@
 #!/usr/bin/env python3
 """Validate a linked review declaration; does not authenticate agent identity."""
 import argparse
-import json
 import re
 import subprocess
-import tempfile
 from urllib.parse import urlsplit
 
 from pr_landing_readiness import (
-    REVIEW_RECORD_FENCE,
-    REVIEW_RECORD_MARKER,
     machine_review_candidate,
     parse_repo,
+    run_json,
 )
 
 
-def verify(repo, pr, head, record_author, identity, evidence_url, pr_author):
+def verify(repo, pr, head, branch_ref, record_author, identity, evidence_url, pr_author):
     parse_repo(repo)
     if not re.fullmatch(r"[1-9][0-9]*", str(pr)):
         raise ValueError('PR must be a positive decimal integer')
@@ -25,44 +22,25 @@ def verify(repo, pr, head, record_author, identity, evidence_url, pr_author):
             or url.path != expected_path or url.query
             or not re.fullmatch(r'issuecomment-[1-9][0-9]*', url.fragment)):
         raise ValueError('evidence must be a GitHub comment on this repository and PR')
-    if not identity.strip() or (record_author == pr_author and identity == record_author):
+    if not identity.strip():
         raise ValueError('reviewing identity must be explicit and distinct from record author')
     comment_id = url.fragment.split('-', 1)[1]
     # Construct a fixed API endpoint, never fetch the caller-supplied URL.
-    with tempfile.TemporaryFile() as out, tempfile.TemporaryFile() as err:
-        result = subprocess.run(
-            ['gh', 'api', f'repos/{repo}/issues/comments/{comment_id}'],
-            stdout=out, stderr=err, timeout=30, check=False,
-        )
-        if result.returncode != 0:
-            raise ValueError('review evidence unavailable')
-        if out.tell() > 262144:
-            raise ValueError('review evidence exceeds byte limit')
-        out.seek(0)
-        comment = json.load(out)
+    comment = run_json(['gh', 'api', f'repos/{repo}/issues/comments/{comment_id}'])
     if (comment.get('html_url') != evidence_url
             or comment.get('issue_url') != f'https://api.github.com/repos/{repo}/issues/{pr}'
             or comment.get('user', {}).get('login') != record_author):
         raise ValueError('review evidence publisher or PR does not match')
     body = comment.get('body', '').strip()
-    machine = machine_review_candidate(body, record_author)
+    machine = machine_review_candidate(body, record_author, head, branch_ref)
     if machine is None or machine['verdict'] != 'READY' or machine['bound_sha'] != head:
         raise ValueError('review identity, head, verdict or independence declaration mismatch')
-    match = REVIEW_RECORD_FENCE.fullmatch(body[len(REVIEW_RECORD_MARKER):].strip())
-    if match is None:
-        raise ValueError('review record envelope is malformed')
-    record = json.loads(match.group(1))
-    reviewer = record.get('reviewer', {})
     direct_human = (
         identity == record_author and record_author != pr_author
-        and reviewer.get('agent') == 'human'
-        and reviewer.get('instance') == record_author
+        and machine['reviewer_identity'] == f'human/{record_author}'
     )
     if not (machine['reviewer_identity'] == identity or direct_human):
         raise ValueError('review identity, head, verdict or independence declaration mismatch')
-    builder = record.get('builder', {})
-    if (builder.get('agent'), builder.get('instance')) == (reviewer.get('agent'), reviewer.get('instance')):
-        raise ValueError('reviewer is also the declared builder')
     print(f'Record author: {record_author}')
     print(f'Reviewing identity: {identity}')
     print(f'Review evidence: {evidence_url}')
@@ -71,11 +49,11 @@ def verify(repo, pr, head, record_author, identity, evidence_url, pr_author):
 
 def main():
     parser = argparse.ArgumentParser()
-    for name in ('repo', 'pr', 'head', 'record-author', 'reviewer-identity', 'review-evidence-url', 'pr-author'):
+    for name in ('repo', 'pr', 'head', 'branch-ref', 'record-author', 'reviewer-identity', 'review-evidence-url', 'pr-author'):
         parser.add_argument('--' + name, required=True)
     args = parser.parse_args()
     try:
-        verify(args.repo, args.pr, args.head, args.record_author,
+        verify(args.repo, args.pr, args.head, args.branch_ref, args.record_author,
                args.reviewer_identity, args.review_evidence_url, args.pr_author)
     except (ValueError, TypeError, AttributeError, OSError, subprocess.TimeoutExpired) as error:
         parser.exit(1, f'BLOCKED: {error}\n')

--- a/scripts/review/verify_review_identity.py
+++ b/scripts/review/verify_review_identity.py
@@ -10,11 +10,15 @@ from urllib.parse import urlsplit
 from pr_landing_readiness import (
     REVIEW_RECORD_FENCE,
     REVIEW_RECORD_MARKER,
-    declared_reviewer_identity,
+    machine_review_candidate,
+    parse_repo,
 )
 
 
 def verify(repo, pr, head, record_author, identity, evidence_url, pr_author):
+    parse_repo(repo)
+    if not re.fullmatch(r"[1-9][0-9]*", str(pr)):
+        raise ValueError('PR must be a positive decimal integer')
     url = urlsplit(evidence_url)
     expected_path = f'/{repo}/pull/{pr}'
     if (url.scheme != 'https' or url.netloc != 'github.com'
@@ -41,29 +45,20 @@ def verify(repo, pr, head, record_author, identity, evidence_url, pr_author):
             or comment.get('user', {}).get('login') != record_author):
         raise ValueError('review evidence publisher or PR does not match')
     body = comment.get('body', '').strip()
-    if not body.startswith(REVIEW_RECORD_MARKER):
-        raise ValueError('evidence is not a completed structured review record')
+    machine = machine_review_candidate(body, record_author)
+    if machine is None or machine['verdict'] != 'READY' or machine['bound_sha'] != head:
+        raise ValueError('review identity, head, verdict or independence declaration mismatch')
     match = REVIEW_RECORD_FENCE.fullmatch(body[len(REVIEW_RECORD_MARKER):].strip())
     if match is None:
         raise ValueError('review record envelope is malformed')
     record = json.loads(match.group(1))
     reviewer = record.get('reviewer', {})
-    independence = record.get('independence', {})
-    agent_identity = declared_reviewer_identity(reviewer)
     direct_human = (
         identity == record_author and record_author != pr_author
         and reviewer.get('agent') == 'human'
         and reviewer.get('instance') == record_author
     )
-    if (record.get('schema') != 'assay.review-record.v0'
-            or record.get('head_sha') != head
-            or record.get('verdict') != 'READY'
-            or record.get('review_completed') is not True
-            or reviewer.get('github_login') != record_author
-            or agent_identity is None
-            or not (agent_identity == identity or direct_human)
-            or independence.get('did_not_build') is not True
-            or independence.get('did_not_author_governing_spec') is not True):
+    if not (machine['reviewer_identity'] == identity or direct_human):
         raise ValueError('review identity, head, verdict or independence declaration mismatch')
     builder = record.get('builder', {})
     if (builder.get('agent'), builder.get('instance')) == (reviewer.get('agent'), reviewer.get('instance')):


### PR DESCRIPTION
Closes #2820.

## Problem

The prior landing helper used one login for two different facts: the GitHub account publishing a READY carrier and the independent agent that performed the review. An owner relay therefore could not be represented honestly.

## Change

- tracks the previously local review helpers under `scripts/review/`;
- replaces the ambiguous `--reviewer` interface with `--record-author`, `--reviewer-identity`, and `--review-evidence-url`;
- imports the canonical `assay.review-record.v0` parser and validator from `scripts/ci/assay_review_record_check.py` instead of maintaining a second schema implementation;
- treats malformed current-head machine carriers, valid BLOCKED records, and current-head `CHANGES_REQUESTED` reviews as blockers while ignoring dismissed reviews;
- binds merge authorization to a fetched READY record with the same publisher, reviewer identity, branch, PR, and exact head;
- closes GitHub command families, validates repository/ref inputs, and applies timeout and byte ceilings before parsing;
- requires exact `SUCCESS`/`pass` status for every required context and JSON-escapes all API-provided scalars before rendering;
- runs the full review-relay protocol suite in the PR-head Kernel Matrix pre-commit lane.

## Verification

At exact head `4fe65c9599c63f3d59f9a21bffdd39cd233493e2`:

- `python3 scripts/review/test_review_relay.py`: 23 fail-closed subcases, pass;
- `python3 scripts/review/test_safe_merge_protocol.py`: 8 cases, pass;
- `python3 scripts/review/test_pr_landing_readiness.py`: 33 tests, pass;
- `python3 scripts/ci/assay_review_record_check.py --self-test`: pass;
- `python3 -m unittest discover -s scripts/review -p 'test_*.py'`: 34 tests plus 8 protocol cases, pass;
- `pre-commit run review-relay-protocol-tests --all-files`: pass;
- `pre-commit run assay-review-record-self-test --all-files`: pass;
- `python3 scripts/ci/test-review-record-workflow.py`: 23 tests, pass;
- full pre-commit and pre-push hooks: pass after one separately re-measured transient local process-start refusal;
- `python3 -m py_compile scripts/review/*.py scripts/ci/assay_review_record_check.py`, `bash -n scripts/review/safe_merge.sh`, and `git diff --check`: pass.

CodeQL alert #1117 was independently classified as a false positive on this head: `validate_gh_command` runs before the list-argv, no-shell spawn; command, endpoint, repository, branch, and flag shapes are closed; hostile shapes are proven to refuse before spawn. The exact-head alert was dismissed with that bounded technical record, and the CodeQL check is green.

## Review disposition

Independent Ruley/Grok Bot review is **READY** at exact head `4fe65c9599c63f3d59f9a21bffdd39cd233493e2`, with no findings. The readable relay is in [comment 5554831272](https://github.com/Rul1an/assay/pull/2821#issuecomment-5554831272); the machine-readable current-head carrier is [comment 5554831366](https://github.com/Rul1an/assay/pull/2821#issuecomment-5554831366). All A-J guard mutations went RED and the final no-op control stayed green.

## Non-claims

- This validates the retrieved declaration; it does not authenticate an agent identity or independently prove its independence.
- GitHub comments remain editable and are not immutable attestations.
- Prose-only reviews are not supported by this bounded adapter yet.
- This PR does not deploy the tracked files into the local Codex skill or alter the trusted-base review workflow to execute pull-request code.
