### PR TITLE
feat(ci): record a declared install source in the host-proof manifest

### DIFF
--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -46,6 +46,7 @@ import {
   CWD_DIFFERS_FROM_PROJECT_ROOT,
   CWD_MATCHES_PROJECT_ROOT,
   projectRetainedEvent,
+  installSourceBound,
   projectHostIdentity,
   proofAllowlist,
   requirePrivateDirectory,
@@ -58,6 +59,8 @@ import {
   validateProofRoot,
   walkDepth,
 } from "./codex_host_proof_validator.mjs";
+
+const INSTALL_SUBJECTS = Object.freeze(["codex", "codexCodeModeHost", "assayMcp"]);
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_BYTES = 1_048_576;
@@ -72,6 +75,7 @@ export function parseArgs(argv) {
     childArgv: null,
     proofRoot: null,
     projectRoot: null,
+    installSources: {},
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -101,6 +105,26 @@ export function parseArgs(argv) {
       case "--allow-live-turn":
         out.allowLiveTurn = true;
         break;
+      // Install source is declared, never inferred: how a binary got onto this
+      // machine is not observable from the binary the host launches. Each token is
+      // validated structurally here so nothing free-form reaches the record.
+      case "--install-source": {
+        const subject = next();
+        const route = next();
+        const reference = next();
+        if (!INSTALL_SUBJECTS.includes(subject)) {
+          throw new Error(`--install-source subject must be one of ${INSTALL_SUBJECTS.join(", ")}`);
+        }
+        if (Object.prototype.hasOwnProperty.call(out.installSources, subject)) {
+          throw new Error(`--install-source declared twice for ${subject}`);
+        }
+        const candidate = { route, reference };
+        if (!installSourceBound(candidate)) {
+          throw new Error(`--install-source for ${subject} is not a valid route and reference`);
+        }
+        out.installSources[subject] = candidate;
+        break;
+      }
       default:
         throw new Error(`unknown argument ${arg}`);
     }
@@ -338,6 +362,13 @@ function probeAssayMcpVersion(binary) {
 }
 
 export function resolveHostIdentity(options = {}) {
+  const declared = options.installSources ?? {};
+  const missing = INSTALL_SUBJECTS.filter((s) => !declared[s]);
+  if (missing.length > 0) {
+    // Fail closed. A record without a declared install source cannot satisfy the
+    // #2684 "record install source" cell, and an absent field must not read as a pass.
+    throw new Error(`--install-source is required for: ${missing.join(", ")}`);
+  }
   const codexPath = findOnPath("codex");
   const mcpPath = findOnPath("assay-mcp-server");
   if (!codexPath) {
@@ -374,18 +405,18 @@ export function resolveHostIdentity(options = {}) {
         path: fs.realpathSync(codexSnap),
         version: probeCodexVersion(codexSnap),
         sha256: sha256File(codexSnap),
-        installSource: "PATH",
+        installSource: declared.codex,
       },
       codexCodeModeHost: {
         path: fs.realpathSync(codeModeHostSnap),
         sha256: sha256File(codeModeHostSnap),
-        installSource: "codex-sibling",
+        installSource: declared.codexCodeModeHost,
       },
       assayMcp: {
         path: fs.realpathSync(mcpSnap),
         version: probeAssayMcpVersion(mcpSnap),
         sha256: sha256File(mcpSnap),
-        installSource: "PATH",
+        installSource: declared.assayMcp,
       },
     };
     identity[BOUND_EXEC] = {
@@ -660,7 +691,10 @@ export async function runProof(options) {
   }
 
   if (!options.testOnlyChild && !options.hostIdentity) {
-    options.hostIdentity = resolveHostIdentity({ proofRoot: options.proofRoot });
+    options.hostIdentity = resolveHostIdentity({
+      proofRoot: options.proofRoot,
+      installSources: options.installSources,
+    });
   }
   let codexHome;
   try {

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -26,6 +26,21 @@ export const PUBLISHED_INSTALL_ROUTES = Object.freeze([
   "host-bundled",
 ]);
 export const MAX_INSTALL_REFERENCE = 200;
+// One line of printable ASCII. This is an allowlist on purpose. The first version of
+// this check blocked C0 and DEL, and that blocklist silently admitted U+2028, U+2029,
+// U+0085, U+200B, U+FEFF and the bidi overrides, every one of which can split or
+// reorder rendered output without failing closed. An allowlist cannot be defeated by
+// a code point nobody thought to list.
+const PRINTABLE_ASCII_LINE = /^[\x20-\x7e]+$/;
+
+export function boundedPrintable(value, max = MAX_INSTALL_REFERENCE) {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= max &&
+    PRINTABLE_ASCII_LINE.test(value)
+  );
+}
 export const SKILL_NAME = "assay-golden-path";
 export const DECIDE_TOOL = "assay_policy_decide";
 export const DECIDE_INPUT = {
@@ -278,11 +293,7 @@ export function installSourceBound(source) {
   return (
     exactKeys(source, ["route", "reference"]) &&
     INSTALL_ROUTES.includes(source.route) &&
-    typeof source.reference === "string" &&
-    source.reference.length > 0 &&
-    source.reference.length <= MAX_INSTALL_REFERENCE &&
-    // one line, printable, no credential-shaped content
-    !/[\u0000-\u001f\u007f]/.test(source.reference) &&
+    boundedPrintable(source.reference) &&
     !CREDENTIAL_KEY.test(source.reference)
   );
 }
@@ -323,11 +334,7 @@ function boundBinary(bin) {
     typeof bin.sha256 === "string" &&
     /^[a-f0-9]{64}$/.test(bin.sha256) &&
     installSourceBound(bin.installSource) &&
-    (bin.version === undefined ||
-      (typeof bin.version === "string" &&
-        bin.version.length > 0 &&
-        bin.version.length <= MAX_INSTALL_REFERENCE &&
-        !/[\u0000-\u001f\u007f]/.test(bin.version)))
+    (bin.version === undefined || boundedPrintable(bin.version))
   );
 }
 

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -9,8 +9,23 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const SCHEMA = "assay.codex-host-proof.v4";
+export const SCHEMA = "assay.codex-host-proof.v5";
 export const FAKE_USER_AGENT = "assay-codex-host-proof-fake/1";
+// Closed install-route vocabulary. "local-build" is recordable on purpose: a failed
+// provenance run must be retained as what it was, not omitted into a cleaner record.
+export const INSTALL_ROUTES = Object.freeze([
+  "github-release",
+  "crates-io",
+  "host-bundled",
+  "local-build",
+]);
+// Routes that satisfy #2684 DoD cell 2. A local build never does.
+export const PUBLISHED_INSTALL_ROUTES = Object.freeze([
+  "github-release",
+  "crates-io",
+  "host-bundled",
+]);
+export const MAX_INSTALL_REFERENCE = 200;
 export const SKILL_NAME = "assay-golden-path";
 export const DECIDE_TOOL = "assay_policy_decide";
 export const DECIDE_INPUT = {
@@ -259,11 +274,29 @@ function exactKeys(value, expected) {
   );
 }
 
+export function installSourceBound(source) {
+  return (
+    exactKeys(source, ["route", "reference"]) &&
+    INSTALL_ROUTES.includes(source.route) &&
+    typeof source.reference === "string" &&
+    source.reference.length > 0 &&
+    source.reference.length <= MAX_INSTALL_REFERENCE &&
+    // one line, printable, no credential-shaped content
+    !/[\u0000-\u001f\u007f]/.test(source.reference) &&
+    !CREDENTIAL_KEY.test(source.reference)
+  );
+}
+
 function projectBoundBinary(bin) {
-  return {
+  const projected = {
     path: bin?.path,
     sha256: bin?.sha256,
+    installSource: bin?.installSource,
   };
+  if (bin?.version !== undefined) {
+    projected.version = bin.version;
+  }
+  return projected;
 }
 
 export function projectHostIdentity(identity) {
@@ -271,6 +304,8 @@ export function projectHostIdentity(identity) {
     return null;
   }
   return {
+    os: identity.os,
+    arch: identity.arch,
     codex: projectBoundBinary(identity.codex),
     codexCodeModeHost: projectBoundBinary(identity.codexCodeModeHost),
     assayMcp: projectBoundBinary(identity.assayMcp),
@@ -278,17 +313,34 @@ export function projectHostIdentity(identity) {
 }
 
 function boundBinary(bin) {
+  const shape = bin?.version === undefined
+    ? ["path", "sha256", "installSource"]
+    : ["path", "sha256", "installSource", "version"];
   return (
-    exactKeys(bin, ["path", "sha256"]) &&
+    exactKeys(bin, shape) &&
     typeof bin.path === "string" &&
     path.isAbsolute(bin.path) &&
     typeof bin.sha256 === "string" &&
-    /^[a-f0-9]{64}$/.test(bin.sha256)
+    /^[a-f0-9]{64}$/.test(bin.sha256) &&
+    installSourceBound(bin.installSource) &&
+    (bin.version === undefined ||
+      (typeof bin.version === "string" &&
+        bin.version.length > 0 &&
+        bin.version.length <= MAX_INSTALL_REFERENCE &&
+        !/[\u0000-\u001f\u007f]/.test(bin.version)))
   );
 }
 
 export function liveIdentityBound(identity) {
-  if (!exactKeys(identity, ["codex", "codexCodeModeHost", "assayMcp"])) {
+  if (!exactKeys(identity, ["os", "arch", "codex", "codexCodeModeHost", "assayMcp"])) {
+    return false;
+  }
+  if (
+    typeof identity.os !== "string" ||
+    identity.os.length === 0 ||
+    typeof identity.arch !== "string" ||
+    identity.arch.length === 0
+  ) {
     return false;
   }
   return (

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -26,11 +26,25 @@ export const PUBLISHED_INSTALL_ROUTES = Object.freeze([
   "host-bundled",
 ]);
 export const MAX_INSTALL_REFERENCE = 200;
-// One line of printable ASCII. This is an allowlist on purpose. The first version of
-// this check blocked C0 and DEL, and that blocklist silently admitted U+2028, U+2029,
-// U+0085, U+200B, U+FEFF and the bidi overrides, every one of which can split or
-// reorder rendered output without failing closed. An allowlist cannot be defeated by
-// a code point nobody thought to list.
+// Contract: a reference or version is one line of printable ASCII, U+0020 to U+007E
+// inclusive. Everything else is refused. Stated as what that excludes, because the
+// review finding was about classes nobody enumerated:
+//
+//   U+0000-U+001F  C0 controls, including newline and tab
+//   U+007F-U+009F  DEL and the C1 controls, including U+0085 NEL
+//   U+00A0         no-break space, and every other non-ASCII space
+//   U+200B-U+200F  zero-width space, ZWNJ, ZWJ, LRM, RLM
+//   U+202A-U+202E  bidi embeddings and overrides
+//   U+2028, U+2029 line and paragraph separators
+//   U+2066-U+2069  bidi isolates
+//   U+FEFF         BOM / zero-width no-break space
+//   everything else outside U+0020-U+007E, including all astral planes
+//
+// This is an allowlist on purpose. The first version blocked C0 and DEL only, and that
+// blocklist silently admitted six of the classes above. A blocklist has to enumerate
+// every hostile code point; an allowlist cannot be defeated by one nobody listed. The
+// list above documents the contract, it does not implement it, so it cannot drift out
+// of sync with enforcement. `boundedPrintable` is the single validator for both fields.
 const PRINTABLE_ASCII_LINE = /^[\x20-\x7e]+$/;
 
 export function boundedPrintable(value, max = MAX_INSTALL_REFERENCE) {

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -15,7 +15,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   parseArgs,
   resolveHostIdentity as resolveHostIdentityProduction,
-  runProof,
+  runProof as runProofProduction,
 } from "./codex_host_proof.mjs";
 import {
   ALLOWED_TURN_ITEMS_VIEWS,
@@ -25,6 +25,11 @@ import {
   EXPECTED_TOOLS,
   HARD_MAX_SNAPSHOT_BYTES,
   HOST_SUBJECTS,
+  INSTALL_ROUTES,
+  PUBLISHED_INSTALL_ROUTES,
+  installSourceBound,
+  liveIdentityBound,
+  projectHostIdentity,
   KNOWN_ITEM_TYPES,
   KNOWN_METHODS,
   classifyCells,
@@ -93,10 +98,36 @@ function scratch() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "assay-2684-"));
 }
 
+// Declared install sources for CLI-level tests. Refusal tests need these too, so a
+// refusal still proves the behaviour under test rather than the missing precondition.
+const CLI_INSTALL_SOURCE_ARGS = Object.freeze([
+  "--install-source", "codex", "host-bundled", "test-fixture-codex",
+  "--install-source", "codexCodeModeHost", "host-bundled", "test-fixture-code-mode-host",
+  "--install-source", "assayMcp", "crates-io", "assay-mcp-server@0.0.0-test",
+]);
+
+const TEST_INSTALL_SOURCES = Object.freeze({
+  codex: { route: "host-bundled", reference: "test-fixture-codex" },
+  codexCodeModeHost: { route: "host-bundled", reference: "test-fixture-code-mode-host" },
+  assayMcp: { route: "crates-io", reference: "assay-mcp-server@0.0.0-test" },
+});
+
+// The in-process API bypasses parseArgs, so declared install sources are injected
+// here the same way the CLI injects them through argv.
+function runProof(options = {}) {
+  const { installSources, ...rest } = options;
+  return runProofProduction({
+    ...rest,
+    installSources: installSources ?? TEST_INSTALL_SOURCES,
+  });
+}
+
 function resolveHostIdentity(options = {}) {
+  const { installSources, proofRoot, ...rest } = options;
   return resolveHostIdentityProduction({
-    proofRoot: options.proofRoot ?? scratch(),
-    ...options,
+    ...rest,
+    proofRoot: proofRoot ?? scratch(),
+    installSources: installSources ?? TEST_INSTALL_SOURCES,
   });
 }
 
@@ -252,6 +283,7 @@ function driveCli(scenario, journey = "tool", extra = {}) {
     journey,
     "--timeout-ms",
     String(extra.timeoutMs ?? 4000),
+    ...CLI_INSTALL_SOURCE_ARGS,
   ];
   if (extra.allowLiveTurn) {
     args.push("--allow-live-turn");
@@ -286,7 +318,7 @@ test("driver calls the validator classification function; no extra classify modu
 test("synthetic positive control: cells pass without inventing external attestation", async () => {
   const { classified, manifest, proofRoot, driverOutcome, childExitCode, events } = await drive("valid");
   assert.equal(manifest.captureMode, "synthetic-fixture");
-  assert.equal(manifest.schema, "assay.codex-host-proof.v4");
+  assert.equal(manifest.schema, "assay.codex-host-proof.v5");
   assert.equal(childExitCode, 0);
   assert.equal(driverOutcome.exitCode, 0);
   assert.equal(manifest.childExitCode, 0);
@@ -893,6 +925,7 @@ function driveCliInline(childArgv, extra = {}) {
     extra.journey ?? "tool",
     "--timeout-ms",
     String(extra.timeoutMs ?? 4000),
+    ...CLI_INSTALL_SOURCE_ARGS,
   ];
   if (extra.maxBytes != null) {
     args.push("--max-bytes", String(extra.maxBytes));
@@ -1436,6 +1469,7 @@ test("production CLI rejects --child-argv; credential name variants are rejected
       proofRoot,
       "--project-root",
       projectRoot,
+      ...CLI_INSTALL_SOURCE_ARGS,
       "--child-argv",
       JSON.stringify(["node", FAKE, "--scenario", "valid", "--project-root", projectRoot]),
     ],
@@ -1694,9 +1728,19 @@ test("production host identity is observed from proof-owned binaries before CLI 
     const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
     const identity = manifest.hostIdentity;
     assert.ok(identity && typeof identity === "object", "production CLI must construct hostIdentity");
-    assert.deepEqual(Object.keys(identity).sort(), ["assayMcp", "codex", "codexCodeModeHost"]);
+    assert.deepEqual(
+      Object.keys(identity).sort(),
+      ["arch", "assayMcp", "codex", "codexCodeModeHost", "os"],
+    );
     for (const role of ["codex", "codexCodeModeHost", "assayMcp"]) {
-      assert.deepEqual(Object.keys(identity[role]).sort(), ["path", "sha256"]);
+      const expectedKeys = role === "codexCodeModeHost"
+        ? ["installSource", "path", "sha256"]
+        : ["installSource", "path", "sha256", "version"];
+      assert.deepEqual(Object.keys(identity[role]).sort(), expectedKeys);
+      assert.deepEqual(
+        Object.keys(identity[role].installSource).sort(),
+        ["reference", "route"],
+      );
       assert.equal(path.isAbsolute(identity[role].path), true, `${role} path must be absolute`);
       assert.match(identity[role].sha256, /^[a-f0-9]{64}$/);
       assert.equal(fs.lstatSync(identity[role].path).isFile(), true);
@@ -2036,6 +2080,7 @@ test("production CLI refuses --codex-bin and --assay-mcp-bin before spawn", () =
         proofRoot,
         "--project-root",
         projectRoot,
+        ...CLI_INSTALL_SOURCE_ARGS,
         flag,
         evil,
         "--journey",
@@ -2093,8 +2138,8 @@ test("PATH shadows drive observed Codex and Assay MCP identities", () => {
     assert.equal(sha256File(ignored.codex.path), sha256File(codexBin));
     assert.equal(sha256File(ignored.codexCodeModeHost.path), sha256File(codeModeHost));
     assert.equal(sha256File(ignored.assayMcp.path), sha256File(mcpBin));
-    assert.equal(ignored.codex.installSource, "PATH");
-    assert.equal(ignored.assayMcp.installSource, "PATH");
+    assert.deepEqual(ignored.codex.installSource, TEST_INSTALL_SOURCES.codex);
+    assert.deepEqual(ignored.assayMcp.installSource, TEST_INSTALL_SOURCES.assayMcp);
     assert.match(ignored.codex.version, /codex-shadow/);
     assert.match(ignored.assayMcp.version, /assay-mcp-server-shadow/);
     assert.notEqual(ignored.codex.path, fs.realpathSync(flagCodex));
@@ -2118,6 +2163,7 @@ test("PATH shadows drive observed Codex and Assay MCP identities", () => {
       "tool",
       "--timeout-ms",
       "4000",
+      ...CLI_INSTALL_SOURCE_ARGS,
     ],
     {
       encoding: "utf8",
@@ -2138,14 +2184,20 @@ test("PATH shadows drive observed Codex and Assay MCP identities", () => {
   assert.equal(sha256File(manifest.hostIdentity.assayMcp.path), sha256File(mcpBin));
   assert.deepEqual(
     Object.keys(manifest.hostIdentity).sort(),
-    ["assayMcp", "codex", "codexCodeModeHost"],
+    ["arch", "assayMcp", "codex", "codexCodeModeHost", "os"],
   );
-  assert.deepEqual(Object.keys(manifest.hostIdentity.codex).sort(), ["path", "sha256"]);
+  assert.deepEqual(
+    Object.keys(manifest.hostIdentity.codex).sort(),
+    ["installSource", "path", "sha256", "version"],
+  );
   assert.deepEqual(
     Object.keys(manifest.hostIdentity.codexCodeModeHost).sort(),
-    ["path", "sha256"],
+    ["installSource", "path", "sha256"],
   );
-  assert.deepEqual(Object.keys(manifest.hostIdentity.assayMcp).sort(), ["path", "sha256"]);
+  assert.deepEqual(
+    Object.keys(manifest.hostIdentity.assayMcp).sort(),
+    ["installSource", "path", "sha256", "version"],
+  );
   const events = JSON.parse(fs.readFileSync(path.join(proofRoot, "events.json"), "utf8"));
   const start = events.find(
     (event) => event.direction === "client" && event.method === "thread/start",
@@ -3157,8 +3209,8 @@ test("F5 PATH snapshot copy enforces a binary ceiling and running growth bound; 
   process.env.PATH = `${path.dirname(controlCodex)}${path.delimiter}${path.dirname(controlMcp)}${path.delimiter}${previousPath}`;
   try {
     const control = resolveHostIdentity();
-    assert.equal(control.codex.installSource, "PATH");
-    assert.equal(control.assayMcp.installSource, "PATH");
+    assert.deepEqual(control.codex.installSource, TEST_INSTALL_SOURCES.codex);
+    assert.deepEqual(control.assayMcp.installSource, TEST_INSTALL_SOURCES.assayMcp);
     assert.match(control.codex.version, /codex-shadow/);
   } finally {
     process.env.PATH = previousPath;
@@ -3382,8 +3434,8 @@ test("P1 shared 512 MiB ceiling rejects sparse hash and removes snap root; contr
   process.env.PATH = `${path.dirname(controlCodex)}${path.delimiter}${path.dirname(controlMcp)}${path.delimiter}${previousPath}`;
   try {
     const control = resolveHostIdentity();
-    assert.equal(control.codex.installSource, "PATH");
-    assert.equal(control.assayMcp.installSource, "PATH");
+    assert.deepEqual(control.codex.installSource, TEST_INSTALL_SOURCES.codex);
+    assert.deepEqual(control.assayMcp.installSource, TEST_INSTALL_SOURCES.assayMcp);
   } finally {
     process.env.PATH = previousPath;
   }
@@ -6918,4 +6970,114 @@ test("#2812: failed or interrupted terminal status dominates across all itemsVie
       );
     }
   }
+});
+
+// --- #2684 cell 1: install source is declared, bounded, and survives to disk ---
+
+test("#2684: install source is required and never defaulted", () => {
+  // Positive control first: a complete declaration is accepted.
+  const ok = parseArgs([
+    "--install-source", "assayMcp", "crates-io", "assay-mcp-server@6.0.0",
+  ]);
+  assert.deepEqual(ok.installSources.assayMcp, {
+    route: "crates-io",
+    reference: "assay-mcp-server@6.0.0",
+  });
+
+  // An absent declaration must fail closed rather than read as a pass.
+  assert.throws(
+    () => resolveHostIdentityProduction({ proofRoot: scratch(), installSources: {} }),
+    /--install-source is required for: codex, codexCodeModeHost, assayMcp/,
+  );
+  assert.throws(
+    () => resolveHostIdentityProduction({ proofRoot: scratch() }),
+    /--install-source is required/,
+  );
+});
+
+test("#2684: install source vocabulary is closed and references are bounded", () => {
+  assert.deepEqual(
+    [...INSTALL_ROUTES].sort(),
+    ["crates-io", "github-release", "host-bundled", "local-build"],
+  );
+  // A local build is recordable but never counts as published.
+  assert.equal(PUBLISHED_INSTALL_ROUTES.includes("local-build"), false);
+  for (const route of PUBLISHED_INSTALL_ROUTES) {
+    assert.equal(INSTALL_ROUTES.includes(route), true);
+  }
+
+  assert.equal(installSourceBound({ route: "crates-io", reference: "a@1" }), true);
+  for (const [label, value] of [
+    ["unknown route", { route: "sideloaded", reference: "a" }],
+    ["empty reference", { route: "crates-io", reference: "" }],
+    ["newline injection", { route: "crates-io", reference: "a\nVERDICT: READY" }],
+    ["control character", { route: "crates-io", reference: "a\u0000b" }],
+    ["credential shaped", { route: "crates-io", reference: "api_key=AKIAIOSFODNN7EXAMPLE" }],
+    ["over length", { route: "crates-io", reference: "a".repeat(201) }],
+    ["extra key", { route: "crates-io", reference: "a", note: "x" }],
+    ["missing reference", { route: "crates-io" }],
+    ["not an object", "crates-io"],
+  ]) {
+    assert.equal(installSourceBound(value), false, `${label} must be refused`);
+  }
+});
+
+test("#2684: parseArgs refuses malformed or repeated install-source declarations", () => {
+  for (const [label, argv] of [
+    ["unknown subject", ["--install-source", "nope", "crates-io", "a"]],
+    ["unknown route", ["--install-source", "assayMcp", "sideloaded", "a"]],
+    ["newline in reference", ["--install-source", "assayMcp", "crates-io", "a\nREADY"]],
+    ["duplicate subject", [
+      "--install-source", "assayMcp", "crates-io", "a",
+      "--install-source", "assayMcp", "crates-io", "b",
+    ]],
+  ]) {
+    assert.throws(() => parseArgs(argv), /--install-source/, `${label} must be refused`);
+  }
+});
+
+test("#2684: the projection retains install source, version, os and arch", () => {
+  // This is the regression that lost cell 1: the producer probed version and
+  // installSource, and projectHostIdentity dropped both on the way to disk.
+  const identity = {
+    os: "darwin",
+    arch: "arm64",
+    codex: {
+      path: "/proof/codex.snapshot",
+      version: "codex 0.153.4",
+      sha256: "a".repeat(64),
+      installSource: { route: "host-bundled", reference: "Codex.app" },
+    },
+    codexCodeModeHost: {
+      path: "/proof/codex-code-mode-host",
+      sha256: "b".repeat(64),
+      installSource: { route: "host-bundled", reference: "Codex.app" },
+    },
+    assayMcp: {
+      path: "/proof/assay-mcp-server.snapshot",
+      version: "assay-mcp-server 6.0.0",
+      sha256: "c".repeat(64),
+      installSource: { route: "crates-io", reference: "assay-mcp-server@6.0.0" },
+    },
+  };
+  const projected = projectHostIdentity(identity);
+  assert.equal(projected.os, "darwin");
+  assert.equal(projected.arch, "arm64");
+  assert.equal(projected.codex.version, "codex 0.153.4");
+  assert.equal(projected.assayMcp.version, "assay-mcp-server 6.0.0");
+  assert.deepEqual(projected.assayMcp.installSource, {
+    route: "crates-io",
+    reference: "assay-mcp-server@6.0.0",
+  });
+  // A subject without a probed version keeps the shorter shape rather than a null.
+  assert.deepEqual(
+    Object.keys(projected.codexCodeModeHost).sort(),
+    ["installSource", "path", "sha256"],
+  );
+  // The projected identity must still satisfy the live binding contract.
+  assert.equal(liveIdentityBound(projected), true);
+  // ... and lose it if the install source is stripped, so the field is load bearing.
+  const stripped = JSON.parse(JSON.stringify(projected));
+  delete stripped.assayMcp.installSource;
+  assert.equal(liveIdentityBound(stripped), false);
 });

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -27,6 +27,7 @@ import {
   HOST_SUBJECTS,
   INSTALL_ROUTES,
   PUBLISHED_INSTALL_ROUTES,
+  boundedPrintable,
   installSourceBound,
   liveIdentityBound,
   projectHostIdentity,
@@ -7080,4 +7081,62 @@ test("#2684: the projection retains install source, version, os and arch", () =>
   const stripped = JSON.parse(JSON.stringify(projected));
   delete stripped.assayMcp.installSource;
   assert.equal(liveIdentityBound(stripped), false);
+});
+
+test("#2822 F1: reference and version are printable ASCII, not merely control-free", () => {
+  const cp = (n) => String.fromCodePoint(n);
+  // Positive control: an ordinary reference stays acceptable.
+  assert.equal(installSourceBound({ route: "crates-io", reference: "assay-mcp-server@6.0.0" }), true);
+  assert.equal(boundedPrintable("codex 0.153.4"), true);
+
+  // The blocklist this replaced admitted every one of these. Named individually so a
+  // regression says which class came back rather than only that something did.
+  const hostile = [
+    ["U+0085 NEL", 0x85],
+    ["U+200B zero-width space", 0x200b],
+    ["U+200E left-to-right mark", 0x200e],
+    ["U+2028 line separator", 0x2028],
+    ["U+2029 paragraph separator", 0x2029],
+    ["U+202E right-to-left override", 0x202e],
+    ["U+2066 left-to-right isolate", 0x2066],
+    ["U+2069 pop directional isolate", 0x2069],
+    ["U+FEFF byte order mark", 0xfeff],
+    ["U+0000 NUL", 0x00],
+    ["U+000A newline", 0x0a],
+    ["U+007F DEL", 0x7f],
+  ];
+  for (const [label, point] of hostile) {
+    const reference = `a${cp(point)}b`;
+    assert.equal(
+      installSourceBound({ route: "crates-io", reference }),
+      false,
+      `${label} must be refused in an install reference`,
+    );
+    assert.equal(boundedPrintable(reference), false, `${label} must be refused in a version`);
+  }
+
+  // The same rule reaches version through the binding contract.
+  const withVersion = (version) => liveIdentityBound({
+    os: "darwin",
+    arch: "arm64",
+    codex: {
+      path: "/proof/codex.snapshot",
+      version,
+      sha256: "a".repeat(64),
+      installSource: { route: "host-bundled", reference: "Codex.app" },
+    },
+    codexCodeModeHost: {
+      path: "/proof/codex-code-mode-host",
+      sha256: "b".repeat(64),
+      installSource: { route: "host-bundled", reference: "Codex.app" },
+    },
+    assayMcp: {
+      path: "/proof/assay-mcp-server.snapshot",
+      version: "assay-mcp-server 6.0.0",
+      sha256: "c".repeat(64),
+      installSource: { route: "crates-io", reference: "assay-mcp-server@6.0.0" },
+    },
+  });
+  assert.equal(withVersion("codex 0.153.4"), true);
+  assert.equal(withVersion(`codex${cp(0x2028)}0.153.4`), false);
 });

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -7140,3 +7140,59 @@ test("#2822 F1: reference and version are printable ASCII, not merely control-fr
   assert.equal(withVersion("codex 0.153.4"), true);
   assert.equal(withVersion(`codex${cp(0x2028)}0.153.4`), false);
 });
+
+test("#2822 F1: the printable-ASCII contract is exactly U+0020-U+007E, swept", () => {
+  const cp = (n) => String.fromCodePoint(n);
+  // Completeness is proven rather than asserted: for every code point in the BMP the
+  // validator's answer must agree with the stated contract, in both directions. A
+  // blocklist cannot pass this; only an allowlist can.
+  let checked = 0;
+  for (let point = 0; point <= 0xffff; point += 1) {
+    if (point >= 0xd800 && point <= 0xdfff) {
+      continue; // lone surrogates are not scalar values
+    }
+    const inContract = point >= 0x20 && point <= 0x7e;
+    const value = `a${cp(point)}b`;
+    if (boundedPrintable(value) !== inContract) {
+      assert.fail(
+        `U+${point.toString(16).toUpperCase().padStart(4, "0")} disagrees with the contract: ` +
+        `expected ${inContract ? "accepted" : "refused"}`,
+      );
+    }
+    checked += 1;
+  }
+  assert.equal(checked, 0x10000 - 0x800, "the sweep must cover every BMP scalar value");
+
+  // Astral planes are outside the contract too, including emoji and tag characters.
+  for (const point of [0x1f600, 0xe0001, 0xe0041, 0x10ffff]) {
+    assert.equal(boundedPrintable(`a${cp(point)}b`), false, `U+${point.toString(16)} must be refused`);
+  }
+
+  // The full agreed bidi ranges, named so a regression reports which range returned.
+  for (const [label, lo, hi] of [
+    ["bidi embeddings and overrides U+202A-U+202E", 0x202a, 0x202e],
+    ["bidi isolates U+2066-U+2069", 0x2066, 0x2069],
+    ["zero-width and marks U+200B-U+200F", 0x200b, 0x200f],
+  ]) {
+    for (let point = lo; point <= hi; point += 1) {
+      const reference = `assay-mcp-server@6.0.0${cp(point)}`;
+      assert.equal(
+        installSourceBound({ route: "crates-io", reference }),
+        false,
+        `${label}: U+${point.toString(16).toUpperCase()} must be refused in a reference`,
+      );
+    }
+  }
+
+  // Positive controls: the vocabulary references actually used must all remain valid.
+  for (const reference of [
+    "assay-mcp-server@6.0.0",
+    "v6.0.0/assay-v6.0.0-aarch64-apple-darwin.tar.gz",
+    "Codex.app",
+    "assay-mcp-server-v6.0.0-x86_64-unknown-linux-gnu.tar.gz",
+    "a".repeat(200),
+  ]) {
+    assert.equal(installSourceBound({ route: "github-release", reference }), true, reference.slice(0, 40));
+  }
+  assert.equal(installSourceBound({ route: "github-release", reference: "a".repeat(201) }), false);
+});


### PR DESCRIPTION
Addresses part of cell 1. Leaves #2684 open.

## What was wrong

#2684's DoD cell 1 requires the install source, and the retained proof pack recorded none. The independent review of the `b9c8ac6` journey (https://github.com/Rul1an/assay/issues/2684#issuecomment-5554980138) recorded the issue as BLOCKED partly on that.

Tracing it turned up two separate causes, and the first is the interesting one:

1. **The projection was lossy.** `resolveHostIdentity` already probed `os`, `arch` and both binary versions, but `projectHostIdentity` kept only `{path, sha256}`. Every provenance field was measured and then discarded on the way to disk.
2. **The value was not an answer.** The `installSource` it did build was the literal `"PATH"`, which names where the binary was *resolved*, not where it came from. It cannot distinguish a release asset from a crates.io package from a local build, which is exactly the distinction cell 2 turns on.

## What this changes

Install source is **declared, never inferred**. How a binary reached the machine is not observable from the binary the host launches, so deriving it would substitute one layer for another, which is the failure mode the host-proof skill exists to prevent.

`--install-source <subject> <route> <reference>`, repeatable, validated structurally at parse time, and **required for all three subjects** so an absent declaration fails closed rather than reading as a pass.

The route vocabulary is closed: `github-release`, `crates-io`, `host-bundled`, `local-build`. `local-build` is recordable **on purpose**. A failed provenance run must be retained as what it was rather than omitted into a cleaner record.

`projectHostIdentity` now retains `installSource`, `version`, `os` and `arch`, and `liveIdentityBound` requires them, so the fields are load bearing rather than decorative.

The manifest shape is a contract enforced by `exactKeys`, so the schema moves `assay.codex-host-proof.v4` -> `v5`. Retained v4 packs stay valid under their own pinned verifier, which is the point of pinning it.

## Controls

190 tests pass, 186 existing plus 4 new. The new ones include a positive control on a complete declaration, and refusals for unknown routes and subjects, duplicate declarations, newline and control-character injection, credential-shaped references, over-length references, and extra keys.

The projection regression test was **verified to bite**: reverting `installSource` out of `projectBoundBinary` turns it red, and restoring it turns it green. A test that passes is not the same as a test that guards.

## What this does not do

- **Leaves #2684 open.** The `b9c8ac6` proof pack predates this change, so a fresh run is still required to produce a pack that carries the field.
- **`PUBLISHED_INSTALL_ROUTES` is defined but not yet enforced by a cell.** A run declaring `local-build` still classifies every cell as pass while recording an unpublished route. Wiring that into a classification cell changes the classification contract and the retained `classification.json` shape, so it is deliberately left as a separate decision rather than smuggled in here.
- It does not change the scrubbing of `initialize.platformOs`, which remains `[present]`. `os` and `arch` now come from the identity block instead.

## Review

**This branch needs an independent reviewer, and it must not be me.** The same agent wrote this change, reviewed #2684, and amended #2684's DoD. That is builder, governing-spec author and reviewer collapsed onto one actor, which the repository's own review-record schema refuses via `identical_writer_reviewer` and `independence.did_not_build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Current-head coordination

Head: `0b1172a3a657157afdb3760463cc0be0683eeea7`.
Independent Ruley READY record: https://github.com/Rul1an/assay/pull/2822#issuecomment-5555259566 . The prior BLOCKED record remains unchanged. Earlier test counts above describe the initial implementation, not this final head. Current reported counts are 192 passed on macOS and 191 passed / 1 skipped on Linux; these are agent-reported, not a coordinator rerun. Required CI remains a separate landing gate. Leaves #2684 open pending the remaining install-route evidence and a fresh host-proof run.
