### PR TITLE
fix(host-proof): verify retained Assay package before host execution

### DIFF
--- a/docs/guides/codex-host-package-proof.md
+++ b/docs/guides/codex-host-package-proof.md
@@ -1,0 +1,81 @@
+# Codex Host Package Proof
+
+The `assay.codex-host-proof.v6` driver requires retained Assay package evidence
+before a `host-observation` run. This is not an installation recipe or release
+acceptance by itself. Synthetic fixtures remain synthetic, even if their package
+checks pass.
+
+## Supported Route
+
+This slice verifies the **crates.io source package** for `assay-mcp-server`.
+The declared reference must be `assay-mcp-server@<exact-version>`. A local build
+or host-bundled Assay does not qualify. A GitHub release is an admissible route
+in principle, but this verifier does not yet verify that archive format: it
+refuses rather than substitutes a source-package check.
+
+Supply three explicit files; the driver never searches credentials or profiles:
+
+- The retained `.crate` package, at most 4 MiB.
+- The exact release's JSON row from the official
+  [Cargo sparse index](https://index.crates.io/as/sa/assay-mcp-server), at most
+  256 KiB. It must name the same crate/version, be non-yanked, and its `cksum`
+  must equal the SHA-256 of the actual package bytes.
+- The installation prefix's `.crates2.json`, at most 4 MiB. Its selected entry
+  must name that registry package, an exact version requirement, the
+  `assay-mcp-server` binary, and a release profile. The selected PATH binary
+  must be in that prefix's `bin` directory. Only the selected package identity,
+  version requirement, binary name, profile, target and rustc fields are retained,
+  not other installed packages or the original metadata file.
+
+An operator must independently check acquisition of the index row and package.
+The offline validator does **not** fetch the index or authenticate copied index
+bytes. `indexSource` names the expected official source, not a verified network
+receipt. Cargo documents the checksum in its
+[registry index contract](https://doc.rust-lang.org/cargo/reference/registry-index.html).
+
+## Execution And Retention
+
+For an otherwise prepared, authorized host journey, add:
+
+```sh
+--install-source assayMcp crates-io "assay-mcp-server@$VERSION" \
+--assay-package "$PACKAGE_FILE" \
+--assay-index-row "$INDEX_ROW_FILE" \
+--assay-cargo-metadata "$INSTALL_PREFIX/.crates2.json"
+```
+
+All three file arguments must be absolute paths. Existing Codex and code-mode
+host install-source declarations remain required. There is no new vendor-bundle
+checksum obligation and no authentication change. A tool journey still requires
+its explicit model-turn authorization.
+
+The producer copies fixed-name binary snapshots, retains the package and row,
+projects the selected Cargo metadata, and verifies them **before either version
+probe**. It recomputes the retained package check before starting the host.
+Missing or invalid evidence stops execution; acquisition failure can leave an
+incomplete directory, which is not a valid proof. Use a fresh proof root for a
+new attempt, not a repaired historical record.
+
+Successful acquisition retains `assay-package.crate`, `assay-registry-row.json`
+and `assay-install.json`. The manifest's `packageVerification` binds their hashes
+and the binary snapshot hash. The offline consumer reads those files again and
+recomputes the comparison; two matching digest strings do not suffice.
+
+Every host journey requires both `installRouteAdmissible` and
+`installPackageVerified` to pass. Missing, unavailable or failed cells do not
+pass. No new `not_applicable` status or aggregate exception is introduced.
+
+## Claim Boundary
+
+The package-to-binary association is **Cargo installation metadata**, not a
+cryptographic proof of compilation from those bytes. It proves neither a
+reproducible build nor an uncompromised build environment. An internally
+consistent record does not authenticate origin, authorship or execution order;
+before-execution ordering is enforced by the reviewed producer, not proved by a
+timestamp. The complete record still needs independent acquisition and host-run
+review before it can support a launch claim.
+
+Previously retained v4/v5 packs remain immutable and use their pinned verifiers.
+The v6 validator rejects those schemas; do not retrofit new checks or fields into
+old packs. A newly recomputed package checksum says nothing about whether that
+check ran before an earlier host execution.

--- a/docs/guides/codex-host-package-proof.md
+++ b/docs/guides/codex-host-package-proof.md
@@ -25,7 +25,9 @@ Supply three explicit files; the driver never searches credentials or profiles:
   `assay-mcp-server` binary, and a release profile. The selected PATH binary
   must be in that prefix's `bin` directory. Only the selected package identity,
   version requirement, binary name, profile, target and rustc fields are retained,
-  not other installed packages or the original metadata file.
+  not other installed packages or the original metadata file. Cargo's verbose
+  `rustc` value may contain LF or CRLF line endings within a 2048-character bound;
+  its lines are printable ASCII. Versions and install references remain single-line.
 
 An operator must independently check acquisition of the index row and package.
 The offline validator does **not** fetch the index or authenticate copied index

--- a/scripts/ci/codex_host_proof.mjs
+++ b/scripts/ci/codex_host_proof.mjs
@@ -26,6 +26,7 @@ import {
   HARD_MAX_TIMEOUT_MS,
   HOST_ENV_NAMES,
   HOST_SUBJECTS,
+  PACKAGE_SUBJECTS,
   SCHEMA,
   SKILL_NAME,
   boundedPositiveInt,
@@ -47,6 +48,11 @@ import {
   CWD_MATCHES_PROJECT_ROOT,
   projectRetainedEvent,
   installSourceBound,
+  assayPackageVersion,
+  packageFiles,
+  verifyAssayPackage,
+  readBoundedFile,
+  parseJsonBytes,
   projectHostIdentity,
   proofAllowlist,
   requirePrivateDirectory,
@@ -61,6 +67,7 @@ import {
 } from "./codex_host_proof_validator.mjs";
 
 const INSTALL_SUBJECTS = Object.freeze(["codex", "codexCodeModeHost", "assayMcp"]);
+const PACKAGE_VERIFICATION = Symbol("producer-package-verification");
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_BYTES = 1_048_576;
@@ -105,6 +112,17 @@ export function parseArgs(argv) {
       case "--allow-live-turn":
         out.allowLiveTurn = true;
         break;
+      case "--assay-package":
+      case "--assay-index-row":
+      case "--assay-cargo-metadata": {
+        const key = { "--assay-package": "package", "--assay-index-row": "index", "--assay-cargo-metadata": "installation" }[arg];
+        out.packageInputs ??= {};
+        if (out.packageInputs[key]) throw new Error(`duplicate ${arg}`);
+        const value = next();
+        if (!value || !path.isAbsolute(value)) throw new Error(`${arg} requires an absolute file path`);
+        out.packageInputs[key] = value;
+        break;
+      }
       // Install source is declared, never inferred: how a binary got onto this
       // machine is not observable from the binary the host launches. Each token is
       // validated structurally here so nothing free-form reaches the record.
@@ -361,6 +379,37 @@ function probeAssayMcpVersion(binary) {
   return probeVersion(binary, "assay-mcp-server");
 }
 
+function retainAssayPackage(options, mcpPath, mcpSnapshot) {
+  const input = options.packageInputs;
+  if (!input?.package || !input.index || !input.installation) throw new Error("Assay package inputs are required before execution");
+  if (path.basename(input.installation) !== ".crates2.json" ||
+      fs.realpathSync(path.join(path.dirname(input.installation), "bin", "assay-mcp-server")) !== fs.realpathSync(mcpPath)) {
+    throw new Error("Assay package installation metadata must belong to the selected binary prefix");
+  }
+  const source = options.installSources.assayMcp;
+  const version = assayPackageVersion(source);
+  const key = `assay-mcp-server ${version} (registry+https://github.com/rust-lang/crates.io-index)`;
+  const cargo = parseJsonBytes(readBoundedFile(input.installation, HARD_MAX_BYTES), HARD_MAX_BYTES);
+  const entry = cargo?.installs?.[key];
+  if (!entry) throw new Error("Assay package is absent from Cargo installation metadata");
+  const installation = { package: key, version_req: entry.version_req, bins: entry.bins,
+    profile: entry.profile, target: entry.target, rustc: entry.rustc };
+  const chunks = [readBoundedFile(input.package, HARD_MAX_BYTES),
+    readBoundedFile(input.index, 256 * 1024), Buffer.from(stableStringify(installation))];
+  const created = [];
+  try {
+    for (let i = 0; i < PACKAGE_SUBJECTS.length; i += 1) {
+      const file = path.join(options.proofRoot, PACKAGE_SUBJECTS[i]);
+      fs.writeFileSync(file, chunks[i], { flag: "wx", mode: 0o600 });
+      created.push(file);
+    }
+    return { ...verifyAssayPackage(packageFiles(options.proofRoot), source), binarySha256: sha256File(mcpSnapshot) };
+  } catch (error) {
+    for (const file of created) fs.unlinkSync(file);
+    throw error;
+  }
+}
+
 export function resolveHostIdentity(options = {}) {
   const declared = options.installSources ?? {};
   const missing = INSTALL_SUBJECTS.filter((s) => !declared[s]);
@@ -398,6 +447,9 @@ export function resolveHostIdentity(options = {}) {
     snapshotNamedBinary(codexSource, snapRoot, "codex.snapshot", snapOpts);
     snapshotNamedBinary(codeModeHostSource, snapRoot, codeModeHostName, snapOpts);
     snapshotNamedBinary(mcpPath, snapRoot, "assay-mcp-server.snapshot", snapOpts);
+    // Before either --version probe: a host executable can itself start Assay.
+    const packageVerification = options.captureMode === "host-observation"
+      ? retainAssayPackage(options, mcpPath, mcpSnap) : null;
     const identity = {
       os: os.platform(),
       arch: os.arch(),
@@ -423,6 +475,10 @@ export function resolveHostIdentity(options = {}) {
       codexPath: codexSnap,
       mcpPath: mcpSnap,
     };
+    identity[PACKAGE_VERIFICATION] = packageVerification;
+    if (packageVerification && identity.assayMcp.version !== `assay-mcp-server ${packageVerification.version}`) {
+      throw new Error("Assay package version and probed binary version disagree");
+    }
     return identity;
   } catch (error) {
     for (const subject of [codexSnap, codeModeHostSnap, mcpSnap]) {
@@ -540,7 +596,7 @@ function retainedIdentityProjection(events, projectRoot) {
 }
 
 function writeProofFiles(options, pack) {
-  pack = { ...pack, events: retainedIdentityProjection(pack.events, options.projectRoot) };
+  pack = { ...pack, captureMode: options.captureMode, events: retainedIdentityProjection(pack.events, options.projectRoot) };
   const initialize = initializeFromEvents(pack.events, options.journey);
   const hostIdentity = projectHostIdentity(options.hostIdentity ?? null);
   const invocationArgv = persistableArgv(
@@ -560,6 +616,8 @@ function writeProofFiles(options, pack) {
     streamUnavailable: pack.streamUnavailable,
     initialize,
     hostIdentity,
+    packageVerification: options.hostIdentity?.[PACKAGE_VERIFICATION] ?? null,
+    proofRoot: options.proofRoot,
     invocation: { argv: invocationArgv, envNames: [...HOST_ENV_NAMES] },
     expected: {
       projectRoot: options.projectRoot,
@@ -605,10 +663,11 @@ function writeProofFiles(options, pack) {
     invocation: record.invocation,
     initialize,
     hostIdentity,
+    packageVerification: record.packageVerification,
     expected: record.expected,
     hashes: { events: sha256Utf8(eventsText) },
     allowlist: [
-      ...proofAllowlist(hostSubjectsRequired(options.captureMode, options.hostIdentity)),
+      ...proofAllowlist(hostSubjectsRequired(options.captureMode, options.hostIdentity), record.packageVerification != null),
     ].sort(),
   };
   writeJson(path.join(options.proofRoot, "manifest.json"), manifest);
@@ -694,7 +753,20 @@ export async function runProof(options) {
     options.hostIdentity = resolveHostIdentity({
       proofRoot: options.proofRoot,
       installSources: options.installSources,
+      captureMode: options.captureMode,
+      packageInputs: options.packageInputs,
     });
+  }
+  if (options.captureMode === "host-observation") {
+    // A supplied identity must not bypass the production acquisition gate.
+    const expected = options.hostIdentity?.[PACKAGE_VERIFICATION];
+    if (!expected || stableStringify({
+      ...verifyAssayPackage(packageFiles(options.proofRoot), options.hostIdentity.assayMcp.installSource),
+      binarySha256: sha256File(options.hostIdentity.assayMcp.path),
+    }) !== stableStringify(expected)) {
+      if (options.testOnlyChild) options.testOnlyChild.kill("SIGTERM");
+      throw new Error("Assay package verification is missing or changed before host execution");
+    }
   }
   let codexHome;
   try {

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -55,7 +55,7 @@ export function verifyAssayPackage(files, source) {
   if (!exactKeys(install, ["package", "version_req", "bins", "profile", "target", "rustc"]) ||
       install.package !== `assay-mcp-server ${version} (registry+https://github.com/rust-lang/crates.io-index)` ||
       install.version_req !== `=${version}` || !sameJson(install.bins, ["assay-mcp-server"]) ||
-      install.profile !== "release" || !boundedPrintable(install.target) || !boundedPrintable(install.rustc)) {
+      install.profile !== "release" || !boundedPrintable(install.target) || !boundedCompilerMetadata(install.rustc)) {
     throw new Error("Assay Cargo installation metadata does not name the pinned registry package");
   }
   return {
@@ -99,6 +99,12 @@ export function boundedPrintable(value, max = MAX_INSTALL_REFERENCE) {
     value.length <= max &&
     PRINTABLE_ASCII_LINE.test(value)
   );
+}
+
+// Cargo retains rustc -vV, including line endings, rather than just its first line.
+function boundedCompilerMetadata(value) {
+  return typeof value === "string" && value.length > 0 && value.length <= 2048 &&
+    value.split(/\r?\n/).every((line) => line === "" || boundedPrintable(line, 2048));
 }
 export const SKILL_NAME = "assay-golden-path";
 export const DECIDE_TOOL = "assay_policy_decide";

--- a/scripts/ci/codex_host_proof_validator.mjs
+++ b/scripts/ci/codex_host_proof_validator.mjs
@@ -9,7 +9,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const SCHEMA = "assay.codex-host-proof.v5";
+export const SCHEMA = "assay.codex-host-proof.v6";
 export const FAKE_USER_AGENT = "assay-codex-host-proof-fake/1";
 // Closed install-route vocabulary. "local-build" is recordable on purpose: a failed
 // provenance run must be retained as what it was, not omitted into a cleaner record.
@@ -19,12 +19,57 @@ export const INSTALL_ROUTES = Object.freeze([
   "host-bundled",
   "local-build",
 ]);
-// Routes that satisfy #2684 DoD cell 2. A local build never does.
+// Route admissibility is not package verification. Only crates-io has a
+// retained-package verifier in v6; other routes cannot claim that cell yet.
 export const PUBLISHED_INSTALL_ROUTES = Object.freeze([
   "github-release",
   "crates-io",
-  "host-bundled",
 ]);
+export const PACKAGE_SUBJECTS = Object.freeze([
+  "assay-package.crate", "assay-registry-row.json", "assay-install.json",
+]);
+export const PACKAGE_NONCLAIM = "Cargo installation metadata does not cryptographically bind the package to the binary or establish reproducibility or build integrity; retained registry bytes do not authenticate their origin";
+export const ASSAY_INDEX_SOURCE = "https://index.crates.io/as/sa/assay-mcp-server";
+
+// Both acquisition and offline consumption call this function over actual bytes.
+// This slice supports the crates.io route only. It does not infer an install route.
+export function assayPackageVersion(source) {
+  if (source?.route !== "crates-io") throw new Error("Assay package route is not supported by this verifier");
+  const match = /^assay-mcp-server@(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/.exec(source.reference);
+  if (!match) throw new Error("Assay package reference must pin its exact version");
+  return match[1];
+}
+
+export function verifyAssayPackage(files, source) {
+  const version = assayPackageVersion(source);
+  const bytes = readBoundedFile(files.package, HARD_MAX_BYTES);
+  const indexBytes = readBoundedFile(files.index, 256 * 1024);
+  const installBytes = readBoundedFile(files.installation, 16 * 1024);
+  const row = parseJsonBytes(indexBytes, 256 * 1024);
+  const install = parseJsonBytes(installBytes, 16 * 1024);
+  const digest = createHash("sha256").update(bytes).digest("hex");
+  if (row?.name !== "assay-mcp-server" || row.vers !== version || row.yanked !== false ||
+      !/^[a-f0-9]{64}$/.test(row.cksum) || row.cksum !== digest || bytes.length === 0) {
+    throw new Error("Assay registry package name, version, checksum or availability mismatch");
+  }
+  if (!exactKeys(install, ["package", "version_req", "bins", "profile", "target", "rustc"]) ||
+      install.package !== `assay-mcp-server ${version} (registry+https://github.com/rust-lang/crates.io-index)` ||
+      install.version_req !== `=${version}` || !sameJson(install.bins, ["assay-mcp-server"]) ||
+      install.profile !== "release" || !boundedPrintable(install.target) || !boundedPrintable(install.rustc)) {
+    throw new Error("Assay Cargo installation metadata does not name the pinned registry package");
+  }
+  return {
+    method: "crates-io-sha256", packageName: "assay-mcp-server", version,
+    indexSource: ASSAY_INDEX_SOURCE, packageSha256: digest,
+    indexSha256: createHash("sha256").update(indexBytes).digest("hex"),
+    installationSha256: createHash("sha256").update(installBytes).digest("hex"),
+    limitation: PACKAGE_NONCLAIM,
+  };
+}
+
+export function packageFiles(root) {
+  return Object.fromEntries(["package", "index", "installation"].map((key, i) => [key, path.join(root, PACKAGE_SUBJECTS[i])]));
+}
 export const MAX_INSTALL_REFERENCE = 200;
 // Contract: a reference or version is one line of printable ASCII, U+0020 to U+007E
 // inclusive. Everything else is refused. Stated as what that excludes, because the
@@ -119,8 +164,8 @@ export function requirePrivateProofRoot(proofRoot) {
   return requirePrivateDirectory(proofRoot, "proof root");
 }
 
-export function proofAllowlist(hasHostIdentity) {
-  return hasHostIdentity ? HOST_ALLOWLIST : ALLOWLIST;
+export function proofAllowlist(hasHostIdentity, hasPackage = false) {
+  return [...(hasHostIdentity ? HOST_ALLOWLIST : ALLOWLIST), ...(hasPackage ? PACKAGE_SUBJECTS : [])];
 }
 export const CELLS = Object.freeze([
   "skillDiscovered",
@@ -511,19 +556,20 @@ export function observedIdentityBound(
   return verifyLiveIdentity(identity, invocation, topology, proofRoot, journey);
 }
 
-export function requiredCellsForJourney(journey) {
+export function requiredCellsForJourney(journey, captureMode = "synthetic-fixture") {
+  const packageCells = captureMode === "host-observation" ? ["installRouteAdmissible", "installPackageVerified"] : [];
   switch (journey) {
     case "discovery":
-      return ["skillDiscovered"];
+      return [...packageCells, "skillDiscovered"];
     case "failures":
-      return CELLS.filter(
+      return [...packageCells, ...CELLS.filter(
         (name) =>
           name !== "driverCompleted" &&
           name !== "oneToolInvoked" &&
           name !== "structuredResultValidated",
-      );
+      )];
     case "tool":
-      return CELLS.filter((name) => name !== "driverCompleted");
+      return [...packageCells, ...CELLS.filter((name) => name !== "driverCompleted")];
     default:
       throw new Error(`unknown journey ${journey}`);
   }
@@ -568,7 +614,7 @@ export function driverOutcomeExit(pack, cells, journey) {
   if (cells?.driverCompleted?.status !== "pass") {
     return fail;
   }
-  const required = requiredCellsForJourney(journey);
+  const required = requiredCellsForJourney(journey, pack.captureMode);
   for (const name of required) {
     if (cells?.[name]?.status !== "pass") {
       return fail;
@@ -2056,6 +2102,26 @@ export function classifyRecord(record) {
     events,
   };
   const cells = classifyCells(events, meta, record.expected, journey, topology);
+  const source = record.hostIdentity?.assayMcp?.installSource;
+  cells.installRouteAdmissible = cell(PUBLISHED_INSTALL_ROUTES.includes(source?.route) ? "pass" : "unavailable",
+    "declared Assay route only; not authenticated install provenance");
+  cells.installPackageVerified = cell("unavailable", "Assay package evidence absent");
+  if (record.packageVerification != null) {
+    try {
+      const recomputed = {
+        ...verifyAssayPackage(packageFiles(record.proofRoot), source),
+        binarySha256: sha256File(path.join(record.proofRoot, "assay-mcp-server.snapshot")),
+      };
+      if (!sameJson(record.packageVerification, recomputed) ||
+          recomputed.binarySha256 !== record.hostIdentity?.assayMcp?.sha256 ||
+          record.hostIdentity.assayMcp.version !== `assay-mcp-server ${recomputed.version}`) {
+        throw new Error("package verification record or installed binary binding disagrees");
+      }
+      cells.installPackageVerified = cell("pass", `retained package checksum and installation declaration agree; ${PACKAGE_NONCLAIM}`);
+    } catch {
+      cells.installPackageVerified = cell("fail", "retained Assay package verification failed");
+    }
+  }
   return {
     schema: SCHEMA,
     cells,
@@ -2780,7 +2846,7 @@ const DEFAULT_MAX_BYTES = 1_048_576;
 export function readBoundedFile(file, maxBytes) {
   const requested = boundedPositiveInt("maxBytes", maxBytes, HARD_MAX_BYTES);
   const limit = Math.min(requested, HARD_MAX_BYTES);
-  const flags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0);
+  const flags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0) | (fs.constants.O_NONBLOCK || 0);
   const fd = fs.openSync(file, flags);
   try {
     const st = fs.fstatSync(fd);
@@ -2885,6 +2951,7 @@ function manifestShapeReason(manifest) {
       "invocation",
       "initialize",
       "hostIdentity",
+      "packageVerification",
       "expected",
       "hashes",
       "allowlist",
@@ -3014,7 +3081,7 @@ export function validateProofRoot(proofRoot, maxBytes = DEFAULT_MAX_BYTES) {
   }
   const present = namesIn(proofRoot).sort();
   const allowed = [
-    ...proofAllowlist(hostSubjectsRequired(manifest.captureMode, manifest.hostIdentity)),
+    ...proofAllowlist(hostSubjectsRequired(manifest.captureMode, manifest.hostIdentity), manifest.packageVerification != null),
   ].sort();
   try {
     assertAllowlistedRegularFiles(proofRoot, allowed);
@@ -3081,6 +3148,8 @@ export function validateProofRoot(proofRoot, maxBytes = DEFAULT_MAX_BYTES) {
     streamUnavailable: manifest.streamUnavailable,
     initialize: derivedInitialize,
     hostIdentity: manifest.hostIdentity ?? null,
+    packageVerification: manifest.packageVerification,
+    proofRoot,
     invocation: manifest.invocation ?? null,
     expected: manifest.expected,
     events,

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -84,6 +84,17 @@ test("#2823: package verification recomputes bytes and binds the declared packag
   restore();
   const verify = (declared = source) => validator.verifyAssayPackage(files, declared);
   assert.equal(verify().packageSha256, digest);
+  // Cargo's observed verbose layout, with a synthetic compiler commit identifier.
+  const verboseRustc = "rustc 1.92.0 (abcdef012 2025-12-08)\nbinary: rustc\ncommit-hash: abcdef0123456789abcdef0123456789abcdef0123\ncommit-date: 2025-12-08\nhost: aarch64-apple-darwin\nrelease: 1.92.0\nLLVM version: 21.1.3\n";
+  for (const rustc of [verboseRustc, verboseRustc.replaceAll("\n", "\r\n"), "x".repeat(2048)]) {
+    fs.writeFileSync(files.installation, JSON.stringify({ ...metadata, rustc }));
+    assert.equal(verify().packageSha256, digest, "bounded Cargo compiler metadata accepted");
+  }
+  for (const rustc of ["", "x".repeat(2049), "rustc\rhidden", "rustc\u0000", "rustc\tvalue", "rustc\u0085", "rustc\u2028", "rustc\u202e", "rustc\ufeff"]) {
+    fs.writeFileSync(files.installation, JSON.stringify({ ...metadata, rustc }));
+    assert.throws(verify, /Cargo installation metadata/, "hostile or unbounded compiler metadata refused");
+  }
+  restore();
   for (const [name, edit] of [
     ["changed package", () => fs.appendFileSync(files.package, "changed")],
     ["wrong checksum", () => fs.writeFileSync(files.index, JSON.stringify({ ...row, cksum: "0".repeat(64) }))],

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -169,6 +169,41 @@ test("#2823: retained package is rechecked by the consumer, including forged sto
   assert.equal(validateProofRoot(proofRoot).classified.cells.installPackageVerified.status, "fail");
 });
 
+test("#2823: a package changed by the version probe cannot reach host spawn", (t) => {
+  for (const changePackage of [false, true]) {
+    const proofRoot = portableLiveProofRoot();
+    const root = scratch();
+    t.after(() => fs.rmSync(proofRoot, { recursive: true, force: true }));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    const marker = path.join(root, "host-spawned");
+    const codexBin = path.join(root, "codex");
+    const projectRoot = seedProject();
+    writePortableNodeExecutable(codexBin, `
+import fs from "node:fs";
+import { spawn } from "node:child_process";
+if (process.argv.includes("--version")) {
+  if (${changePackage}) fs.appendFileSync(${JSON.stringify(path.join(proofRoot, "assay-package.crate"))}, "changed after first check");
+  process.stdout.write("codex-shadow/0.0.0\\n");
+} else {
+  fs.writeFileSync(${JSON.stringify(marker)}, "host started");
+  const child = spawn(${JSON.stringify(process.execPath)}, ${JSON.stringify([FAKE, "--scenario", "valid", "--project-root", projectRoot])}, { stdio: "inherit" });
+  const stop = () => { try { child.kill("SIGTERM"); } catch {} };
+  process.on("SIGTERM", stop);
+  child.on("close", code => process.exit(code ?? 1));
+}
+`);
+    const run = driveCli("valid", "discovery", { captureMode: "host-observation", proofRoot, projectRoot, codexBin });
+    assert.equal(fs.existsSync(marker), !changePackage,
+      "the changed package must stop host spawn; the unchanged control must reach it");
+    if (changePackage) {
+      assert.notEqual(run.status, 0);
+      assert.match(run.stderr, /package.*checksum|checksum.*mismatch/i);
+    } else {
+      assert.equal(validateProofRoot(proofRoot).classified.cells.installPackageVerified.status, "pass");
+    }
+  }
+});
+
 test("#2813: shared itemsView validation preserves the closed vocabulary and legacy absence", async () => {
   const { turnItemsViewReason } = await import("./codex_host_proof_validator.mjs");
   assert.equal(typeof turnItemsViewReason, "function");

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -86,11 +86,17 @@ test("#2823: package verification recomputes bytes and binds the declared packag
   assert.equal(verify().packageSha256, digest);
   // Cargo's observed verbose layout, with a synthetic compiler commit identifier.
   const verboseRustc = "rustc 1.92.0 (abcdef012 2025-12-08)\nbinary: rustc\ncommit-hash: abcdef0123456789abcdef0123456789abcdef0123\ncommit-date: 2025-12-08\nhost: aarch64-apple-darwin\nrelease: 1.92.0\nLLVM version: 21.1.3\n";
-  for (const rustc of [verboseRustc, verboseRustc.replaceAll("\n", "\r\n"), "x".repeat(2048)]) {
+  // Each line stays below the per-line ceiling, isolating the total ceiling.
+  const multilineAtLimit = [
+    "x".repeat(1023) + "\n" + "y".repeat(1024),
+    "x".repeat(1023) + "\r\n" + "y".repeat(1023),
+  ];
+  for (const rustc of [verboseRustc, verboseRustc.replaceAll("\n", "\r\n"), "x".repeat(2048), ...multilineAtLimit]) {
     fs.writeFileSync(files.installation, JSON.stringify({ ...metadata, rustc }));
     assert.equal(verify().packageSha256, digest, "bounded Cargo compiler metadata accepted");
   }
-  for (const rustc of ["", "x".repeat(2049), "rustc\rhidden", "rustc\u0000", "rustc\tvalue", "rustc\u0085", "rustc\u2028", "rustc\u202e", "rustc\ufeff"]) {
+  const multilineOverLimit = multilineAtLimit.map((rustc) => rustc + "y");
+  for (const rustc of ["", "x".repeat(2049), ...multilineOverLimit, "rustc\rhidden", "rustc\u0000", "rustc\tvalue", "rustc\u0085", "rustc\u2028", "rustc\u202e", "rustc\ufeff"]) {
     fs.writeFileSync(files.installation, JSON.stringify({ ...metadata, rustc }));
     assert.throws(verify, /Cargo installation metadata/, "hostile or unbounded compiler metadata refused");
   }

--- a/scripts/ci/test_codex_host_proof.mjs
+++ b/scripts/ci/test_codex_host_proof.mjs
@@ -56,6 +56,119 @@ const FAKE = path.join(HERE, "fixtures/codex-host-proof/fake-app-server.mjs");
 const DRIVER_SRC = fs.readFileSync(path.join(HERE, "codex_host_proof.mjs"), "utf8");
 const VALIDATOR_SRC = fs.readFileSync(path.join(HERE, "codex_host_proof_validator.mjs"), "utf8");
 
+test("#2823: package verification recomputes bytes and binds the declared package", async (t) => {
+  const validator = await import("./codex_host_proof_validator.mjs");
+  assert.equal(typeof validator.verifyAssayPackage, "function");
+  const root = scratch();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const bytes = Buffer.from("synthetic package bytes, not published evidence");
+  const { createHash } = await import("node:crypto");
+  const digest = createHash("sha256").update(bytes).digest("hex");
+  const source = { route: "crates-io", reference: "assay-mcp-server@6.0.0" };
+  const row = { name: "assay-mcp-server", vers: "6.0.0", cksum: digest, yanked: false };
+  const metadata = {
+    package: "assay-mcp-server 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+    version_req: "=6.0.0", bins: ["assay-mcp-server"],
+    profile: "release", target: "aarch64-apple-darwin", rustc: "rustc test fixture",
+  };
+  const files = {
+    package: path.join(root, "package"),
+    index: path.join(root, "index"),
+    installation: path.join(root, "installation"),
+  };
+  const restore = () => {
+    fs.writeFileSync(files.package, bytes);
+    fs.writeFileSync(files.index, JSON.stringify(row));
+    fs.writeFileSync(files.installation, JSON.stringify(metadata));
+  };
+  restore();
+  const verify = (declared = source) => validator.verifyAssayPackage(files, declared);
+  assert.equal(verify().packageSha256, digest);
+  for (const [name, edit] of [
+    ["changed package", () => fs.appendFileSync(files.package, "changed")],
+    ["wrong checksum", () => fs.writeFileSync(files.index, JSON.stringify({ ...row, cksum: "0".repeat(64) }))],
+    ["wrong crate", () => fs.writeFileSync(files.index, JSON.stringify({ ...row, name: "other" }))],
+    ["wrong version", () => fs.writeFileSync(files.index, JSON.stringify({ ...row, vers: "6.0.1" }))],
+    ["yanked", () => fs.writeFileSync(files.index, JSON.stringify({ ...row, yanked: true }))],
+    ["wrong installation", () => fs.writeFileSync(files.installation, JSON.stringify({ ...metadata, version_req: "=6.0.1" }))],
+    ["missing bytes", () => fs.unlinkSync(files.package)],
+    ["oversized bytes", () => fs.writeFileSync(files.package, Buffer.alloc(4 * 1024 * 1024 + 1))],
+  ]) {
+    restore(); edit();
+    assert.throws(verify, undefined, name);
+    restore(); assert.equal(verify().packageSha256, digest, `${name} restored control`);
+  }
+  for (const route of ["local-build", "host-bundled", "github-release"]) {
+    assert.throws(() => verify({ ...source, route }), undefined, route);
+  }
+  fs.writeFileSync(files.index, JSON.stringify(row, null, 2));
+  assert.equal(verify().packageSha256, digest, "format-only no-op stays green");
+});
+
+test("#2823: live journeys require package evidence at the final outcome funnel", async () => {
+  const { requiredCellsForJourney, driverOutcomeExit } = await import("./codex_host_proof_validator.mjs");
+  for (const journey of ["discovery", "failures", "tool"]) {
+    const required = requiredCellsForJourney(journey, "host-observation");
+    assert.ok(required.includes("installRouteAdmissible"));
+    assert.ok(required.includes("installPackageVerified"));
+    const cells = Object.fromEntries([...CELLS, ...required].map((key) => [key, { status: "pass" }]));
+    const pack = { childExit: 0, truncated: false, streamUnavailable: false, captureMode: "host-observation" };
+    assert.equal(driverOutcomeExit(pack, cells, journey), 0);
+    for (const key of ["installRouteAdmissible", "installPackageVerified"]) {
+      for (const status of ["unavailable", "fail", "not_applicable"]) {
+        cells[key] = { status };
+        assert.notEqual(driverOutcomeExit(pack, cells, journey), 0, `${journey}/${key}/${status}`);
+      }
+      delete cells[key];
+      assert.notEqual(driverOutcomeExit(pack, cells, journey), 0);
+      cells[key] = { status: "pass" };
+    }
+  }
+});
+
+test("#2823: missing package prevents even the first version probe", (t) => {
+  const root = scratch();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const codexMarker = path.join(root, "codex-executed");
+  const assayMarker = path.join(root, "assay-executed");
+  const codex = writeMarkedBin("codex", codexMarker, "codex-fixture/0.0.0");
+  const assay = writeMarkedBin("assay-mcp-server", assayMarker, "assay-mcp-server 6.0.0");
+  const oldPath = process.env.PATH;
+  process.env.PATH = `${path.dirname(codex)}${path.delimiter}${path.dirname(assay)}${path.delimiter}${oldPath}`;
+  try {
+    assert.throws(() => resolveHostIdentityProduction({
+      captureMode: "host-observation", proofRoot: root,
+      installSources: { ...TEST_INSTALL_SOURCES, assayMcp: { route: "crates-io", reference: "assay-mcp-server@6.0.0" } },
+    }), /package/i);
+    assert.equal(fs.existsSync(codexMarker), false);
+    assert.equal(fs.existsSync(assayMarker), false);
+  } finally { process.env.PATH = oldPath; }
+});
+
+test("#2823: retained package is rechecked by the consumer, including forged stored results", (t) => {
+  const proofRoot = portableLiveProofRoot();
+  t.after(() => fs.rmSync(proofRoot, { recursive: true, force: true }));
+  const result = driveCli("valid", "failures", { captureMode: "host-observation", proofRoot });
+  const manifest = JSON.parse(fs.readFileSync(path.join(proofRoot, "manifest.json"), "utf8"));
+  assert.equal(manifest.schema, "assay.codex-host-proof.v6");
+  const control = validateProofRoot(proofRoot);
+  assert.equal(control.classified.cells.installPackageVerified.status, "pass", result.stderr);
+  assert.equal(control.classified.cells.installRouteAdmissible.status, "pass");
+  assert.equal(control.externalAttestation, "not_provided");
+  const file = path.join(proofRoot, "assay-package.crate");
+  const bytes = fs.readFileSync(file);
+  fs.appendFileSync(file, "altered");
+  const changed = validateProofRoot(proofRoot);
+  assert.equal(changed.ok, false);
+  assert.equal(changed.classified.cells.installPackageVerified.status, "fail");
+  assert.ok(changed.reasons.includes("stored classification disagrees with recomputed classification"));
+  fs.writeFileSync(file, bytes);
+  assert.equal(validateProofRoot(proofRoot).classified.cells.installPackageVerified.status, "pass");
+  manifest.packageVerification.binarySha256 = "0".repeat(64);
+  fs.writeFileSync(path.join(proofRoot, "manifest.json"), stableStringify(manifest));
+  assert.equal(validateProofRoot(proofRoot).classified.cells.installPackageVerified.status, "fail");
+});
+
 test("#2813: shared itemsView validation preserves the closed vocabulary and legacy absence", async () => {
   const { turnItemsViewReason } = await import("./codex_host_proof_validator.mjs");
   assert.equal(typeof turnItemsViewReason, "function");
@@ -252,16 +365,29 @@ child.on("close", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
 }
 
 function writeShadowMcp() {
-  const bin = path.join(scratch(), "assay-mcp-server");
+  const prefix = scratch();
+  fs.mkdirSync(path.join(prefix, "bin"));
+  const bin = path.join(prefix, "bin", "assay-mcp-server");
   writePortableNodeExecutable(
     bin,
     `if (process.argv.includes("--version")) {
-  process.stdout.write("assay-mcp-server-shadow/0.0.0\\n");
+  process.stdout.write("assay-mcp-server 0.0.0-test\\n");
   process.exit(0);
 }
-process.stdout.write("assay-mcp-server-shadow/0.0.0\\n");
+process.stdout.write("assay-mcp-server 0.0.0-test\\n");
 `,
   );
+  const bytes = "synthetic package, never a published installation";
+  fs.writeFileSync(path.join(prefix, "fixture.crate"), bytes);
+  fs.writeFileSync(path.join(prefix, "index.json"), JSON.stringify({
+    name: "assay-mcp-server", vers: "0.0.0-test", yanked: false, cksum: sha256Utf8(bytes),
+  }));
+  fs.writeFileSync(path.join(prefix, ".crates2.json"), JSON.stringify({ installs: {
+    "assay-mcp-server 0.0.0-test (registry+https://github.com/rust-lang/crates.io-index)": {
+      version_req: "=0.0.0-test", bins: ["assay-mcp-server"], profile: "release",
+      target: "fixture-target", rustc: "fixture-rustc",
+    },
+  } }));
   return bin;
 }
 
@@ -286,6 +412,12 @@ function driveCli(scenario, journey = "tool", extra = {}) {
     String(extra.timeoutMs ?? 4000),
     ...CLI_INSTALL_SOURCE_ARGS,
   ];
+  if (extra.captureMode === "host-observation") {
+    const prefix = path.dirname(path.dirname(mcpBin));
+    args.push("--assay-package", path.join(prefix, "fixture.crate"),
+      "--assay-index-row", path.join(prefix, "index.json"),
+      "--assay-cargo-metadata", path.join(prefix, ".crates2.json"));
+  }
   if (extra.allowLiveTurn) {
     args.push("--allow-live-turn");
   }
@@ -319,7 +451,7 @@ test("driver calls the validator classification function; no extra classify modu
 test("synthetic positive control: cells pass without inventing external attestation", async () => {
   const { classified, manifest, proofRoot, driverOutcome, childExitCode, events } = await drive("valid");
   assert.equal(manifest.captureMode, "synthetic-fixture");
-  assert.equal(manifest.schema, "assay.codex-host-proof.v5");
+  assert.equal(manifest.schema, "assay.codex-host-proof.v6");
   assert.equal(childExitCode, 0);
   assert.equal(driverOutcome.exitCode, 0);
   assert.equal(manifest.childExitCode, 0);
@@ -1137,7 +1269,7 @@ child.on("close", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
       assert.notEqual(hostCli.status, 0);
       assert.deepEqual(
         proofFiles(hostCli.proofRoot),
-        retainedFilesWithIdentity,
+        [...retainedFilesWithIdentity, "assay-package.crate", "assay-registry-row.json", "assay-install.json"].sort(),
         `host-observation ${row.journey} failure must retain its proof-owned subjects: ${hostCli.stderr || hostCli.stdout}`,
       );
       const checked = validateProofRoot(hostCli.proofRoot);
@@ -2142,7 +2274,7 @@ test("PATH shadows drive observed Codex and Assay MCP identities", () => {
     assert.deepEqual(ignored.codex.installSource, TEST_INSTALL_SOURCES.codex);
     assert.deepEqual(ignored.assayMcp.installSource, TEST_INSTALL_SOURCES.assayMcp);
     assert.match(ignored.codex.version, /codex-shadow/);
-    assert.match(ignored.assayMcp.version, /assay-mcp-server-shadow/);
+    assert.equal(ignored.assayMcp.version, "assay-mcp-server 0.0.0-test");
     assert.notEqual(ignored.codex.path, fs.realpathSync(flagCodex));
     assert.notEqual(ignored.assayMcp.path, fs.realpathSync(flagMcp));
   } finally {


### PR DESCRIPTION
## Scope

Fixes #2823. Leaves #2684, #2812 and #2194 open; their live host-proof acceptance remains separate.

Head: 96684bd99ca2d94d8b5bfc67bdd290c7c4bcc18a
Current base: 862ba90685627b1a9a646bde31bd496555462194
Writer: Codex, /Users/roelschuurkes/wt-codex-2823-package-preflight

Host-proof v6 retains actual Assay crates.io package bytes, the selected registry row and Cargo installation metadata. Producer and offline consumer share checksum/name/version/installation validation. Verification precedes binary version probes and repeats immediately before host execution, so tampering during a version probe is refused. Multiline Cargo compiler metadata accepts printable LF/CRLF lines within a total 2048-character ceiling.

Only Assay crates.io package verification is implemented. Historical v4/v5 packs remain immutable under pinned verifiers. Copied unsigned registry bytes do not authenticate their origin; Cargo installation declarations do not prove reproducible builds or cryptographic package-to-binary integrity.

## Verification

Measured committed content: 96684bd99ca2d94d8b5bfc67bdd290c7c4bcc18a, writer worktree above, macOS, /usr/local/bin/node v20.16.0.

- Full Node contract suite: 197 passed, zero failed or skipped. Normal commit and push hooks passed, including format, clippy and the Linux cross-target compile gate. Diff whitespace check passed.
- Prior independent review found removal of the second pre-spawn check survived. The regression test now alters retained package bytes during the version probe: unaltered control reaches spawn, altered arm is refused. Ruley independently confirmed the deletion fails at prior head 8f1d70a; Ruley confirmed this again in the fresh full-head review.
- The earlier total-compiler-length-only mutant survived because the per-line limit masked it. New LF/CRLF cases accept exactly 2048 total characters and reject 2049 while each line stays below its own cap. Old-test mutant is green, new-test mutant fails on the intended assertion, restored and comment-only controls pass. This last commit changes tests only.
- Exact-head retained logs and measurement manifest: /Users/roelschuurkes/assay-review-records/2823/96684bd99/.

## Review and claim boundaries

Ruley independently reviewed this exact head and returned READY: https://github.com/Rul1an/assay/pull/2824#issuecomment-5560415563. Actual reviewer declaration: ruley/grokbot-review-1; GitHub publisher: Rul1an. The reviewer authored and confirmed the raw published record. Its body differs from the local carrier only by an omitted terminal newline; both originals and hashes are retained. Reviewer authentication is not claimed. Prior a24 BLOCKED and 8f READY records remain historical. All required checks are green on this head: CI, review-record-check, host-capability-check and lane-check/proof (no delegated proof required).

Tests use local fixture stubs. No new live model, Assay/Codex/Claude installation journey, release, tag or launch acceptance is claimed. Actual reviewer, GitHub publisher and evidence URL must remain separately identified.
