### PR TITLE
test(ci): bind child-presence assertions to discovery probes

### DIFF
--- a/scripts/ci/test-action-discovery-junction.sh
+++ b/scripts/ci/test-action-discovery-junction.sh
@@ -982,11 +982,6 @@ print("ok    mock-child-presence-eperm-unavailable")
 with patch.object(os, "kill", side_effect=OSError(errno.EIO, "I/O error")):
     assert mod.classify_pid(1) == "unavailable"
 print("ok    mock-child-presence-other-oserror-unavailable")
-
-# Weak predicate regression: nonzero kill rc must not imply absence.
-# classify_pid under EPERM is unavailable, so presence is not established.
-assert mod.classify_pid.__doc__ and "Only ESRCH" in mod.classify_pid.__doc__
-print("ok    mock-child-presence-only-esrch-is-absence")
 PYPRESMOCK
 
   # Teardown: signal only the probe-recorded child PID (never rediscover a pgid).
@@ -1020,8 +1015,8 @@ PYPRESMOCK
 
   # Cooperative synthetic child: group TERM/KILL reaps a normal sleep descendant.
   # Without start_new_session+killpg, subprocess.run(timeout=) leaves this child alive.
-  {
-    local probe_dir probe_sh child_pid_file probe_rc child_pid
+  probe_cooperative_child() {
+    local probe_dir probe_sh child_pid_file probe_rc child_pid probe_err
     probe_dir="$(mktemp -d "${TMPDIR:-/tmp}/2802-pg-child.XXXXXX")"
     register_junction_temp "${probe_dir}"
     child_pid_file="${probe_dir}/child.pid"
@@ -1065,7 +1060,7 @@ PROBE
   }
 
   # Parent exits on TERM; child ignores TERM — proves KILL escalation is not skipped on leader exit.
-  {
+  probe_term_ignoring_child() {
     local probe_dir probe_sh child_pid_file probe_rc child_pid
     probe_dir="$(mktemp -d "${TMPDIR:-/tmp}/2802-pg-termign.XXXXXX")"
     register_junction_temp "${probe_dir}"
@@ -1109,6 +1104,62 @@ PROBE
     require_child_absent "${child_pid}" "TERM-ignore child probe"
     ok "process-group-kills-term-ignoring-child"
   }
+
+  # Exercise each actual probe's refusal path without launching a child or sending a signal.
+  # A helper-only errno test cannot notice a removed/unreachable require_child_absent call.
+  check_probe_acceptance() {
+    local probe="$1" acceptance_status expected rc out
+    out="$(mktemp "${TMPDIR:-/tmp}/2806-probe-acceptance.XXXXXX")"
+    register_junction_temp "${out}"
+    for acceptance_status in absent alive unavailable; do
+      set +e
+      (
+        set -e
+        # Own only this acceptance invocation's temporary probe files.
+        JUNCTION_TEMPS=()
+        trap cleanup_junction_temps EXIT
+        python3() {
+          if [[ "$1" == "${pg_runner}" ]]; then
+            # Do not execute the generated parent script; supply its numeric PID record.
+            printf '12345\n' >"${@: -1}"
+            return 124
+          fi
+          [[ "$1" == "${child_presence}" ]] || die "unexpected acceptance Python invocation"
+          printf '%s\n' "${acceptance_status}"
+          case "${acceptance_status}" in
+            absent) return 0 ;;
+            alive) return 1 ;;
+            unavailable) return 2 ;;
+          esac
+        }
+        sleep() { :; }
+        reap_owned_probe_child() { :; } # The PID is synthetic: never signal it.
+        "${probe}"
+      ) >"${out}" 2>&1
+      rc=$?
+      set -e
+      if [[ "${acceptance_status}" == absent ]]; then
+        [[ "${rc}" -eq 0 ]] || { cat "${out}" >&2; die "${probe}: absent acceptance failed"; }
+        grep -Fq 'ok    process-group-kills-' "${out}" \
+          || die "${probe}: absent acceptance did not reach success"
+      else
+        [[ "${rc}" -eq 1 ]] || die "${probe}: ${acceptance_status} acceptance failed to refuse (rc=${rc})"
+        expected='still alive'
+        [[ "${acceptance_status}" != unavailable ]] || expected='presence UNAVAILABLE'
+        grep -Fq "${expected}" "${out}" \
+          || { cat "${out}" >&2; die "${probe}: ${acceptance_status} acceptance lost refusal diagnostic"; }
+        if grep -Fq 'ok    process-group-kills-' "${out}"; then
+          die "${probe}: ${acceptance_status} acceptance reported cleanup success"
+        fi
+      fi
+      ok "${probe}-${acceptance_status}-acceptance"
+    done
+  }
+  check_probe_acceptance probe_cooperative_child
+  check_probe_acceptance probe_term_ignoring_child
+
+  probe_cooperative_child
+  probe_term_ignoring_child
 
   # Eager cleanup of discover scratches; EXIT trap remains as backstop.
   cleanup_junction_temps

--- a/scripts/ci/test-check-assay-action-pin.sh
+++ b/scripts/ci/test-check-assay-action-pin.sh
@@ -96,7 +96,7 @@ expect_fail() {
     cat "${scratch}/err" >&2
     exit 1
   fi
-  echo "ok    ${name} (owner gate failed)"
+  echo "ok    ${name}"
 }
 
 expect_ok() {


### PR DESCRIPTION
## Description

Removing either child-presence assertion previously left the discovery tests green. Both real probe bodies now run through absent/alive/unavailable acceptance cases, so removing, commenting out or making their assertion unreachable fails the named test. Live process isolation, cleanup and timeout behavior remain unchanged.

Also removes a docstring-only check and a misleading unconditional diagnostic suffix, while retaining the behavioral errno and expected-error checks.

Finalize #2806. Leaves #2778 open.

## Verification

Exact reviewed head: `a27b1c5a86d7be1ca0e8eca4ca87786dff3db7ed`; base: `7b505ad06545f264a7f4e1139de365983b33a001`.

Independent reviewer `codex/private_launch_context` ran the full action-pin battery (including the complete discovery junction) and continue-on-error battery successfully in an isolated source archive. Seven inert removal/comment/unreachable mutations failed as intended; baseline and comment-wording controls passed. The expected-diagnostic helper also rejected an incorrect diagnostic. Review toolchain: Bash 5.3.15, Python 3.14.3 and Ruby 2.6.10p210 on macOS.

Builder: `codex/owned_build_space_audit`; independent reviewer: `codex/private_launch_context`; GitHub publisher: `Rul1an`. Reviewer identity and independence are declared, not authenticated by the publisher login. The exact-head review record is published separately.

Local test results are separate from hosted CI and published-binary host evidence. No process-isolation removal mutation was executed; the seven negative controls were inert.

Normal pre-push hooks passed, including shellcheck, cargo fmt, workspace clippy and the Linux cross-target gate, with offline Cargo, one build job and a worktree-local target. The hook summary does not expose individual Linux native-dependency coverage, so no complete Linux compilation claim is made. The remote branch was verified at the reviewed head after push.
