### PR TITLE
docs: mark the completed release programme inactive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ restate or weaken this contract.
 ## Canonical State
 
 - Repository truth is the checked-in code and documentation.
-- The public execution ledger for the active programme is named on this line: [issue #2764](https://github.com/Rul1an/assay/issues/2764).
+- The public execution ledger for the active programme is named on this line. **No programme is active.** The previous one, [issue #2764](https://github.com/Rul1an/assay/issues/2764), closed on 2026-09-03.
 - Keep the number to the ledger line; everywhere else the contract names the role, so the next
   programme costs one edit here rather than one in every section. Name the new ledger there when
   one opens, and say so plainly there when none is active. Nothing enforces that, so it is an


### PR DESCRIPTION
The agent contract still identifies the completed Assay 6.0 programme as active. Its ledger was closed on 2026-09-03, so new handoffs could be routed to a closed issue. Mark the programme inactive and retain the previous ledger link and closure date. The remaining operating rules are unchanged.

Verification for `47afda40a278d1aafc03a9cd8a5e8dce03cdc8d3` in `/Users/roelschuurkes/wt-codex-closed-programme-pointer`: the existing programme-truth suite passed before commit and again through normal commit hooks; formatting and applicable hooks passed. The live ledger API reports `CLOSED` with `closedAt=2026-09-03T20:45:36Z`. This is a one-line documentation change; no runtime behavior or release changes. Independent final-head review and hosted checks remain merge prerequisites.
