### PR TITLE
feat(evidence): relying-party gate over a CAP-1 coverage attestation

### DIFF
--- a/crates/assay-evidence/src/coverage_attestation.rs
+++ b/crates/assay-evidence/src/coverage_attestation.rs
@@ -1,0 +1,563 @@
+//! Relying-party decision layer over a CAP-1 coverage attestation.
+//!
+//! CAP-1, `draft-hillier-coverage-attestation-00` (Hillier / Certisyn, 2026-08-20), is a
+//! tool-agnostic vocabulary for stating what an examination examined, what it did not, and why:
+//! a declared denominator with a declared basis, a closed disposition for every unexamined unit,
+//! and normative rules R0 to R8 that a verifier enforces. Its sections 1.3 and 9 say exactly what
+//! conformance establishes: internal consistency, never truthfulness, and nothing about the
+//! producer. "A conforming document may be entirely false."
+//!
+//! This module is the layer those sections scope out. Given a document that already CONFORMS
+//! (this module runs no CAP-1 verifier and claims no CAP-1 implementation) and the relying
+//! party's OWN state, it answers, per claim kind, what the accounting supports. The vocabulary is
+//! the one this crate already uses for coding-agent evidence and the runner substrate mirrors:
+//! [`CodingAgentClaimKind`] in, [`CodingAgentGateDecision`] out, worst wins.
+//!
+//! One rule, one function. The claim-kind asymmetry (partial coverage supports "this happened",
+//! degrades "these are all of them", blocks "this did not happen"; a self-reported account caps
+//! at `asserted`) is the runner substrate's rule, restated here over a CAP-1 stratum rather than
+//! reinvented. `tests/cap1_relying_party_gate.rs` pins agreement with
+//! [`coding_agent_claim_decision`] on the two shapes that overlap, and pins decision parity with
+//! the Python reference at `github.com/Rul1an/cap1-conforming-but-misleading`, whose vectors
+//! are the fixtures.
+//!
+//! What the rules read, stated exactly. Every rule derives from the document plus the relying
+//! party's context. The document's identities (producer name, subject ref, unit names, catalogue
+//! digest, counts) are producer-written strings and this gate authenticates none of them: a
+//! producer who relabels an identity to one the relying party accepts is not caught here.
+//! Binding identities is a composition profile's job; Iman Schrock's
+//! `EP-CAP1-COVERAGE-COMPOSITION-v1` (emilia-protocol, 2026-08-22) is the published instance and
+//! already binds five of these seven axes at the byte layer. Absence is evaluated over the stratum
+//! the assertion cites, which is what R6 binds it to; CAP-1's free-text `qualifier` is not read.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::coding_agent::{CodingAgentClaimKind, CodingAgentGateDecision};
+
+/// A CAP-1 document, as the normative JSON Schema shapes it (`additionalProperties: false`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Cap1Document {
+    pub profile: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub producer: Option<Cap1Producer>,
+    pub subject: Cap1Subject,
+    pub strata: Vec<Cap1Stratum>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub absence_assertions: Option<Vec<Cap1AbsenceAssertion>>,
+    pub integrity: Cap1Integrity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub as_of: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Cap1Producer {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Cap1Subject {
+    pub kind: String,
+    #[serde(rename = "ref")]
+    pub reference: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub digest: Option<Cap1Digest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Cap1Digest {
+    pub algorithm: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Cap1Stratum {
+    pub id: String,
+    pub population: String,
+    pub basis: Cap1Basis,
+    pub eligible: u64,
+    pub examined: u64,
+    pub unexamined: Vec<Cap1Unexamined>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supports: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Cap1Basis {
+    pub kind: Cap1BasisKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub catalogue_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub catalogue_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enumeration_method: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// CAP-1 section 4.2: ordered by how much a reader can do with them, weakest last.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Cap1BasisKind {
+    Catalogue,
+    Enumeration,
+    Declared,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Cap1Unexamined {
+    pub unit: String,
+    pub disposition: Cap1Disposition,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub withheld_digest: Option<String>,
+}
+
+/// CAP-1 section 6, the closed vocabulary. Closed here too: an unknown value fails to parse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Cap1Disposition {
+    NotApplicable,
+    DisabledByPolicy,
+    UnsupportedInput,
+    ResourceExhausted,
+    Failed,
+    Unavailable,
+    OutOfScope,
+    Withheld,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Cap1AbsenceAssertion {
+    pub assertion: String,
+    pub stratum: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub qualifier: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Cap1Integrity {
+    pub complete: bool,
+    pub statement: String,
+    #[serde(default)]
+    pub uncapped_verdict: Option<String>,
+    #[serde(default)]
+    pub capped_to: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unaccounted: Option<Vec<String>>,
+}
+
+/// The relying party's OWN state. Nothing in it is taken from a producer.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Cap1RelyingPartyContext {
+    /// Catalogue digests the relying party fixed BEFORE any result was known.
+    #[serde(default)]
+    pub precommitted_catalogue_digests: Vec<String>,
+    /// Catalogue digest to the unit list the relying party itself holds behind it.
+    #[serde(default)]
+    pub catalogue_units: BTreeMap<String, Vec<String>>,
+    /// Units the relying party can itself show do not apply to the subject.
+    #[serde(default)]
+    pub confirmable_not_applicable: Vec<String>,
+    /// Units the relying party's own authorisation excludes.
+    #[serde(default)]
+    pub confirmable_out_of_scope: Vec<String>,
+    /// Withheld digest to the result bytes the relying party holds; checked by hash.
+    #[serde(default)]
+    pub withheld_results: BTreeMap<String, String>,
+    /// Producer names the relying party accepts as observers distinct from the subject.
+    /// Names, not authenticated identities.
+    #[serde(default)]
+    pub independent_producers: Vec<String>,
+}
+
+/// The seven rules, named as the Python reference names them so run records line up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum Cap1Rule {
+    #[serde(rename = "C1_denominator_precommitted")]
+    DenominatorPrecommitted,
+    #[serde(rename = "C2_applicability_confirmable")]
+    ApplicabilityConfirmable,
+    #[serde(rename = "C3_absence_bounded_by_examined_units")]
+    AbsenceBoundedByExaminedUnits,
+    #[serde(rename = "C4_withheld_resolvable")]
+    WithheldResolvable,
+    #[serde(rename = "C5_population_granularity")]
+    PopulationGranularity,
+    #[serde(rename = "C6_producer_independent_of_subject")]
+    ProducerIndependentOfSubject,
+    #[serde(rename = "C7_unit_identity_unique")]
+    UnitIdentityUnique,
+}
+
+impl Cap1Rule {
+    pub const ALL: [Cap1Rule; 7] = [
+        Cap1Rule::DenominatorPrecommitted,
+        Cap1Rule::ApplicabilityConfirmable,
+        Cap1Rule::AbsenceBoundedByExaminedUnits,
+        Cap1Rule::WithheldResolvable,
+        Cap1Rule::PopulationGranularity,
+        Cap1Rule::ProducerIndependentOfSubject,
+        Cap1Rule::UnitIdentityUnique,
+    ];
+
+    /// The Python reference's rule id, for run-record parity.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Cap1Rule::DenominatorPrecommitted => "C1_denominator_precommitted",
+            Cap1Rule::ApplicabilityConfirmable => "C2_applicability_confirmable",
+            Cap1Rule::AbsenceBoundedByExaminedUnits => "C3_absence_bounded_by_examined_units",
+            Cap1Rule::WithheldResolvable => "C4_withheld_resolvable",
+            Cap1Rule::PopulationGranularity => "C5_population_granularity",
+            Cap1Rule::ProducerIndependentOfSubject => "C6_producer_independent_of_subject",
+            Cap1Rule::UnitIdentityUnique => "C7_unit_identity_unique",
+        }
+    }
+}
+
+/// What is missing, when something is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Cap1Gap {
+    DenominatorPostHoc,
+    DenominatorNotPrecommitted,
+    SelfClassifiedDisposition,
+    PartialOnly,
+    WithheldUnresolvable,
+    PopulationMismatch,
+    SelfReportedOnly,
+    ProducerNotAcceptedIndependent,
+    DuplicateUnitIdentity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Cap1Finding {
+    pub rule: Cap1Rule,
+    pub decision: CodingAgentGateDecision,
+    pub gap: Cap1Gap,
+    pub detail: String,
+}
+
+/// What a relying party may conclude from one CAP-1 document, for one kind of claim.
+///
+/// No claim ceiling is assigned: the ceiling ladder needs a source class, and a CAP-1 document
+/// carries a producer name, not a vantage. A `SelfReportedOnly` gap says the one thing this
+/// gate can know about vantage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Cap1ClaimDecision {
+    pub claim_kind: CodingAgentClaimKind,
+    pub decision: CodingAgentGateDecision,
+    pub findings: Vec<Cap1Finding>,
+}
+
+impl Cap1ClaimDecision {
+    /// The rules that fired, sorted, as the Python run record lists them.
+    #[must_use]
+    pub fn rules_fired(&self) -> Vec<Cap1Rule> {
+        let set: BTreeSet<Cap1Rule> = self.findings.iter().map(|f| f.rule).collect();
+        set.into_iter().collect()
+    }
+}
+
+fn worst(a: CodingAgentGateDecision, b: CodingAgentGateDecision) -> CodingAgentGateDecision {
+    use CodingAgentGateDecision as D;
+    match (a, b) {
+        (D::Blocked, _) | (_, D::Blocked) => D::Blocked,
+        (D::Degraded, _) | (_, D::Degraded) => D::Degraded,
+        _ => D::Allowed,
+    }
+}
+
+/// Evaluate a conforming CAP-1 document for one claim kind against the relying party's state.
+#[must_use]
+pub fn cap1_claim_decision(
+    doc: &Cap1Document,
+    claim_kind: CodingAgentClaimKind,
+    ctx: &Cap1RelyingPartyContext,
+) -> Cap1ClaimDecision {
+    cap1_claim_decision_with(doc, claim_kind, ctx, &[])
+}
+
+/// As [`cap1_claim_decision`], with named rules silenced. Exists for mutation testing: a rule
+/// whose silence changes no decision is decoration.
+#[must_use]
+pub fn cap1_claim_decision_with(
+    doc: &Cap1Document,
+    claim_kind: CodingAgentClaimKind,
+    ctx: &Cap1RelyingPartyContext,
+    disabled: &[Cap1Rule],
+) -> Cap1ClaimDecision {
+    use CodingAgentClaimKind as Kind;
+    use CodingAgentGateDecision as D;
+
+    let on = |r: Cap1Rule| !disabled.contains(&r);
+    let neg = claim_kind != Kind::PositiveExistence;
+    let mut findings: Vec<Cap1Finding> = Vec::new();
+    let mut add = |rule: Cap1Rule, decision: D, gap: Cap1Gap, detail: String| {
+        findings.push(Cap1Finding {
+            rule,
+            decision,
+            gap,
+            detail,
+        });
+    };
+
+    let cited: BTreeSet<&str> = doc
+        .absence_assertions
+        .iter()
+        .flatten()
+        .map(|a| a.stratum.as_str())
+        .collect();
+    let producer = doc.producer.as_ref().and_then(|p| p.name.as_deref());
+    let subject_ref = doc.subject.reference.as_str();
+
+    // C6, document-wide: who produced the accounting. Two branches, each with its own vector.
+    // A producer that impersonates an accepted name passes this string check; that is the
+    // authentication gap named in the module docs.
+    if on(Cap1Rule::ProducerIndependentOfSubject) {
+        let accepted = producer.is_some_and(|p| ctx.independent_producers.iter().any(|n| n == p));
+        if producer == Some(subject_ref) {
+            add(
+                Cap1Rule::ProducerIndependentOfSubject,
+                if neg { D::Blocked } else { D::Degraded },
+                Cap1Gap::SelfReportedOnly,
+                format!(
+                    "producer {} is the subject; coverage is self-reported, ceiling asserted",
+                    subject_ref
+                ),
+            );
+        } else if neg && !accepted {
+            add(
+                Cap1Rule::ProducerIndependentOfSubject,
+                D::Degraded,
+                Cap1Gap::ProducerNotAcceptedIndependent,
+                format!(
+                    "producer {:?} is not one the relying party accepts as independent of the subject",
+                    producer.unwrap_or("")
+                ),
+            );
+        }
+    }
+
+    for s in &doc.strata {
+        if !cited.contains(s.id.as_str()) {
+            continue; // only strata offered in support of an absence claim are gated
+        }
+        let sid = s.id.as_str();
+
+        // C7: unit identity must be unique within the accounting. CAP-1 does not forbid a
+        // duplicate unit name, so an errored unit can hide under the name of a confirmed one.
+        // First named and refused by Iman Schrock (INTERPRETATION.md, 2026-08-22); Anton
+        // Sokolov's 25 Aug item is the same accounting-layer point. Konrad Gruszka's F6 is the
+        // parse layer (duplicate JSON member names) and a different finding.
+        if on(Cap1Rule::UnitIdentityUnique) && neg {
+            let mut seen = BTreeSet::new();
+            let mut dups = BTreeSet::new();
+            for u in &s.unexamined {
+                if !seen.insert(u.unit.as_str()) {
+                    dups.insert(u.unit.as_str());
+                }
+            }
+            if !dups.is_empty() {
+                add(
+                    Cap1Rule::UnitIdentityUnique,
+                    D::Blocked,
+                    Cap1Gap::DuplicateUnitIdentity,
+                    format!("strata[{sid}] unit names appear more than once in the accounting: {dups:?}"),
+                );
+            }
+        }
+
+        // C1: the denominator must have been fixed before results were known, and the relying
+        // party must be able to say so from its own record. `declared` never satisfies this;
+        // `catalogue` does for a precommitted digest; `enumeration` never does, because the
+        // relying party cannot re-run the producer's method.
+        if on(Cap1Rule::DenominatorPrecommitted) && neg {
+            match s.basis.kind {
+                Cap1BasisKind::Declared => add(
+                    Cap1Rule::DenominatorPrecommitted,
+                    D::Blocked,
+                    Cap1Gap::DenominatorPostHoc,
+                    format!("strata[{sid}] basis is declared; the population can have been fixed after results"),
+                ),
+                Cap1BasisKind::Catalogue => {
+                    let pre = s
+                        .basis
+                        .catalogue_digest
+                        .as_deref()
+                        .is_some_and(|d| ctx.precommitted_catalogue_digests.iter().any(|p| p == d));
+                    if !pre {
+                        add(
+                            Cap1Rule::DenominatorPrecommitted,
+                            D::Degraded,
+                            Cap1Gap::DenominatorNotPrecommitted,
+                            format!("strata[{sid}] catalogue digest is not one the relying party precommitted to"),
+                        );
+                    }
+                }
+                Cap1BasisKind::Enumeration => add(
+                    Cap1Rule::DenominatorPrecommitted,
+                    D::Degraded,
+                    Cap1Gap::DenominatorNotPrecommitted,
+                    format!(
+                        "strata[{sid}] enumerated by the producer ({:?}); the relying party cannot re-run it",
+                        s.basis.enumeration_method.as_deref().unwrap_or("")
+                    ),
+                ),
+            }
+        }
+
+        // C2: an applicability or authorisation disposition is the producer's classification of
+        // a unit, and R7 never fires on it. Each one the relying party cannot confirm from its
+        // own knowledge of the subject (not_applicable) or its own authorisation (out_of_scope)
+        // degrades an absence claim over the stratum.
+        if on(Cap1Rule::ApplicabilityConfirmable) && neg {
+            let unconfirmed: Vec<&str> = s
+                .unexamined
+                .iter()
+                .filter(|u| match u.disposition {
+                    Cap1Disposition::NotApplicable => {
+                        !ctx.confirmable_not_applicable.contains(&u.unit)
+                    }
+                    Cap1Disposition::OutOfScope => !ctx.confirmable_out_of_scope.contains(&u.unit),
+                    _ => false,
+                })
+                .map(|u| u.unit.as_str())
+                .collect();
+            if !unconfirmed.is_empty() {
+                add(
+                    Cap1Rule::ApplicabilityConfirmable,
+                    D::Degraded,
+                    Cap1Gap::SelfClassifiedDisposition,
+                    format!("strata[{sid}] applicability/authorisation dispositions the relying party cannot confirm: {unconfirmed:?}"),
+                );
+            }
+        }
+
+        // C3: absence over the stratum is bounded by the units that could have examined the
+        // input. Any such unit that did not means absence is not a fact about it. All or
+        // nothing, not a share. The runner gate's asymmetry: degrades "these are all of them",
+        // blocks "this did not happen".
+        if on(Cap1Rule::AbsenceBoundedByExaminedUnits) && neg {
+            let shortfall: Vec<&str> = s
+                .unexamined
+                .iter()
+                .filter(|u| {
+                    !matches!(
+                        u.disposition,
+                        Cap1Disposition::NotApplicable
+                            | Cap1Disposition::OutOfScope
+                            | Cap1Disposition::Withheld
+                    )
+                })
+                .map(|u| u.unit.as_str())
+                .collect();
+            if !shortfall.is_empty() {
+                add(
+                    Cap1Rule::AbsenceBoundedByExaminedUnits,
+                    if claim_kind == Kind::BoundedNegative {
+                        D::Blocked
+                    } else {
+                        D::Degraded
+                    },
+                    Cap1Gap::PartialOnly,
+                    format!(
+                        "strata[{sid}] examined {}/{}; absence over the stratum is not a fact about units that did not examine the input: {shortfall:?}",
+                        s.examined, s.eligible
+                    ),
+                );
+            }
+        }
+
+        // C4: withheld means examined-but-undisclosed. It supports absence for the relying party
+        // only if the relying party holds result bytes that hash to the withheld digest.
+        if on(Cap1Rule::WithheldResolvable) && neg {
+            let unresolved: Vec<&str> = s
+                .unexamined
+                .iter()
+                .filter(|u| u.disposition == Cap1Disposition::Withheld)
+                .filter(|u| {
+                    let Some(d) = u.withheld_digest.as_deref() else {
+                        return true;
+                    };
+                    match ctx.withheld_results.get(d) {
+                        Some(bytes) => hex::encode(Sha256::digest(bytes.as_bytes())) != d,
+                        None => true,
+                    }
+                })
+                .map(|u| u.unit.as_str())
+                .collect();
+            if !unresolved.is_empty() {
+                add(
+                    Cap1Rule::WithheldResolvable,
+                    D::Degraded,
+                    Cap1Gap::WithheldUnresolvable,
+                    format!("strata[{sid}] withheld results the relying party cannot resolve: {unresolved:?}"),
+                );
+            }
+        }
+
+        // C5: the population must be the relying party's own catalogue, not merely carry its
+        // digest. A one-unit count, a dropped unit, or a stratum split all agree with the digest
+        // and disagree with the set. This is Iman Schrock's verifier-owned population pin
+        // (EP-CAP1-COVERAGE-COMPOSITION-v1) restated as a decision.
+        if on(Cap1Rule::PopulationGranularity) && neg && s.basis.kind == Cap1BasisKind::Catalogue {
+            if let Some(units) = s
+                .basis
+                .catalogue_digest
+                .as_deref()
+                .and_then(|d| ctx.catalogue_units.get(d))
+            {
+                let set: BTreeSet<&str> = units.iter().map(String::as_str).collect();
+                let foreign: Vec<&str> = s
+                    .unexamined
+                    .iter()
+                    .map(|u| u.unit.as_str())
+                    .filter(|u| !set.contains(u))
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
+                    .collect();
+                if s.eligible != set.len() as u64 || !foreign.is_empty() {
+                    add(
+                        Cap1Rule::PopulationGranularity,
+                        D::Blocked,
+                        Cap1Gap::PopulationMismatch,
+                        format!(
+                            "strata[{sid}] eligible {} vs {} units in the relying party's catalogue; units outside it: {foreign:?}",
+                            s.eligible,
+                            set.len()
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    let decision = findings
+        .iter()
+        .fold(D::Allowed, |acc, f| worst(acc, f.decision));
+    Cap1ClaimDecision {
+        claim_kind,
+        decision,
+        findings,
+    }
+}

--- a/crates/assay-evidence/src/coverage_attestation.rs
+++ b/crates/assay-evidence/src/coverage_attestation.rs
@@ -17,9 +17,9 @@
 //! degrades "these are all of them", blocks "this did not happen"; a self-reported account caps
 //! at `asserted`) is the runner substrate's rule, restated here over a CAP-1 stratum rather than
 //! reinvented. `tests/cap1_relying_party_gate.rs` pins agreement with
-//! [`coding_agent_claim_decision`] on the two shapes that overlap, and pins decision parity with
-//! the Python reference at `github.com/Rul1an/cap1-conforming-but-misleading`, whose vectors
-//! are the fixtures.
+//! [`crate::coding_agent_claim_decision`] on the two shapes that overlap. Fixtures retain the
+//! Python reference at `github.com/Rul1an/cap1-conforming-but-misleading`; tests explicitly name
+//! Assay's stricter handling when the relying party lacks a catalogue population.
 //!
 //! What the rules read, stated exactly. Every rule derives from the document plus the relying
 //! party's context. The document's identities (producer name, subject ref, unit names, catalogue
@@ -244,6 +244,8 @@ pub enum Cap1Gap {
     PartialOnly,
     WithheldUnresolvable,
     PopulationMismatch,
+    PopulationUnavailable,
+    ClaimSupportMissing,
     SelfReportedOnly,
     ProducerNotAcceptedIndependent,
     DuplicateUnitIdentity,
@@ -311,6 +313,11 @@ pub fn cap1_claim_decision_with(
 
     let on = |r: Cap1Rule| !disabled.contains(&r);
     let neg = claim_kind != Kind::PositiveExistence;
+    let absence_decision = if claim_kind == Kind::BoundedNegative {
+        D::Blocked
+    } else {
+        D::Degraded
+    };
     let mut findings: Vec<Cap1Finding> = Vec::new();
     let mut add = |rule: Cap1Rule, decision: D, gap: Cap1Gap, detail: String| {
         findings.push(Cap1Finding {
@@ -327,6 +334,15 @@ pub fn cap1_claim_decision_with(
         .flatten()
         .map(|a| a.stratum.as_str())
         .collect();
+    // C3 also requires cited support: omitting assertions cannot promote a negative claim.
+    if on(Cap1Rule::AbsenceBoundedByExaminedUnits) && neg && cited.is_empty() {
+        add(
+            Cap1Rule::AbsenceBoundedByExaminedUnits,
+            absence_decision,
+            Cap1Gap::ClaimSupportMissing,
+            "no absence assertion cites a stratum in support of this claim".to_string(),
+        );
+    }
     let producer = doc.producer.as_ref().and_then(|p| p.name.as_deref());
     let subject_ref = doc.subject.reference.as_str();
 
@@ -474,11 +490,7 @@ pub fn cap1_claim_decision_with(
             if !shortfall.is_empty() {
                 add(
                     Cap1Rule::AbsenceBoundedByExaminedUnits,
-                    if claim_kind == Kind::BoundedNegative {
-                        D::Blocked
-                    } else {
-                        D::Degraded
-                    },
+                    absence_decision,
                     Cap1Gap::PartialOnly,
                     format!(
                         "strata[{sid}] examined {}/{}; absence over the stratum is not a fact about units that did not examine the input: {shortfall:?}",
@@ -548,6 +560,15 @@ pub fn cap1_claim_decision_with(
                         ),
                     );
                 }
+            } else {
+                add(
+                    Cap1Rule::PopulationGranularity,
+                    D::Degraded,
+                    Cap1Gap::PopulationUnavailable,
+                    format!(
+                        "strata[{sid}] catalogue population is unavailable to the relying party"
+                    ),
+                );
             }
         }
     }

--- a/crates/assay-evidence/src/lib.rs
+++ b/crates/assay-evidence/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod attestation;
 pub mod bundle;
 pub mod coding_agent;
+pub mod coverage_attestation;
 pub mod crypto;
 pub mod denial_marker;
 pub mod diff;
@@ -29,6 +30,12 @@ pub use coding_agent::{
     CodingAgentGateDecision, CodingAgentNetworkPolicy, CodingAgentObservedEffects,
     CodingAgentSourceClass, CodingAgentWeakestCeiling, CODING_AGENT_EVIDENCE_EVENT_TYPE,
     CODING_AGENT_EVIDENCE_SOURCE,
+};
+pub use coverage_attestation::{
+    cap1_claim_decision, cap1_claim_decision_with, Cap1AbsenceAssertion, Cap1Basis, Cap1BasisKind,
+    Cap1ClaimDecision, Cap1Digest, Cap1Disposition, Cap1Document, Cap1Finding, Cap1Gap,
+    Cap1Integrity, Cap1Producer, Cap1RelyingPartyContext, Cap1Rule, Cap1Stratum, Cap1Subject,
+    Cap1Unexamined,
 };
 pub use denial_marker::{
     bindable_denial_marker, classify_denial_marker, BindableDenialMarker, DenialMarkerVersion,

--- a/crates/assay-evidence/tests/cap1_relying_party_gate.rs
+++ b/crates/assay-evidence/tests/cap1_relying_party_gate.rs
@@ -1,9 +1,9 @@
 //! The CAP-1 relying-party gate, pinned three ways.
 //!
-//! 1. DECISION PARITY with the Python reference (`github.com/Rul1an/cap1-conforming-but-misleading`,
-//!    run of 2026-09-07): every vector, every claim kind, same decision, same rules fired. Two
-//!    implementations of one rule drift unless something holds them together; this is the
-//!    something.
+//! 1. REFERENCE BASELINE (`github.com/Rul1an/cap1-conforming-but-misleading`, run of
+//!    2026-09-07): decisions are checked for all three claim kinds on the 20 main vectors;
+//!    rules fired are checked for bounded-negative only. Explicit Assay deviations for EV-01b
+//!    and the five upstream positive vectors preserve the historical reference bytes.
 //! 2. SHAPE PARITY with `coding_agent_claim_decision` on the two shapes that overlap: partial
 //!    coverage (pair 03) and self-report (pair 06). The claim-kind asymmetry is the runner
 //!    substrate's rule, and the CAP-1 gate must not silently mean something different.
@@ -126,7 +126,7 @@ fn every_fixture_parses_under_the_closed_schema() {
 }
 
 #[test]
-fn decision_parity_with_the_python_reference() {
+fn reference_baseline_with_explicit_assay_population_deviations() {
     let ctx = load_context();
     let expected = load_expected();
     for id in vector_ids() {
@@ -159,25 +159,91 @@ fn decision_parity_with_the_python_reference() {
             .into_iter()
             .map(Cap1Rule::as_str)
             .collect();
-        assert_eq!(fired, want.rules_fired_bounded_negative, "{id} rules fired");
+        if id == "EV-01b" {
+            // Unknown digest also lacks an owned population: two independent missing inputs.
+            assert_eq!(
+                want.rules_fired_bounded_negative,
+                vec![Cap1Rule::DenominatorPrecommitted.as_str()]
+            );
+            assert_eq!(
+                fired,
+                vec![
+                    Cap1Rule::DenominatorPrecommitted.as_str(),
+                    Cap1Rule::PopulationGranularity.as_str()
+                ],
+                "{id} Assay rules"
+            );
+        } else {
+            assert_eq!(fired, want.rules_fired_bounded_negative, "{id} rules fired");
+        }
     }
-    // Part 4 of the reference: the author's own positive vectors, for a relying party in his
-    // position. Strictness is pinned, not hidden.
-    for (id, want) in &expected.upstream_positive {
-        let doc = load_doc(&fixtures().join("upstream").join(format!("{id}.json")));
-        let c = context_for(&ctx, id);
-        let neg = cap1_claim_decision(&doc, CodingAgentClaimKind::BoundedNegative, &c);
+    // Historical Python bytes are unchanged. These are Assay expectations, not a new
+    // reference run: each PV context lacks the relying party's catalogue unit set.
+    let deviations = [
+        ("PV-01", "degraded", vec![Cap1Rule::PopulationGranularity]),
+        (
+            "PV-02",
+            "blocked",
+            vec![
+                Cap1Rule::ApplicabilityConfirmable,
+                Cap1Rule::AbsenceBoundedByExaminedUnits,
+                Cap1Rule::PopulationGranularity,
+            ],
+        ),
+        (
+            "PV-03",
+            "blocked",
+            vec![
+                Cap1Rule::AbsenceBoundedByExaminedUnits,
+                Cap1Rule::PopulationGranularity,
+            ],
+        ),
+        (
+            "PV-04",
+            "degraded",
+            vec![
+                Cap1Rule::WithheldResolvable,
+                Cap1Rule::PopulationGranularity,
+            ],
+        ),
+        (
+            "PV-05",
+            "degraded",
+            vec![
+                Cap1Rule::DenominatorPrecommitted,
+                Cap1Rule::PopulationGranularity,
+            ],
+        ),
+    ];
+    assert_eq!(deviations.len(), expected.upstream_positive.len());
+    for (id, decision, rules) in deviations {
+        let historical = &expected.upstream_positive[id];
         assert_eq!(
-            decision_str(neg.decision),
-            want.bounded_negative,
-            "{id} bounded_negative"
+            historical.bounded_negative,
+            if id == "PV-01" { "allowed" } else { decision }
         );
-        let fired: Vec<&str> = neg
-            .rules_fired()
-            .into_iter()
+        let unchanged_rules: Vec<_> = rules
+            .iter()
+            .copied()
+            .filter(|r| *r != Cap1Rule::PopulationGranularity)
             .map(Cap1Rule::as_str)
             .collect();
-        assert_eq!(fired, want.rules_fired_bounded_negative, "{id} rules fired");
+        assert_eq!(
+            historical.rules_fired_bounded_negative, unchanged_rules,
+            "{id} historical rules"
+        );
+        let doc = load_doc(&fixtures().join("upstream").join(format!("{id}.json")));
+        let result = cap1_claim_decision(
+            &doc,
+            CodingAgentClaimKind::BoundedNegative,
+            &context_for(&ctx, id),
+        );
+        assert_eq!(
+            decision_str(result.decision),
+            decision,
+            "{id} Assay decision"
+        );
+        assert_eq!(result.rules_fired(), rules, "{id} Assay rules");
     }
 }
 
@@ -291,8 +357,23 @@ fn every_rule_is_killed_under_mutation() {
                 flipped.push(*id);
             }
         }
+        let expected_flips: &[&str] = match rule {
+            Cap1Rule::DenominatorPrecommitted => &["EV-01a", "MV-01"],
+            Cap1Rule::ApplicabilityConfirmable => &["EV-02b", "MV-02"],
+            Cap1Rule::AbsenceBoundedByExaminedUnits => &["MV-03"],
+            Cap1Rule::WithheldResolvable => &["MV-04"],
+            Cap1Rule::PopulationGranularity => &["EV-05a", "EV-05b", "EV-05c", "MV-05"],
+            Cap1Rule::ProducerIndependentOfSubject => &["EV-06", "MV-06"],
+            Cap1Rule::UnitIdentityUnique => &["EV-02"],
+        };
+        assert_eq!(
+            flipped,
+            expected_flips,
+            "{} exact affected vectors",
+            rule.as_str()
+        );
         for (id, dec) in &mutant {
-            if !id.starts_with("HV") && !flipped.contains(id) {
+            if !id.starts_with("HV") && !expected_flips.contains(id) {
                 others_ok &= *dec != CodingAgentGateDecision::Allowed;
             }
         }
@@ -305,4 +386,126 @@ fn every_rule_is_killed_under_mutation() {
         kills += 1;
     }
     assert_eq!(kills, Cap1Rule::ALL.len());
+    // EV-01b now has independent C1 and C5 gaps. Neither single-rule mutation may allow it;
+    // removing both does, explicitly separating this combined case from each rule's twins.
+    let (id, doc, ctx) = docs.iter().find(|(id, _, _)| id == "EV-01b").unwrap();
+    for disabled in [
+        Cap1Rule::DenominatorPrecommitted,
+        Cap1Rule::PopulationGranularity,
+    ] {
+        assert_eq!(
+            cap1_claim_decision_with(doc, CodingAgentClaimKind::BoundedNegative, ctx, &[disabled])
+                .decision,
+            CodingAgentGateDecision::Degraded,
+            "{id} surviving independent gap"
+        );
+    }
+    assert_eq!(
+        cap1_claim_decision_with(
+            doc,
+            CodingAgentClaimKind::BoundedNegative,
+            ctx,
+            &[
+                Cap1Rule::DenominatorPrecommitted,
+                Cap1Rule::PopulationGranularity
+            ]
+        )
+        .decision,
+        CodingAgentGateDecision::Allowed,
+        "{id} both guards removed"
+    );
+}
+
+#[test]
+fn missing_catalogue_population_is_not_allowed() {
+    use CodingAgentClaimKind as K;
+    use CodingAgentGateDecision as D;
+    let contexts = load_context();
+    let doc = load_doc(&fixtures().join("vectors/MV-05.json"));
+    let mut ctx = context_for(&contexts, "MV-05");
+    assert_eq!(
+        cap1_claim_decision(&doc, K::BoundedNegative, &ctx).decision,
+        D::Blocked
+    );
+    ctx.catalogue_units.clear();
+    for kind in [K::BoundedNegative, K::ExhaustiveSet] {
+        let result = cap1_claim_decision(&doc, kind, &ctx);
+        assert_eq!(
+            result.decision,
+            D::Degraded,
+            "missing owned population, {kind:?}"
+        );
+        assert_eq!(result.rules_fired(), vec![Cap1Rule::PopulationGranularity]);
+        assert_eq!(
+            serde_json::to_value(result.findings[0].gap).unwrap(),
+            "population_unavailable"
+        );
+    }
+    assert_eq!(
+        cap1_claim_decision(&doc, K::PositiveExistence, &ctx).decision,
+        D::Allowed
+    );
+    let honest = load_doc(&fixtures().join("vectors/HV-05.json"));
+    assert_eq!(
+        cap1_claim_decision(
+            &honest,
+            K::BoundedNegative,
+            &context_for(&contexts, "HV-05")
+        )
+        .decision,
+        D::Allowed
+    );
+}
+
+#[test]
+fn missing_absence_support_cannot_allow_nonpositive_claims() {
+    use CodingAgentClaimKind as K;
+    use CodingAgentGateDecision as D;
+    let contexts = load_context();
+    let mut doc = load_doc(&fixtures().join("vectors/MV-03.json"));
+    let ctx = context_for(&contexts, "MV-03");
+    assert_eq!(
+        cap1_claim_decision(&doc, K::BoundedNegative, &ctx).decision,
+        D::Blocked
+    );
+    assert_eq!(
+        cap1_claim_decision(&doc, K::ExhaustiveSet, &ctx).decision,
+        D::Degraded
+    );
+    for support in [None, Some(Vec::new())] {
+        doc.absence_assertions = support;
+        for (kind, expected) in [
+            (K::BoundedNegative, D::Blocked),
+            (K::ExhaustiveSet, D::Degraded),
+        ] {
+            let result = cap1_claim_decision(&doc, kind, &ctx);
+            assert_eq!(
+                result.decision, expected,
+                "missing cited support, {kind:?}, {:?}",
+                doc.absence_assertions
+            );
+            assert_eq!(
+                result.rules_fired(),
+                vec![Cap1Rule::AbsenceBoundedByExaminedUnits]
+            );
+            assert_eq!(
+                serde_json::to_value(result.findings[0].gap).unwrap(),
+                "claim_support_missing"
+            );
+        }
+        assert_eq!(
+            cap1_claim_decision(&doc, K::PositiveExistence, &ctx).decision,
+            D::Allowed
+        );
+    }
+    let honest = load_doc(&fixtures().join("vectors/HV-03.json"));
+    assert_eq!(
+        cap1_claim_decision(
+            &honest,
+            K::BoundedNegative,
+            &context_for(&contexts, "HV-03")
+        )
+        .decision,
+        D::Allowed
+    );
 }

--- a/crates/assay-evidence/tests/cap1_relying_party_gate.rs
+++ b/crates/assay-evidence/tests/cap1_relying_party_gate.rs
@@ -1,0 +1,308 @@
+//! The CAP-1 relying-party gate, pinned three ways.
+//!
+//! 1. DECISION PARITY with the Python reference (`github.com/Rul1an/cap1-conforming-but-misleading`,
+//!    run of 2026-09-07): every vector, every claim kind, same decision, same rules fired. Two
+//!    implementations of one rule drift unless something holds them together; this is the
+//!    something.
+//! 2. SHAPE PARITY with `coding_agent_claim_decision` on the two shapes that overlap: partial
+//!    coverage (pair 03) and self-report (pair 06). The claim-kind asymmetry is the runner
+//!    substrate's rule, and the CAP-1 gate must not silently mean something different.
+//! 3. MUTATION: silence each of the seven rules; its own vectors must flip to `Allowed`, every
+//!    honest twin must stay `Allowed`, every other vector must stay not-allowed. A rule whose
+//!    silence changes nothing is decoration.
+//!
+//! Conformance of the fixtures to CAP-1 itself is NOT re-checked here (this crate has no CAP-1
+//! verifier and claims none); the Python reference checks it under the author's own verifiers
+//! and the fixtures are pinned from that run.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assay_evidence::{
+    cap1_claim_decision, cap1_claim_decision_with, coding_agent_claim_decision, Cap1Document,
+    Cap1RelyingPartyContext, Cap1Rule, CodingAgentClaimKind, CodingAgentCoverageState,
+    CodingAgentGateDecision, CodingAgentSourceClass,
+};
+use serde::Deserialize;
+
+fn fixtures() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cap1")
+}
+
+#[derive(Deserialize)]
+struct ContextFile {
+    default: Cap1RelyingPartyContext,
+    #[serde(default)]
+    per_vector: BTreeMap<String, serde_json::Value>,
+}
+
+/// The Python reference merges per-vector overrides over the default; do the same, field-wise.
+fn context_for(file: &ContextFile, id: &str) -> Cap1RelyingPartyContext {
+    let mut base = serde_json::to_value(&file.default).expect("context serialises");
+    if let Some(over) = file.per_vector.get(id) {
+        let (Some(b), Some(o)) = (base.as_object_mut(), over.as_object()) else {
+            panic!("context objects");
+        };
+        for (k, v) in o {
+            b.insert(k.clone(), v.clone());
+        }
+    }
+    serde_json::from_value(base).expect("merged context parses")
+}
+
+#[derive(Deserialize)]
+struct Expected {
+    vectors: BTreeMap<String, ExpectedVector>,
+    upstream_positive: BTreeMap<String, ExpectedUpstream>,
+}
+
+#[derive(Deserialize)]
+struct ExpectedVector {
+    bounded_negative: String,
+    exhaustive_set: String,
+    positive_existence: String,
+    rules_fired_bounded_negative: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct ExpectedUpstream {
+    bounded_negative: String,
+    rules_fired_bounded_negative: Vec<String>,
+}
+
+fn load_doc(p: &Path) -> Cap1Document {
+    serde_json::from_str(&fs::read_to_string(p).expect("read vector")).expect("vector parses")
+}
+
+fn load_context() -> ContextFile {
+    let raw = fs::read_to_string(fixtures().join("context.json")).expect("read context");
+    // The file carries a leading `_comment` the Rust struct does not; strip it before parsing.
+    let mut v: serde_json::Value = serde_json::from_str(&raw).expect("context json");
+    v.as_object_mut().expect("object").remove("_comment");
+    serde_json::from_value(v).expect("context parses")
+}
+
+fn load_expected() -> Expected {
+    serde_json::from_str(
+        &fs::read_to_string(fixtures().join("expected.json")).expect("read expected"),
+    )
+    .expect("expected parses")
+}
+
+fn decision_str(d: CodingAgentGateDecision) -> &'static str {
+    match d {
+        CodingAgentGateDecision::Allowed => "allowed",
+        CodingAgentGateDecision::Degraded => "degraded",
+        CodingAgentGateDecision::Blocked => "blocked",
+    }
+}
+
+fn vector_ids() -> Vec<String> {
+    let mut ids: Vec<String> = fs::read_dir(fixtures().join("vectors"))
+        .expect("vectors dir")
+        .map(|e| {
+            e.expect("entry")
+                .file_name()
+                .to_string_lossy()
+                .trim_end_matches(".json")
+                .to_string()
+        })
+        .collect();
+    ids.sort();
+    ids
+}
+
+#[test]
+fn every_fixture_parses_under_the_closed_schema() {
+    let ids = vector_ids();
+    assert_eq!(ids.len(), 20, "6 MV + 6 HV + 8 EV");
+    for id in &ids {
+        let _ = load_doc(&fixtures().join("vectors").join(format!("{id}.json")));
+    }
+    for i in 1..=5 {
+        let _ = load_doc(&fixtures().join("upstream").join(format!("PV-0{i}.json")));
+    }
+}
+
+#[test]
+fn decision_parity_with_the_python_reference() {
+    let ctx = load_context();
+    let expected = load_expected();
+    for id in vector_ids() {
+        let doc = load_doc(&fixtures().join("vectors").join(format!("{id}.json")));
+        let c = context_for(&ctx, &id);
+        let want = expected
+            .vectors
+            .get(&id)
+            .unwrap_or_else(|| panic!("expected row for {id}"));
+        let neg = cap1_claim_decision(&doc, CodingAgentClaimKind::BoundedNegative, &c);
+        let exh = cap1_claim_decision(&doc, CodingAgentClaimKind::ExhaustiveSet, &c);
+        let pos = cap1_claim_decision(&doc, CodingAgentClaimKind::PositiveExistence, &c);
+        assert_eq!(
+            decision_str(neg.decision),
+            want.bounded_negative,
+            "{id} bounded_negative"
+        );
+        assert_eq!(
+            decision_str(exh.decision),
+            want.exhaustive_set,
+            "{id} exhaustive_set"
+        );
+        assert_eq!(
+            decision_str(pos.decision),
+            want.positive_existence,
+            "{id} positive_existence"
+        );
+        let fired: Vec<&str> = neg
+            .rules_fired()
+            .into_iter()
+            .map(Cap1Rule::as_str)
+            .collect();
+        assert_eq!(fired, want.rules_fired_bounded_negative, "{id} rules fired");
+    }
+    // Part 4 of the reference: the author's own positive vectors, for a relying party in his
+    // position. Strictness is pinned, not hidden.
+    for (id, want) in &expected.upstream_positive {
+        let doc = load_doc(&fixtures().join("upstream").join(format!("{id}.json")));
+        let c = context_for(&ctx, id);
+        let neg = cap1_claim_decision(&doc, CodingAgentClaimKind::BoundedNegative, &c);
+        assert_eq!(
+            decision_str(neg.decision),
+            want.bounded_negative,
+            "{id} bounded_negative"
+        );
+        let fired: Vec<&str> = neg
+            .rules_fired()
+            .into_iter()
+            .map(Cap1Rule::as_str)
+            .collect();
+        assert_eq!(fired, want.rules_fired_bounded_negative, "{id} rules fired");
+    }
+}
+
+#[test]
+fn honest_twins_are_allowed_and_everything_else_is_not() {
+    let ctx = load_context();
+    for id in vector_ids() {
+        let doc = load_doc(&fixtures().join("vectors").join(format!("{id}.json")));
+        let c = context_for(&ctx, &id);
+        let neg = cap1_claim_decision(&doc, CodingAgentClaimKind::BoundedNegative, &c);
+        let pos = cap1_claim_decision(&doc, CodingAgentClaimKind::PositiveExistence, &c);
+        if id.starts_with("HV") {
+            assert_eq!(neg.decision, CodingAgentGateDecision::Allowed, "{id}");
+        } else {
+            assert_ne!(neg.decision, CodingAgentGateDecision::Allowed, "{id}");
+        }
+        // The asymmetry: a positive claim is never blocked by coverage alone.
+        assert_ne!(
+            pos.decision,
+            CodingAgentGateDecision::Blocked,
+            "{id} positive"
+        );
+    }
+}
+
+/// One rule, one function: the two shapes this gate shares with `coding_agent_claim_decision`
+/// must decide the same way, or the CAP-1 gate silently means something different.
+#[test]
+fn shape_parity_with_the_coding_agent_gate() {
+    let ctx = load_context();
+    let kinds = [
+        CodingAgentClaimKind::PositiveExistence,
+        CodingAgentClaimKind::ExhaustiveSet,
+        CodingAgentClaimKind::BoundedNegative,
+    ];
+
+    // Pair 03: partial coverage over an observed-in-path source.
+    let partial = load_doc(&fixtures().join("vectors/MV-03.json"));
+    let c = context_for(&ctx, "MV-03");
+    for kind in kinds {
+        let ours = cap1_claim_decision(&partial, kind, &c).decision;
+        let theirs = coding_agent_claim_decision(
+            CodingAgentSourceClass::BoundaryObserved,
+            CodingAgentCoverageState::Partial,
+            kind,
+        )
+        .decision;
+        assert_eq!(ours, theirs, "partial coverage, {kind:?}");
+    }
+
+    // Pair 06: the account comes from the subject.
+    let selfrep = load_doc(&fixtures().join("vectors/MV-06.json"));
+    let c = context_for(&ctx, "MV-06");
+    for kind in kinds {
+        let ours = cap1_claim_decision(&selfrep, kind, &c).decision;
+        let theirs = coding_agent_claim_decision(
+            CodingAgentSourceClass::ProducerReported,
+            CodingAgentCoverageState::SelfReported,
+            kind,
+        )
+        .decision;
+        assert_eq!(ours, theirs, "self-reported, {kind:?}");
+    }
+}
+
+/// CAP-1 section 7.2, applied to the consumer: rules that are never exercised are decoration.
+#[test]
+fn every_rule_is_killed_under_mutation() {
+    let ctx = load_context();
+    let ids = vector_ids();
+    let docs: Vec<(String, Cap1Document, Cap1RelyingPartyContext)> = ids
+        .iter()
+        .map(|id| {
+            (
+                id.clone(),
+                load_doc(&fixtures().join("vectors").join(format!("{id}.json"))),
+                context_for(&ctx, id),
+            )
+        })
+        .collect();
+    let baseline: BTreeMap<&str, CodingAgentGateDecision> = docs
+        .iter()
+        .map(|(id, d, c)| {
+            (
+                id.as_str(),
+                cap1_claim_decision(d, CodingAgentClaimKind::BoundedNegative, c).decision,
+            )
+        })
+        .collect();
+
+    let mut kills = 0;
+    for rule in Cap1Rule::ALL {
+        let mut flipped = Vec::new();
+        let mut twins_ok = true;
+        let mut others_ok = true;
+        let mutant: BTreeMap<&str, CodingAgentGateDecision> = docs
+            .iter()
+            .map(|(id, d, c)| {
+                (
+                    id.as_str(),
+                    cap1_claim_decision_with(d, CodingAgentClaimKind::BoundedNegative, c, &[rule])
+                        .decision,
+                )
+            })
+            .collect();
+        for (id, dec) in &mutant {
+            let allowed = *dec == CodingAgentGateDecision::Allowed;
+            if id.starts_with("HV") {
+                twins_ok &= allowed;
+            } else if baseline[id] != CodingAgentGateDecision::Allowed && allowed {
+                flipped.push(*id);
+            }
+        }
+        for (id, dec) in &mutant {
+            if !id.starts_with("HV") && !flipped.contains(id) {
+                others_ok &= *dec != CodingAgentGateDecision::Allowed;
+            }
+        }
+        let killed = !flipped.is_empty() && twins_ok && others_ok;
+        assert!(
+            killed,
+            "{} survived: flipped={flipped:?} twins_ok={twins_ok} others_ok={others_ok}",
+            rule.as_str()
+        );
+        kills += 1;
+    }
+    assert_eq!(kills, Cap1Rule::ALL.len());
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/README.md
+++ b/crates/assay-evidence/tests/fixtures/cap1/README.md
@@ -1,0 +1,9 @@
+# CAP-1 relying-party gate fixtures
+
+Vectors and expected decisions for `assay_evidence::coverage_attestation`, pinned from the
+Python reference `cap1-conforming-but-misleading` (public at
+github.com/Rul1an/cap1-conforming-but-misleading) at its 2026-09-07 run. `vectors/` are the
+20 original documents (6 MV misleading, 6 HV honest twins, 8 EV evasions); `upstream/` are
+the five positive vectors of CAP-1 itself (Apache-2.0, copyright 2026 Certisyn, Inc.,
+`Certisyn-Inc/certisyn-drafts@0980d32`); `context.json` is the relying party's own state;
+`expected.json` is the decision table the Rust gate must reproduce.

--- a/crates/assay-evidence/tests/fixtures/cap1/README.md
+++ b/crates/assay-evidence/tests/fixtures/cap1/README.md
@@ -6,4 +6,20 @@ github.com/Rul1an/cap1-conforming-but-misleading) at its 2026-09-07 run. `vector
 20 original documents (6 MV misleading, 6 HV honest twins, 8 EV evasions); `upstream/` are
 the five positive vectors of CAP-1 itself (Apache-2.0, copyright 2026 Certisyn, Inc.,
 `Certisyn-Inc/certisyn-drafts@0980d32`); `context.json` is the relying party's own state;
-`expected.json` is the decision table the Rust gate must reproduce.
+`expected.json` retains the historical Python decision table unchanged. The Rust test checks
+all three claim-kind decisions for the 20 original documents, and rules fired for
+bounded-negative claims only. It explicitly records these Assay deviations:
+
+- EV-01b remains degraded but fires C5 as well as C1: its unknown catalogue digest has no
+  relying-party unit set. Removing C1 alone therefore no longer allows it.
+- PV-01 becomes degraded and fires C5 for its unavailable population.
+- PV-02 through PV-05 retain their historical decisions and additionally fire C5.
+
+The test owns these stricter expectations; they are not results of a new Python run. Fixture
+and historical expectation bytes are preserved. The gate does not re-check CAP-1 conformance.
+
+The retained reference output is [`runs/run.json`](https://github.com/Rul1an/cap1-conforming-but-misleading/blob/bbfe9f9b5c0a1d23600a8767ff6b0b5e28b57ddd/runs/run.json)
+at commit `bbfe9f9b5c0a1d23600a8767ff6b0b5e28b57ddd`, SHA-256
+`1bae6310f66d932751abc4c93865861c1f79a448fa95a62739fb0bf6ea6360ad`.
+The 20 original and five upstream historical expectation rows match its stored output. This
+pins retained bytes; it is not an independent rerun or authentication of the reference producer.

--- a/crates/assay-evidence/tests/fixtures/cap1/context.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/context.json
@@ -1,0 +1,70 @@
+{
+ "_comment": "The relying party's OWN state. Nothing here is taken from a producer. default applies to every vector; per_vector overrides model a relying party in a different position (pair 04 is byte-identical on the wire, so only this can separate it). catalogue_units is the unit list behind the digest the relying party precommitted to. withheld_results holds RESULT BYTES the relying party obtained out of band; the gate checks sha256(bytes) == withheld_digest. Here the bytes are the model strings the vectors were built from. PV-0x overrides model a relying party in the author's own position (precommitted to his digest, no unit set held), used only by run.py Part 4.",
+ "default": {
+  "precommitted_catalogue_digests": [
+   "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  ],
+  "catalogue_units": {
+   "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc": [
+    "pdf.ts",
+    "audio.ts",
+    "video.ts",
+    "exif.ts",
+    "selector.ts",
+    "quant.ts",
+    "ela.ts"
+   ]
+  },
+  "confirmable_not_applicable": [
+   "pdf.ts",
+   "audio.ts"
+  ],
+  "confirmable_out_of_scope": [],
+  "withheld_results": {},
+  "independent_producers": [
+   "reference",
+   "observer-y"
+  ]
+ },
+ "per_vector": {
+  "HV-04": {
+   "withheld_results": {
+    "6eba4ed548d118baeffa61e8ecc63524868e11b093c3abdea18c35d470a1e187": "withheld:video.ts",
+    "131208726f04b3001b54cbad086eeaa25d17c6f9ac97498795fd8013b683648e": "withheld:exif.ts",
+    "27a9fc94e197681fe4c1d623f8bf1c9532f3c55a9c9ec846d361caa6df87cf10": "withheld:selector.ts",
+    "8c29d80953692dc3fa58ceda925c2d1659adf869232bc55c2b3d54911cb2635c": "withheld:quant.ts",
+    "d6076cbf8a082cf4bff7d91bc89e6991b26eda679a447c0db61c9c7e7e2f7e9a": "withheld:ela.ts"
+   }
+  },
+  "PV-01": {
+   "precommitted_catalogue_digests": [
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+   ],
+   "catalogue_units": {}
+  },
+  "PV-02": {
+   "precommitted_catalogue_digests": [
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+   ],
+   "catalogue_units": {}
+  },
+  "PV-03": {
+   "precommitted_catalogue_digests": [
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+   ],
+   "catalogue_units": {}
+  },
+  "PV-04": {
+   "precommitted_catalogue_digests": [
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+   ],
+   "catalogue_units": {}
+  },
+  "PV-05": {
+   "precommitted_catalogue_digests": [
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+   ],
+   "catalogue_units": {}
+  }
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/expected.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/expected.json
@@ -1,0 +1,184 @@
+{
+ "source": "runs/run.json of the Python reference, 2026-09-07",
+ "vectors": {
+  "EV-01a": {
+   "bounded_negative": "degraded",
+   "exhaustive_set": "degraded",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": [
+    "C1_denominator_precommitted"
+   ]
+  },
+  "EV-01b": {
+   "bounded_negative": "degraded",
+   "exhaustive_set": "degraded",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": [
+    "C1_denominator_precommitted"
+   ]
+  },
+  "EV-02": {
+   "bounded_negative": "blocked",
+   "exhaustive_set": "blocked",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": [
+    "C7_unit_identity_unique"
+   ]
+  },
+  "EV-02b": {
+   "bounded_negative": "degraded",
+   "exhaustive_set": "degraded",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": [
+    "C2_applicability_confirmable"
+   ]
+  },
+  "EV-05a": {
+   "bounded_negative": "blocked",
+   "exhaustive_set": "blocked",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": [
+    "C5_population_granularity"
+   ]
+  },
+  "EV-05b": {
+   "bounded_negative": "blocked",
+   "exhaustive_set": "blocked",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": [
+    "C5_population_granularity"
+   ]
+  },
+  "EV-05c": {
+   "bounded_negative": "blocked",
+   "exhaustive_set": "blocked",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": [
+    "C5_population_granularity"
+   ]
+  },
+  "EV-06": {
+   "bounded_negative": "degraded",
+   "exhaustive_set": "degraded",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": [
+    "C6_producer_independent_of_subject"
+   ]
+  },
+  "HV-01": {
+   "bounded_negative": "allowed",
+   "exhaustive_set": "allowed",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": []
+  },
+  "HV-02": {
+   "bounded_negative": "allowed",
+   "exhaustive_set": "allowed",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": []
+  },
+  "HV-03": {
+   "bounded_negative": "allowed",
+   "exhaustive_set": "allowed",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": []
+  },
+  "HV-04": {
+   "bounded_negative": "allowed",
+   "exhaustive_set": "allowed",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": []
+  },
+  "HV-05": {
+   "bounded_negative": "allowed",
+   "exhaustive_set": "allowed",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": []
+  },
+  "HV-06": {
+   "bounded_negative": "allowed",
+   "exhaustive_set": "allowed",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": []
+  },
+  "MV-01": {
+   "bounded_negative": "blocked",
+   "exhaustive_set": "blocked",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": [
+    "C1_denominator_precommitted"
+   ]
+  },
+  "MV-02": {
+   "bounded_negative": "degraded",
+   "exhaustive_set": "degraded",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": [
+    "C2_applicability_confirmable"
+   ]
+  },
+  "MV-03": {
+   "bounded_negative": "blocked",
+   "exhaustive_set": "degraded",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": [
+    "C3_absence_bounded_by_examined_units"
+   ]
+  },
+  "MV-04": {
+   "bounded_negative": "degraded",
+   "exhaustive_set": "degraded",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": [
+    "C4_withheld_resolvable"
+   ]
+  },
+  "MV-05": {
+   "bounded_negative": "blocked",
+   "exhaustive_set": "blocked",
+   "positive_existence": "allowed",
+   "rules_fired_bounded_negative": [
+    "C5_population_granularity"
+   ]
+  },
+  "MV-06": {
+   "bounded_negative": "blocked",
+   "exhaustive_set": "blocked",
+   "positive_existence": "degraded",
+   "rules_fired_bounded_negative": [
+    "C6_producer_independent_of_subject"
+   ]
+  }
+ },
+ "upstream_positive": {
+  "PV-01": {
+   "bounded_negative": "allowed",
+   "rules_fired_bounded_negative": []
+  },
+  "PV-02": {
+   "bounded_negative": "blocked",
+   "rules_fired_bounded_negative": [
+    "C2_applicability_confirmable",
+    "C3_absence_bounded_by_examined_units"
+   ]
+  },
+  "PV-03": {
+   "bounded_negative": "blocked",
+   "rules_fired_bounded_negative": [
+    "C3_absence_bounded_by_examined_units"
+   ]
+  },
+  "PV-04": {
+   "bounded_negative": "degraded",
+   "rules_fired_bounded_negative": [
+    "C4_withheld_resolvable"
+   ]
+  },
+  "PV-05": {
+   "bounded_negative": "degraded",
+   "rules_fired_bounded_negative": [
+    "C1_denominator_precommitted"
+   ]
+  }
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/upstream/PV-01.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/upstream/PV-01.json
@@ -1,0 +1,58 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "vector-subject",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+   },
+   "eligible": 6,
+   "examined": 4,
+   "unexamined": [
+    {
+     "unit": "pdf.ts",
+     "disposition": "not_applicable",
+     "detail": "subject is not a PDF"
+    },
+    {
+     "unit": "audio.ts",
+     "disposition": "not_applicable",
+     "detail": "subject carries no audio stream"
+    }
+   ],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors",
+   "qualifier": "Not observed within the examined units of this stratum."
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/upstream/PV-02.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/upstream/PV-02.json
@@ -1,0 +1,68 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "vector-subject",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+   },
+   "eligible": 8,
+   "examined": 4,
+   "unexamined": [
+    {
+     "unit": "pdf.ts",
+     "disposition": "not_applicable",
+     "detail": "subject is not a PDF"
+    },
+    {
+     "unit": "audio.ts",
+     "disposition": "not_applicable",
+     "detail": "subject carries no audio stream"
+    },
+    {
+     "unit": "secrets.ts",
+     "disposition": "disabled_by_policy",
+     "detail": "off under the governing policy"
+    },
+    {
+     "unit": "cloud.ts",
+     "disposition": "out_of_scope",
+     "detail": "outside the authorised scope"
+    }
+   ],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors",
+   "qualifier": "Not observed within the examined units of this stratum."
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/upstream/PV-03.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/upstream/PV-03.json
@@ -1,0 +1,65 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "vector-subject",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+   },
+   "eligible": 7,
+   "examined": 4,
+   "unexamined": [
+    {
+     "unit": "pdf.ts",
+     "disposition": "not_applicable",
+     "detail": "subject is not a PDF"
+    },
+    {
+     "unit": "audio.ts",
+     "disposition": "not_applicable",
+     "detail": "subject carries no audio stream"
+    },
+    {
+     "unit": "video.ts",
+     "disposition": "failed",
+     "detail": "decoder error"
+    }
+   ],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors",
+   "qualifier": "Not observed within the examined units of this stratum."
+  }
+ ],
+ "integrity": {
+  "complete": false,
+  "uncapped_verdict": "pass",
+  "capped_to": "indeterminate",
+  "unaccounted": [
+   "video.ts"
+  ],
+  "statement": "One unit failed. The verdict is capped and may not be read as clean."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/upstream/PV-04.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/upstream/PV-04.json
@@ -1,0 +1,63 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "vector-subject",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+   },
+   "eligible": 7,
+   "examined": 4,
+   "unexamined": [
+    {
+     "unit": "pdf.ts",
+     "disposition": "not_applicable",
+     "detail": "subject is not a PDF"
+    },
+    {
+     "unit": "audio.ts",
+     "disposition": "not_applicable",
+     "detail": "subject carries no audio stream"
+    },
+    {
+     "unit": "selector.ts",
+     "disposition": "withheld",
+     "withheld_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+   ],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors",
+   "qualifier": "Not observed within the examined units of this stratum."
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/upstream/PV-05.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/upstream/PV-05.json
@@ -1,0 +1,76 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "vector-subject",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+   },
+   "eligible": 6,
+   "examined": 4,
+   "unexamined": [
+    {
+     "unit": "pdf.ts",
+     "disposition": "not_applicable",
+     "detail": "subject is not a PDF"
+    },
+    {
+     "unit": "audio.ts",
+     "disposition": "not_applicable",
+     "detail": "subject carries no audio stream"
+    }
+   ],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  },
+  {
+   "id": "records",
+   "population": "messages eligible in the queried table",
+   "basis": {
+    "kind": "enumeration",
+    "enumeration_method": "SELECT COUNT(*) over the table under the authorised date range"
+   },
+   "eligible": 1000,
+   "examined": 1000,
+   "unexamined": [],
+   "supports": [
+    "absence-of-message"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors",
+   "qualifier": "Not observed within the examined units of this stratum."
+  },
+  {
+   "assertion": "No message matching the term was observed.",
+   "stratum": "records"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-01a.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-01a.json
@@ -1,0 +1,45 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-01",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "enumeration",
+    "enumeration_method": "ls detectors/"
+   },
+   "eligible": 7,
+   "examined": 7,
+   "unexamined": [],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-01b.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-01b.json
@@ -1,0 +1,46 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-01",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "9.9.9",
+    "catalogue_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+   },
+   "eligible": 7,
+   "examined": 7,
+   "unexamined": [],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-02.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-02.json
@@ -1,0 +1,62 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-02",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 7,
+   "examined": 4,
+   "unexamined": [
+    {
+     "unit": "pdf.ts",
+     "disposition": "not_applicable",
+     "detail": "subject is not a PDF"
+    },
+    {
+     "unit": "audio.ts",
+     "disposition": "not_applicable",
+     "detail": "subject carries no audio stream"
+    },
+    {
+     "unit": "pdf.ts",
+     "disposition": "not_applicable",
+     "detail": "decoder not applicable to this container"
+    }
+   ],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-02b.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-02b.json
@@ -1,0 +1,62 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-02",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 7,
+   "examined": 4,
+   "unexamined": [
+    {
+     "unit": "pdf.ts",
+     "disposition": "not_applicable",
+     "detail": "subject is not a PDF"
+    },
+    {
+     "unit": "audio.ts",
+     "disposition": "not_applicable",
+     "detail": "subject carries no audio stream"
+    },
+    {
+     "unit": "exif.ts",
+     "disposition": "out_of_scope",
+     "detail": "outside the engagement letter"
+    }
+   ],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-05a.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-05a.json
@@ -1,0 +1,46 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-05",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 5,
+   "examined": 5,
+   "unexamined": [],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-05b.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-05b.json
@@ -1,0 +1,57 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-02",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 6,
+   "examined": 4,
+   "unexamined": [
+    {
+     "unit": "pdf.ts",
+     "disposition": "not_applicable",
+     "detail": "subject is not a PDF"
+    },
+    {
+     "unit": "audio.ts",
+     "disposition": "not_applicable",
+     "detail": "subject carries no audio stream"
+    }
+   ],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-05c.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-05c.json
@@ -1,0 +1,90 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-03",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 1,
+   "examined": 1,
+   "unexamined": [],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  },
+  {
+   "id": "detectors-policy",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 6,
+   "examined": 0,
+   "unexamined": [
+    {
+     "unit": "audio.ts",
+     "disposition": "disabled_by_policy",
+     "detail": "fast profile"
+    },
+    {
+     "unit": "video.ts",
+     "disposition": "disabled_by_policy",
+     "detail": "fast profile"
+    },
+    {
+     "unit": "exif.ts",
+     "disposition": "disabled_by_policy",
+     "detail": "fast profile"
+    },
+    {
+     "unit": "selector.ts",
+     "disposition": "disabled_by_policy",
+     "detail": "fast profile"
+    },
+    {
+     "unit": "quant.ts",
+     "disposition": "disabled_by_policy",
+     "detail": "fast profile"
+    },
+    {
+     "unit": "ela.ts",
+     "disposition": "disabled_by_policy",
+     "detail": "fast profile"
+    }
+   ],
+   "supports": []
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator is present in the subject.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-06.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/EV-06.json
@@ -1,0 +1,46 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "auditor-z",
+  "version": "auditor-z/1.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "agent-x",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 7,
+   "examined": 7,
+   "unexamined": [],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/HV-01.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/HV-01.json
@@ -1,0 +1,46 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-01",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 7,
+   "examined": 7,
+   "unexamined": [],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/HV-02.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/HV-02.json
@@ -1,0 +1,57 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-02",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 7,
+   "examined": 5,
+   "unexamined": [
+    {
+     "unit": "pdf.ts",
+     "disposition": "not_applicable",
+     "detail": "subject is not a PDF"
+    },
+    {
+     "unit": "audio.ts",
+     "disposition": "not_applicable",
+     "detail": "subject carries no audio stream"
+    }
+   ],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/HV-03.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/HV-03.json
@@ -1,0 +1,46 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-03",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 7,
+   "examined": 7,
+   "unexamined": [],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator is present in the subject.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/HV-04.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/HV-04.json
@@ -1,0 +1,72 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-04",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 7,
+   "examined": 2,
+   "unexamined": [
+    {
+     "unit": "video.ts",
+     "disposition": "withheld",
+     "withheld_digest": "6eba4ed548d118baeffa61e8ecc63524868e11b093c3abdea18c35d470a1e187"
+    },
+    {
+     "unit": "exif.ts",
+     "disposition": "withheld",
+     "withheld_digest": "131208726f04b3001b54cbad086eeaa25d17c6f9ac97498795fd8013b683648e"
+    },
+    {
+     "unit": "selector.ts",
+     "disposition": "withheld",
+     "withheld_digest": "27a9fc94e197681fe4c1d623f8bf1c9532f3c55a9c9ec846d361caa6df87cf10"
+    },
+    {
+     "unit": "quant.ts",
+     "disposition": "withheld",
+     "withheld_digest": "8c29d80953692dc3fa58ceda925c2d1659adf869232bc55c2b3d54911cb2635c"
+    },
+    {
+     "unit": "ela.ts",
+     "disposition": "withheld",
+     "withheld_digest": "d6076cbf8a082cf4bff7d91bc89e6991b26eda679a447c0db61c9c7e7e2f7e9a"
+    }
+   ],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/HV-05.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/HV-05.json
@@ -1,0 +1,46 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-05",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 7,
+   "examined": 7,
+   "unexamined": [],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/HV-06.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/HV-06.json
@@ -1,0 +1,46 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "observer-y",
+  "version": "observer-y/0.4",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "agent-x",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 7,
+   "examined": 7,
+   "unexamined": [],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/MV-01.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/MV-01.json
@@ -1,0 +1,45 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-01",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "declared",
+    "note": "seven detectors were run"
+   },
+   "eligible": 7,
+   "examined": 7,
+   "unexamined": [],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/MV-02.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/MV-02.json
@@ -1,0 +1,62 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-02",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 7,
+   "examined": 4,
+   "unexamined": [
+    {
+     "unit": "pdf.ts",
+     "disposition": "not_applicable",
+     "detail": "subject is not a PDF"
+    },
+    {
+     "unit": "audio.ts",
+     "disposition": "not_applicable",
+     "detail": "subject carries no audio stream"
+    },
+    {
+     "unit": "video.ts",
+     "disposition": "not_applicable",
+     "detail": "decoder not applicable to this container"
+    }
+   ],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/MV-03.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/MV-03.json
@@ -1,0 +1,77 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-03",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 7,
+   "examined": 1,
+   "unexamined": [
+    {
+     "unit": "audio.ts",
+     "disposition": "disabled_by_policy",
+     "detail": "fast profile"
+    },
+    {
+     "unit": "video.ts",
+     "disposition": "disabled_by_policy",
+     "detail": "fast profile"
+    },
+    {
+     "unit": "exif.ts",
+     "disposition": "disabled_by_policy",
+     "detail": "fast profile"
+    },
+    {
+     "unit": "selector.ts",
+     "disposition": "disabled_by_policy",
+     "detail": "fast profile"
+    },
+    {
+     "unit": "quant.ts",
+     "disposition": "disabled_by_policy",
+     "detail": "fast profile"
+    },
+    {
+     "unit": "ela.ts",
+     "disposition": "disabled_by_policy",
+     "detail": "fast profile"
+    }
+   ],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator is present in the subject.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/MV-04.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/MV-04.json
@@ -1,0 +1,72 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-04",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 7,
+   "examined": 2,
+   "unexamined": [
+    {
+     "unit": "video.ts",
+     "disposition": "withheld",
+     "withheld_digest": "6eba4ed548d118baeffa61e8ecc63524868e11b093c3abdea18c35d470a1e187"
+    },
+    {
+     "unit": "exif.ts",
+     "disposition": "withheld",
+     "withheld_digest": "131208726f04b3001b54cbad086eeaa25d17c6f9ac97498795fd8013b683648e"
+    },
+    {
+     "unit": "selector.ts",
+     "disposition": "withheld",
+     "withheld_digest": "27a9fc94e197681fe4c1d623f8bf1c9532f3c55a9c9ec846d361caa6df87cf10"
+    },
+    {
+     "unit": "quant.ts",
+     "disposition": "withheld",
+     "withheld_digest": "8c29d80953692dc3fa58ceda925c2d1659adf869232bc55c2b3d54911cb2635c"
+    },
+    {
+     "unit": "ela.ts",
+     "disposition": "withheld",
+     "withheld_digest": "d6076cbf8a082cf4bff7d91bc89e6991b26eda679a447c0db61c9c7e7e2f7e9a"
+    }
+   ],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/MV-05.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/MV-05.json
@@ -1,0 +1,46 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "reference",
+  "version": "cap-1-ref/1.0.0",
+  "policy": "policy/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "subject-05",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "the examination",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 1,
+   "examined": 1,
+   "unexamined": [],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/crates/assay-evidence/tests/fixtures/cap1/vectors/MV-06.json
+++ b/crates/assay-evidence/tests/fixtures/cap1/vectors/MV-06.json
@@ -1,0 +1,46 @@
+{
+ "profile": "cap/1",
+ "producer": {
+  "name": "agent-x",
+  "version": "agent-x/2.1",
+  "policy": "self-audit/1"
+ },
+ "subject": {
+  "kind": "artefact",
+  "ref": "agent-x",
+  "digest": {
+   "algorithm": "SHA-256",
+   "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+ },
+ "strata": [
+  {
+   "id": "detectors",
+   "population": "catalogued detector units",
+   "basis": {
+    "kind": "catalogue",
+    "catalogue_version": "1.0.0",
+    "catalogue_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+   },
+   "eligible": 7,
+   "examined": 7,
+   "unexamined": [],
+   "supports": [
+    "absence-of-detector-finding"
+   ]
+  }
+ ],
+ "absence_assertions": [
+  {
+   "assertion": "No manipulation indicator was observed.",
+   "stratum": "detectors"
+  }
+ ],
+ "integrity": {
+  "complete": true,
+  "uncapped_verdict": "pass",
+  "capped_to": null,
+  "unaccounted": [],
+  "statement": "Every dispatched unit reached a recorded outcome."
+ }
+}

--- a/docs/architecture/CONFIGURATION-VOCABULARY-CROSSWALK.md
+++ b/docs/architecture/CONFIGURATION-VOCABULARY-CROSSWALK.md
@@ -105,7 +105,7 @@ page stated only the last two, so the first excluded records silently.
 
 Scope is decided per document, while both tables above are keyed per schema. **4 schemas** had documents on both sides and are counted above rather than below, so nothing is listed twice: `assay.coverage_aware_drift.annotation.v0`, `assay.experiment.evidenceref_recompute_consumer.v0`, `assay.manifest_establish.v0`, `assay.runner.observation_health.v0`
 
-**196 further records** carry a configuration-ish key and declare no schema
+**222 further records** carry a configuration-ish key and declare no schema
 and no namespaced type, so they fail the first conjunct and appear nowhere on this page.
 55 of them declare a **meta-schema** under `$schema`, so they
 are schemas rather than records. The rest are records this rule drops, including some that


### PR DESCRIPTION
## Behavior

Adds a CAP-1 relying-party claim gate in `assay-evidence`, using the existing positive-existence, exhaustive-set and bounded-negative decision vocabulary. CAP-1 document conformance alone does not establish that an absence claim is supported.

Missing population context now produces a degraded nonpositive claim, while a demonstrated population mismatch remains blocked. An absent or empty list of absence assertions blocks bounded-negative claims and degrades exhaustive-set claims. Positive-existence decisions retain their existing behavior. The two C3 paths share the same claim-kind severity rule.

## Verification scope

The checked-in Python reference output is retained unchanged. Tests compare its three claim decisions and bounded-negative fired rules, with explicit Assay strengthening for missing population context (EV-01b and PV-01 through PV-05). They do not claim complete Python parity or a fresh execution of that reference. The fixture README pins the retained upstream revision and run-output digest.

Tests also pin the exact expected vector set for each rule-disable case. Separate production-guard removal mutations exercise both repaired refusal paths, alongside a no-op control. The generated configuration vocabulary crosswalk is refreshed for the 26 newly included CAP-1 fixture records. Rustdoc uses a resolved crate-qualified link.

Local verification at `065634c450a11247acfb4428979314803861a8cf`, worktree `/Users/roelschuurkes/wt-codex-2830-cap1-review-repairs`, Rust/Cargo 1.96.0 on aarch64-apple-darwin:

- `cargo test -p assay-evidence`: 688 passed, zero failed, four intentionally ignored fixture/fuzz generators; includes seven CAP-1 tests and fifteen doctests.
- Both production guard-removal mutations fail their named behavioral assertion; the comment-only control passes. Measured source hashes match the final committed files.
- Clippy all-targets with warnings denied, Rustdoc with warnings denied, formatting, diff hygiene, generated-doc drift and its safety/self-tests pass.

Independent Codex reviewer `plimsoll115_review` declared READY after reviewing the whole change and retained test evidence; that reviewer did not build or design the change and did not rerun Rust tests. Hosted CI remains a separate final-head landing gate. No release or installed-host proof is claimed.

## Boundaries and authorship

No CAP-1 conformance verifier, producer authentication, CLI command, trust score, detector catalogue or content scanner is introduced. The catalogue input is the relying party’s denominator population, not a detector product. The gate does not interpret free-text qualifiers or prove producer outcomes.

Original implementation: Claude Code. Review repairs and integration: Codex in its own worktree, preserving the original head and Claude checkout. Independent final-head review is recorded separately; neither builder nor repair-plan author counts toward quorum. The account publishing a review is a relay, not proof of reviewer identity.
