### PR TITLE
docs(attestation): publish v1 predicate specification and extent ADR

### DIFF
--- a/crates/assay-evidence/src/attestation.rs
+++ b/crates/assay-evidence/src/attestation.rs
@@ -46,8 +46,8 @@ const STATEMENT_TYPE: &str = "https://in-toto.io/Statement/v1";
 const IN_TOTO_PAYLOAD_TYPE: &str = "application/vnd.in-toto+json";
 /// The v1 evidence-bundle predicate type.
 ///
-/// On `docs.getassay.dev`, where the contract surface actually resolves — the profile URIs under
-/// `docs/profiles/` already point there.
+/// Names the contract page on `docs.getassay.dev`. The local URI-to-page binding is tested;
+/// publication still requires a separate fetch of this URI after deployment.
 pub const EVIDENCE_BUNDLE_PREDICATE_TYPE_V1: &str =
     "https://docs.getassay.dev/attestation/evidence-bundle/v1";
 
@@ -611,6 +611,60 @@ mod tests {
     use crate::bundle::BundleWriter;
     use crate::types::{EvidenceEvent, ProducerMeta};
     use chrono::{DateTime, Utc};
+
+    /// Check the repository binding only; this cannot prove deployment or the prose's correctness.
+    fn check_predicate_page_binding(uri: &str, docs: &std::path::Path) -> Result<()> {
+        let relative = uri
+            .strip_prefix("https://docs.getassay.dev/")
+            .context("predicate URI must use the documentation host")?;
+        let page = docs.join(format!("{relative}.md"));
+        let text = std::fs::read_to_string(&page).context("predicate URI page must exist")?;
+        let declared: Vec<_> = text
+            .lines()
+            .filter_map(|line| line.strip_prefix("- Type URI: `")?.strip_suffix('`'))
+            .collect();
+        anyhow::ensure!(
+            declared == [uri],
+            "predicate page must declare its exact Type URI once"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn v1_predicate_uri_names_its_documented_page() {
+        let docs = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs");
+        check_predicate_page_binding(EVIDENCE_BUNDLE_PREDICATE_TYPE_V1, &docs)
+            .expect("the emitted predicate URI must bind its repository page");
+    }
+
+    #[test]
+    fn v1_predicate_uri_binding_refuses_a_missing_page() {
+        let docs = tempfile::tempdir().expect("isolated docs directory");
+        let error = check_predicate_page_binding(EVIDENCE_BUNDLE_PREDICATE_TYPE_V1, docs.path())
+            .expect_err("an absent target must not satisfy the binding");
+        assert_eq!(error.to_string(), "predicate URI page must exist");
+    }
+
+    #[test]
+    fn v1_predicate_uri_binding_refuses_a_changed_constant() {
+        let docs = tempfile::tempdir().expect("isolated docs directory");
+        let changed = format!("{EVIDENCE_BUNDLE_PREDICATE_TYPE_V1}-changed");
+        let relative = changed.strip_prefix("https://docs.getassay.dev/").unwrap();
+        let page = docs.path().join(format!("{relative}.md"));
+        std::fs::create_dir_all(page.parent().unwrap()).expect("target directory");
+        // The changed URI reaches a real page, so only the declaration mismatch can refuse it.
+        std::fs::write(
+            page,
+            format!("- Type URI: `{EVIDENCE_BUNDLE_PREDICATE_TYPE_V1}`\n"),
+        )
+        .expect("page still declaring the original constant");
+        let error = check_predicate_page_binding(&changed, docs.path())
+            .expect_err("a changed constant must not agree with the original declaration");
+        assert_eq!(
+            error.to_string(),
+            "predicate page must declare its exact Type URI once"
+        );
+    }
 
     fn producer() -> ProducerMeta {
         ProducerMeta {

--- a/docs/architecture/ADR-049-attestation-extent.md
+++ b/docs/architecture/ADR-049-attestation-extent.md
@@ -44,54 +44,84 @@ The extension is an optional top-level `predicate.extent` object under the same 
 revision 1.1 is not the current specification published with this ADR. No existing field changes
 meaning, and no `specVersion` payload field is introduced.
 
-An absent `extent` means **not stated** and follows the v1.0 path. An explicit null parent is
-malformed when recognized. A present extension has these required members:
+An absent or null optional `extent` means **not stated** and follows legacy field verification.
+Neither permits an extent-aware claim. New extent producers emit an object, never null. A
+malformed non-null extension is refused. Its two required members are:
 
 | Member | Value and meaning |
 | --- | --- |
-| `retained_events_by_type` | A sorted map from exact event-type strings to counts of every retained event. Only encountered types appear; absence is not synthesized as a zero-valued entry. |
-| `observed` | Null if there is no recognized summary; otherwise an object with required `files`, `network`, `processes`, and `sandbox_degradations` members. Each member is a count or null. Null means the selected summary does not state that dimension, never zero. |
-| `observed_source` | Null exactly when `observed` is null; otherwise the exact recognized summary event-type string. This names the source of the count assertion, not an authenticated producer identity. |
-| `support_ceiling` | Exactly the string `artifact_bound`, checked by equality. It names the existing attestation boundary and grants no additional support. |
+| `retained_events_by_type` | A sorted map from exact event-type strings to recomputed counts of every retained event. Only encountered types appear; absence is not synthesized as a zero-valued entry. |
+| `observed` | A required object with an explicit `basis`, as described below. It carries producer assertions from a recognized summary, or explicitly says they are not stated. |
+
+`observed` has two forms:
+
+- `basis: "not_stated"`: the producer emits only `basis`. No recognized count summary exists.
+  Known `source_type` or `counts` fields contradicting this basis are refused, rather than silently
+  treated as checked information.
+- `basis: "producer_reported"`: `source_type` and `counts` are required. `source_type` names the
+  selected recognized summary event type. `counts` contains the fields that source schema states,
+  using the mappings below. Null required structures, missing or unknown basis values, and
+  malformed required counts are refused.
 
 Unknown members of known structured objects remain ignored, consistent with ADR-044. Histogram
 keys are data, not schema extensions: every entry participates in comparison. Every present known
 field must agree with derivation from the verified artifact. A disagreement names a static field
-path without echoing attacker-provided values. Parent presence is checked separately from nested
-null values.
+path without echoing attacker-provided values. Optional parent presence is checked separately from
+the required tagged structures inside it.
+
+The claim boundary belongs in the specification's Parsing Rules, not an emitted `support_ceiling`
+field. No separate `observed_source` field is emitted; the source belongs to the producer-reported
+form. A reader that has only the Statement and does not consult its specification has no signed field naming the
+claim boundary. Any explanation of that boundary must distinguish specification interpretation
+from signed payload data.
 
 An older reader can accept a signed statement while ignoring this extension. Such acceptance
 means only that its known fields were checked. Admission that requires checked extent must require
-a reader that checks it; neither absent nor ignored extent is an affirmative extent claim.
+a reader that checks it; absent, null, or ignored extent is not an affirmative extent claim. The
+explicit basis avoids overloading a missing observation dimension; it does not assert that null
+or an empty object mathematically means zero.
 
-### 2. Recognize exactly two summary schemas
+### 2. Recognize and rank exactly two summary schemas
 
-Recognition in revision 1.1 is limited to the following event types and mappings:
+Recognition in revision 1.1 uses this closed ordered list, highest priority first:
 
 | Summary type | `files` | `network` | `processes` | `sandbox_degradations` |
 | --- | --- | --- | --- | --- |
 | `assay.profile.finished` | `files_count` | `network_count` | `processes_count` | `sandbox_degradation_count` |
-| `assay.sandbox.summary` | `fs_count` | null | `exec_count` | `degradation_count` |
+| `assay.sandbox.summary` | `fs_count` | omitted | `exec_count` | `degradation_count` |
+
+Selection order is deterministic, not a ranking of trust or measurement quality. Validate every
+recognized summary, including a lower-ranked one that will not be selected. Repeated instances of
+the same recognized type are refused, whether identical or conflicting. At most one of each type
+may exist. When both valid types exist, select `assay.profile.finished` regardless of input order.
+No recognized summary yields `observed: {"basis": "not_stated"}`.
 
 All listed source count fields are required and must pass the shared numeric validation below.
-The sandbox summary states no network count. Program-entry counts remain program-entry counts,
-not sums of per-program hits or syscall counts. More generally, these are assertions carried in
-retained summary events; verifying them against the artifact does not independently measure host
-activity or prove complete observations.
+The sandbox summary states no network count, so its generated `counts` omits `network`; omission
+means not stated, never zero. An attested sandbox `network` count is a known-field disagreement,
+not silently checked data. Required counts cannot be null, and producers emit no null inside
+extent. Program-entry counts remain program-entry counts, not sums of per-program hits or syscall
+counts. Profile counts concern aggregated profile entries, not independently measured activity of
+one run.
 
-No recognized summary yields `observed: null` and `observed_source: null`. More than one recognized
-summary is a refusal, including identical repeats, conflicting repeats, and a mixture of both
-families. The derivation never picks the first or last, sums summaries, or hides malformed data by
-turning it into null. A recognized summary with missing or malformed required counts is refused.
-Extending the recognition list requires a documented revision and compatibility assessment.
+Summary fields are producer assertions read from verified generic event payloads. Comparing them
+with the artifact does not independently establish their truth, host activity, or observation
+completeness. A recognized event type is not authentication of its producer. The existing typed
+profile-summary decoder does not match all actual producer keys and is not the derivation source.
 
-These summary refusals apply only when deriving an extent-aware statement or verifying a present
-extent. Ordinary bundle verification and absent-extent attestation verification retain their
-existing accepted input set.
+`assay.coding_agent.evidence_pack.v0` remains ordinary retained histogram data, never a count-summary
+candidate. A normal sandbox bundle containing that pack and `assay.sandbox.summary` therefore has
+one recognized summary. Extending the recognition list requires a documented revision and
+compatibility assessment.
+
+Malformed required counts and repeated recognized source types are refused only when deriving an
+extent-aware statement or verifying a present non-null extent. The derivation never picks the
+first or last row, sums summaries, or hides malformed data by turning it into not stated. Ordinary
+bundle verification and absent/null-extent attestation verification retain legacy acceptance.
 
 ### 3. Use one exact integer domain and bound aggregation
 
-Every non-null count, including histogram values, is an integer in the inclusive domain
+Every count, including histogram values, is an integer in the inclusive domain
 `0..9007199254740991` (`0..2^53-1`), represented internally as `u64`. This is an interoperability
 and representation ceiling, not a limit on host resources or a policy about observed activity.
 The current JCS serialization path uses IEEE 754 number representation; unrestricted `u64` values
@@ -131,7 +161,7 @@ Additive producer APIs are `statement_for_bundle_with_extent` and
 Additive `verify_attestation_for_bundle_with_extent` and
 `verify_attestation_for_bundle_with_extent_and_limits` APIs expose the original verified result
 plus optional checked extent. Existing verification APIs share the canonical internal verifier
-and discard only the new result projection: a recognized present extent is still checked.
+and discard only the new result projection: a recognized present non-null extent is still checked.
 
 Signature verification, bundle verification, raw archive matching, and extent derivation are not
 copied into a second consumer. Signature-only verification remains artifact-unmatched. The
@@ -142,13 +172,19 @@ judgment, or provider-outcome verification.
 
 The following are pending obligations, not results reported by this ADR:
 
-- Behavioral cases must distinguish retained type counts from summary entry counts, preserve
-  absent-extent acceptance, exercise unknown event types with no summary, and cover sandbox
-  network null and program-entry semantics.
+- Behavioral cases must distinguish recomputed retained counts from producer-reported summary
+  entry counts; preserve absent/null optional-parent equivalence; and cover unknown event types
+  with `basis: "not_stated"`, sandbox network omission, aggregated profile entries, and
+  program-entry rather than hit-count semantics. Inspect actual output bytes for no emitted null
+  inside extent.
 - False extent values must be signed after alteration so they reach named field comparison, not
-  merely fail signature verification. Each histogram, observed, source, and ceiling mismatch needs
-  its own refusal witness. Parent null, missing fields, invalid count types, repeated summaries,
-  and both recognized families must be covered.
+  merely fail signature verification. Histogram, basis, source type, and count mismatches need
+  their own refusal witnesses. Missing or unknown basis, null required structures, contradictory
+  known fields under not_stated, and an attested sandbox network count must be covered.
+- Exercise both input orders for the two valid recognized types, malformed lower-ranked input,
+  repeated instances of each recognized type, and the normal sandbox summary plus coding-agent
+  pack. Selection must not hide a malformed lower-ranked summary. The ordinary and absent/null
+  paths must retain their acceptance controls.
 - Downstream-style literals and exhaustive destructures must continue compiling for the existing
   public structs. Existing unknown-field acceptance stays covered. An immutable old-reader
   control must distinguish ignoring new fields from checking them.
@@ -159,10 +195,11 @@ The following are pending obligations, not results reported by this ADR:
   ordinary verification accepts it before testing extent refusal. A BundleWriter-only witness
   can round the number earlier and miss the public byte-input boundary.
 - Histogram cardinality and aggregate key-byte boundaries need accepted maximum controls and
-  maximum-plus-one refusals before insertion, with ordinary and absent-extent paths preserved.
+  maximum-plus-one refusals before insertion, with ordinary and absent/null-extent paths preserved.
   Generated Statement bytes must satisfy the consumer's strict parser.
 - Removing effective extent comparison, histogram accumulation, observed derivation, repeated-summary
-  refusal, numeric ceiling, or aggregate bounds must defeat the corresponding behavioral test.
+  refusal, source selection, numeric ceiling, or aggregate bounds must defeat the corresponding
+  behavioral test.
   A no-op control must pass. Successful setup or a failed signature is not a substitute for the
   intended refusal assertion.
 
@@ -173,6 +210,7 @@ Deployment still needs a fetch of the actual predicate Type URI; a local site bu
 that it resolves publicly. Implementation and publication evidence remain separate.
 
 The accepted extension adds derivable detail without changing what an artifact signature means.
-Producers may continue emitting v1.0, and absence remains not stated. The new behavior needs the
-implementation and verification evidence above before the specification describes it as current.
+Producers may continue emitting v1.0, and absent or null optional extent remains not stated. The
+new behavior needs the implementation and verification evidence above before the specification
+describes it as current.
 No CLI opt-in or extent-aware consumer is claimed by this documentation change.

--- a/docs/architecture/ADR-049-attestation-extent.md
+++ b/docs/architecture/ADR-049-attestation-extent.md
@@ -1,0 +1,178 @@
+# ADR-049: Optional artifact-derived attestation extent
+
+- Status: Accepted; implementation pending
+- Date: 2026-09-07
+- Applies: [ADR-044 decision 3](ADR-044-attestation-subject-is-the-artifact.md#decision)
+- Supersedes: none
+- Documentation: [#2832](https://github.com/Rul1an/assay/issues/2832)
+- Library implementation: [#2833](https://github.com/Rul1an/assay/issues/2833)
+
+This is an accepted technical decision, not a statement that the extension is implemented. At
+source baseline `3a36085c90cef1b6c06170716a0351b6423e084d`, the producer emits the three-field
+[v1.0 predicate](../attestation/evidence-bundle/v1.md). That specification continues to describe
+current behavior. This ADR defines the obligations for an optional minor extension; it does not
+change the wire format by being published.
+
+## Context
+
+The existing predicate states the semantic run root, event count, run identity, producer metadata,
+and time window. Artifact verification checks these against the verified archive. The total event
+count alone does not describe which event types the archive retained. A summary event may also
+state counts of entries that were not exported individually. Those are different facts.
+
+The run root covers the ordered content-hash inputs of retained events. Changing those inputs can
+change the root; changing an export detail option without changing those inputs does not guarantee
+a different root. Neither the option name nor the root establishes how much of a run was observed.
+
+ADR-044 decision 3 already requires derivable predicate fields, ignores unknown fields within a
+known major, and refuses unknown majors. This decision applies that rule to an optional extension;
+it does not reopen the archive-subject boundary or the meanings of existing fields. Unknown-field
+acceptance by an older reader is not verification of that field's contents.
+
+There are two additional compatibility constraints. Published Rust result and predicate structs
+have public fields, so adding even an optional field can break downstream literals and exhaustive
+destructures. Also, a fixed object shape is not a fixed byte size: existing metadata strings can
+grow, and a histogram adds variable keys and cardinality. Both constraints apply before claiming
+an additive extension is compatible.
+
+## Decision
+
+### 1. Keep the major contract and distinguish absence from a checked statement
+
+The extension is an optional top-level `predicate.extent` object under the same v1 Type URI and
+`schema_version: 1`. Its parsing rules belong in specification revision 1.1 when implemented;
+revision 1.1 is not the current specification published with this ADR. No existing field changes
+meaning, and no `specVersion` payload field is introduced.
+
+An absent `extent` means **not stated** and follows the v1.0 path. An explicit null parent is
+malformed when recognized. A present extension has these required members:
+
+| Member | Value and meaning |
+| --- | --- |
+| `retained_events_by_type` | A sorted map from exact event-type strings to counts of every retained event. Only encountered types appear; absence is not synthesized as a zero-valued entry. |
+| `observed` | Null if there is no recognized summary; otherwise an object with required `files`, `network`, `processes`, and `sandbox_degradations` members. Each member is a count or null. Null means the selected summary does not state that dimension, never zero. |
+| `observed_source` | Null exactly when `observed` is null; otherwise the exact recognized summary event-type string. This names the source of the count assertion, not an authenticated producer identity. |
+| `support_ceiling` | Exactly the string `artifact_bound`, checked by equality. It names the existing attestation boundary and grants no additional support. |
+
+Unknown members of known structured objects remain ignored, consistent with ADR-044. Histogram
+keys are data, not schema extensions: every entry participates in comparison. Every present known
+field must agree with derivation from the verified artifact. A disagreement names a static field
+path without echoing attacker-provided values. Parent presence is checked separately from nested
+null values.
+
+An older reader can accept a signed statement while ignoring this extension. Such acceptance
+means only that its known fields were checked. Admission that requires checked extent must require
+a reader that checks it; neither absent nor ignored extent is an affirmative extent claim.
+
+### 2. Recognize exactly two summary schemas
+
+Recognition in revision 1.1 is limited to the following event types and mappings:
+
+| Summary type | `files` | `network` | `processes` | `sandbox_degradations` |
+| --- | --- | --- | --- | --- |
+| `assay.profile.finished` | `files_count` | `network_count` | `processes_count` | `sandbox_degradation_count` |
+| `assay.sandbox.summary` | `fs_count` | null | `exec_count` | `degradation_count` |
+
+All listed source count fields are required and must pass the shared numeric validation below.
+The sandbox summary states no network count. Program-entry counts remain program-entry counts,
+not sums of per-program hits or syscall counts. More generally, these are assertions carried in
+retained summary events; verifying them against the artifact does not independently measure host
+activity or prove complete observations.
+
+No recognized summary yields `observed: null` and `observed_source: null`. More than one recognized
+summary is a refusal, including identical repeats, conflicting repeats, and a mixture of both
+families. The derivation never picks the first or last, sums summaries, or hides malformed data by
+turning it into null. A recognized summary with missing or malformed required counts is refused.
+Extending the recognition list requires a documented revision and compatibility assessment.
+
+These summary refusals apply only when deriving an extent-aware statement or verifying a present
+extent. Ordinary bundle verification and absent-extent attestation verification retain their
+existing accepted input set.
+
+### 3. Use one exact integer domain and bound aggregation
+
+Every non-null count, including histogram values, is an integer in the inclusive domain
+`0..9007199254740991` (`0..2^53-1`), represented internally as `u64`. This is an interoperability
+and representation ceiling, not a limit on host resources or a policy about observed activity.
+The current JCS serialization path uses IEEE 754 number representation; unrestricted `u64` values
+can round when serialized. The shared ceiling prevents that loss for accepted counts.
+
+One definition and one conversion/validation function serve both summary families and histogram
+counts. Negative values, fractional values, strings, null in required source count fields, and
+values above the ceiling are refused before JCS serialization. Count addition and byte arithmetic
+use checked operations.
+
+The distinct histogram-key ceiling reads the strict parser's existing `MAX_KEYS_PER_OBJECT`
+constant, currently 10,000; it is not maintained as a second literal. The collector also applies
+one named aggregate decoded key-byte ceiling of 1 MiB, measured over UTF-8 key bytes. Both bounds
+are checked before cloning or inserting a new key. They complement the existing bundle limits
+and strict parser limits. Overflow or a resource refusal cannot silently truncate the histogram
+or turn a requested extent into absence.
+
+The actual JCS-canonicalized bytes of an extent-aware generated Statement must pass the same strict
+JSON parser as the consumer. Passing a pre-serialization object check alone does not establish
+producer/reader closure or numeric preservation. Existing `VerifyLimits` still apply before the
+archive hash, as required by the canonical attestation verifier.
+
+### 4. Preserve public Rust shapes and share the canonical verification path
+
+The layouts and signatures of `EvidenceBundlePredicate`, `AttestationVerified`, `VerifyResult`,
+and `VerifyLimits` remain unchanged. New public extent types and APIs are additive; their design
+uses non-exhaustive structs or private fields with getters to avoid repeating the existing
+constructor-compatibility constraint.
+
+One accumulator derives extent during the canonical verified event pass, using an internal
+`VerifiedBundle` sidecar only when extent is requested. Ordinary mode neither allocates a
+histogram nor enforces summary-specific semantics. Both modes share one verification loop.
+
+Additive producer APIs are `statement_for_bundle_with_extent` and
+`statement_for_bundle_with_extent_and_limits`. Existing `statement_for_bundle` and
+`statement_for_bundle_with_limits` remain v1.0 producers until a caller explicitly opts in.
+Additive `verify_attestation_for_bundle_with_extent` and
+`verify_attestation_for_bundle_with_extent_and_limits` APIs expose the original verified result
+plus optional checked extent. Existing verification APIs share the canonical internal verifier
+and discard only the new result projection: a recognized present extent is still checked.
+
+Signature verification, bundle verification, raw archive matching, and extent derivation are not
+copied into a second consumer. Signature-only verification remains artifact-unmatched. The
+extension creates no trust root, transparency log, completeness guarantee, policy-correctness
+judgment, or provider-outcome verification.
+
+## Required implementation evidence
+
+The following are pending obligations, not results reported by this ADR:
+
+- Behavioral cases must distinguish retained type counts from summary entry counts, preserve
+  absent-extent acceptance, exercise unknown event types with no summary, and cover sandbox
+  network null and program-entry semantics.
+- False extent values must be signed after alteration so they reach named field comparison, not
+  merely fail signature verification. Each histogram, observed, source, and ceiling mismatch needs
+  its own refusal witness. Parent null, missing fields, invalid count types, repeated summaries,
+  and both recognized families must be covered.
+- Downstream-style literals and exhaustive destructures must continue compiling for the existing
+  public structs. Existing unknown-field acceptance stays covered. An immutable old-reader
+  control must distinguish ignoring new fields from checking them.
+- Numeric boundaries must cover acceptance of zero and `2^53-1`, and named refusal of `2^53` and
+  `2^53+1`. Assert preserved counts in the decoded, signed DSSE payload, not only in the struct
+  before signing. Include an independently assembled, otherwise valid NDJSON archive that retains
+  `2^53+1` exactly, with event-byte length/digest and semantic roots consistent. Establish that
+  ordinary verification accepts it before testing extent refusal. A BundleWriter-only witness
+  can round the number earlier and miss the public byte-input boundary.
+- Histogram cardinality and aggregate key-byte boundaries need accepted maximum controls and
+  maximum-plus-one refusals before insertion, with ordinary and absent-extent paths preserved.
+  Generated Statement bytes must satisfy the consumer's strict parser.
+- Removing effective extent comparison, histogram accumulation, observed derivation, repeated-summary
+  refusal, numeric ceiling, or aggregate bounds must defeat the corresponding behavioral test.
+  A no-op control must pass. Successful setup or a failed signature is not a substitute for the
+  intended refusal assertion.
+
+## Consequences and implementation state
+
+Documentation of the existing v1.0 predicate can be served independently of this extension.
+Deployment still needs a fetch of the actual predicate Type URI; a local site build is not proof
+that it resolves publicly. Implementation and publication evidence remain separate.
+
+The accepted extension adds derivable detail without changing what an artifact signature means.
+Producers may continue emitting v1.0, and absence remains not stated. The new behavior needs the
+implementation and verification evidence above before the specification describes it as current.
+No CLI opt-in or extent-aware consumer is claimed by this documentation change.

--- a/docs/attestation/evidence-bundle/v1.md
+++ b/docs/attestation/evidence-bundle/v1.md
@@ -94,6 +94,10 @@ below are required too.
 
 These rules describe verification of the artifact and its declared metadata. They do not prove
 observation completeness, policy correctness, safe execution, or an external action's outcome.
+The verified event count counts retained events; it does not establish how many observations were
+omitted. A count asserted by a producer in event data is not made independently true by signing
+or matching the archive. These limits are specification interpretation, not additional signed
+predicate fields.
 
 ### Fields
 

--- a/docs/attestation/evidence-bundle/v1.md
+++ b/docs/attestation/evidence-bundle/v1.md
@@ -1,0 +1,191 @@
+# Predicate type: Assay evidence bundle
+
+- Type URI: `https://docs.getassay.dev/attestation/evidence-bundle/v1`
+- Version: 1.0
+- Predicate name: Assay evidence bundle
+
+## Purpose
+
+This predicate binds a signed statement to the exact bytes of one completed Assay evidence
+bundle and describes the verified run inside it. It keeps two identifiers separate: the archive
+SHA-256 identifies the artifact, while the run root identifies an ordered sequence of event
+content-hash inputs under Assay's semantic-equivalence algorithm.
+
+The contract follows [ADR-044](../../architecture/ADR-044-attestation-subject-is-the-artifact.md).
+A signature does not establish that the recorded observations are complete or that a provider-side
+outcome occurred. It does not upgrade the support carried by the evidence.
+
+## Use Cases
+
+- A recipient holding a finished `.tar.gz` bundle and its signed statement can check that the
+  statement names those exact archive bytes and that the stated run metadata agrees with the
+  verified bundle.
+- A recipient comparing re-exports can inspect semantic equivalence separately from artifact
+  identity. Repackaging can change the archive digest without changing the ordered content-hash
+  inputs. Matching semantic roots alone does not match the archives.
+
+This predicate describes an Assay evidence bundle; it does not describe a software build or replace
+an artifact digest with a run identifier.
+
+## Prerequisites
+
+Readers need the [in-toto Statement v1 specification](https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md),
+the [DSSE protocol](https://github.com/secure-systems-lab/dsse/blob/master/protocol.md), and the
+[Assay evidence contract](../../spec/EVIDENCE-CONTRACT-v1.md). Bundle verification and resource
+handling retain the boundaries in [ADR-043](../../architecture/ADR-043-evidence-chain-integrity-invariants.md).
+
+An artifact-matching consumer needs the complete compressed archive bytes, the DSSE envelope,
+an explicitly supplied Ed25519 verification key, and applicable resource limits. Key selection and
+trust policy are external inputs. This predicate provides neither a trust root nor a transparency
+log or trusted timestamp.
+
+## Model
+
+The producer finishes and verifies a bundle, derives the predicate from that verification, and
+computes the SHA-256 of the entire finished `.tar.gz`, including the gzip trailer. It constructs an
+in-toto Statement and signs its JCS-serialized bytes using Ed25519 over the DSSE pre-authentication
+encoding. The DSSE `payloadType` is `application/vnd.in-toto+json`; its `payload` is base64-encoded
+statement JSON.
+
+Assay's library distinguishes two checks:
+
+- `verify_envelope_signature` checks the DSSE payload type, signature under the supplied key,
+  unambiguous statement JSON, and Statement type. Its `SignatureVerified` result is
+  **signature-verified, artifact-unmatched**. It has not compared any archive or predicate data.
+- `verify_attestation_for_bundle` and its `_with_limits` variant additionally verify the supplied
+  bundle, match the artifact digest and bundle identifier, and compare every defined predicate
+  field with values derived from that verified bundle. Their successful result is
+  `AttestationVerified`.
+
+The implementation checks the first DSSE signature using the caller-supplied key; the envelope's
+`keyid` is not a trust lookup or an authenticated identity policy. A verified signature does not by
+itself authenticate the producer metadata asserted in a run as an external identity.
+
+## Schema
+
+The statement has `_type`, `subject`, `predicateType`, and `predicate`. The predicate has three
+required members: `schema_version`, `semantic_equivalence`, and `run`. All nested fields listed
+below are required too.
+
+### Parsing Rules
+
+1. `_type` must equal `https://in-toto.io/Statement/v1`. `predicateType` must equal the Type URI
+   above. `predicate.schema_version` must be the integer `1`. The document version `1.0` is not a
+   separate statement field. An unrecognized predicate major version is refused, never reported
+   as verified.
+2. Unknown fields within the known predicate major version are ignored. This does not mean their
+   contents were verified. Missing or null required fields, wrong field types, and ambiguous JSON
+   such as duplicate object members are refused. The Assay signed-payload reader also applies its
+   strict JSON nesting, object-member and string limits.
+3. There must be exactly one subject and exactly one digest entry in that subject. The digest key
+   must be `sha256`. No semantic-equivalence digest belongs in the subject's digest set.
+4. Before hashing the supplied archive for subject matching, the artifact verifier applies the
+   caller's `VerifyLimits` through bundle verification. These cover compressed and decoded bytes,
+   manifest and event bytes, event count, line bytes, path length, and JSON depth. The byte-slice
+   library API receives already-materialized input; callers still need bounded source reads.
+5. The subject digest must match the SHA-256 of the full compressed archive, and the subject name
+   must equal the verified manifest's `bundle_id`. An archive-entry hash or a run root is not an
+   alternative artifact digest.
+6. Every defined predicate field must compare exactly with its value derived from the verified
+   bundle. Verification recomputes the run root and actual event count, reads run and producer
+   metadata from the verified manifest, and derives the time window from the events. A field
+   mismatch is a refusal, not a warning. A zero-event bundle is refused, so the time window has no
+   null case.
+
+These rules describe verification of the artifact and its declared metadata. They do not prove
+observation completeness, policy correctness, safe execution, or an external action's outcome.
+
+### Fields
+
+All rows are required. Object rows name their required nested members in the following rows.
+
+| Field | JSON type | Contents and matching rule |
+| --- | --- | --- |
+| `_type` | string | Exactly `https://in-toto.io/Statement/v1`. |
+| `subject` | array | Exactly one artifact subject. |
+| `subject[0].name` | string | Exactly the verified manifest's `bundle_id`. This identifier is not the archive digest. |
+| `subject[0].digest` | object | Exactly one member, `sha256`. |
+| `subject[0].digest.sha256` | string | SHA-256 of the complete compressed archive, as 64 lowercase hexadecimal characters without a prefix. |
+| `predicateType` | string | Exactly `https://docs.getassay.dev/attestation/evidence-bundle/v1`. |
+| `predicate` | object | The three members below. |
+| `predicate.schema_version` | integer | Exactly `1`. |
+| `predicate.semantic_equivalence` | object | `algorithm` and `value`. |
+| `predicate.semantic_equivalence.algorithm` | string | Exactly `assay-run-root-v1`. |
+| `predicate.semantic_equivalence.value` | string | Recomputed run root, `sha256:` followed by 64 lowercase hexadecimal characters. |
+| `predicate.run` | object | `run_id`, `event_count`, `producer`, and `time_window`. |
+| `predicate.run.run_id` | string | Exactly the verified manifest's `run_id`. |
+| `predicate.run.event_count` | integer | Actual verified event count, greater than zero and within the applicable bundle-verification limit. |
+| `predicate.run.producer` | object | `name`, `version`, and `git`. |
+| `predicate.run.producer.name` | string | Exactly the verified manifest's producer name. |
+| `predicate.run.producer.version` | string | Exactly the verified manifest's producer version. |
+| `predicate.run.producer.git` | string | Exactly the manifest's producer git value, or the empty string if that optional manifest value is absent. The predicate field itself remains required. |
+| `predicate.run.time_window` | object | `start` and `end`. |
+| `predicate.run.time_window.start` | string | Earliest event time, rendered as RFC 3339 UTC with `Z`. |
+| `predicate.run.time_window.end` | string | Latest event time, rendered as RFC 3339 UTC with `Z`. |
+
+Time-window bounds are chronological minima and maxima, not necessarily the first and last rows.
+Assay renders them with Chrono's `SecondsFormat::AutoSi`: no fractional part for whole seconds,
+otherwise milliseconds, microseconds, or nanoseconds as needed. The verifier compares those rendered
+strings exactly; an equivalent instant written with a different offset or fractional formatting is
+not interchangeable in this predicate.
+
+The field list fixes the shape, not a constant serialized byte size: identifiers and producer
+metadata remain strings. The semantic root covers the event content-hash inputs defined by the
+evidence contract; equal roots do not assert that all event metadata or archive bytes are equal.
+
+## Example
+
+This complete in-toto Statement is technically illustrative JSON, **not real evidence**. Its
+identifiers and digest values are invented; no archive or signature is supplied, and it is not a
+verification fixture. A real producer must derive these values from the same verified archive.
+This is the statement carried inside a DSSE envelope, not the envelope itself.
+
+```json
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "digest": {
+        "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+      }
+    }
+  ],
+  "predicateType": "https://docs.getassay.dev/attestation/evidence-bundle/v1",
+  "predicate": {
+    "schema_version": 1,
+    "semantic_equivalence": {
+      "algorithm": "assay-run-root-v1",
+      "value": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    },
+    "run": {
+      "run_id": "illustrative-run",
+      "event_count": 2,
+      "producer": {
+        "name": "illustrative-producer",
+        "version": "1.0.0",
+        "git": ""
+      },
+      "time_window": {
+        "start": "2026-09-07T08:00:00Z",
+        "end": "2026-09-07T08:00:01.250Z"
+      }
+    }
+  }
+}
+```
+
+## Changelog and Migrations
+
+Version 1.0 documents the artifact-subject contract introduced by ADR-044. It uses the v1 Type URI
+and `schema_version: 1`.
+
+Legacy statements under `https://assay.dev/attestation/evidence-bundle/v0` put a semantic run root
+in the subject digest. The artifact verifier refuses that predicate explicitly. Relabeling a v0
+statement cannot recover the archive bytes it did not identify: a v1 statement must be derived from
+the actual verified archive and signed again.
+
+The Rust library retains deprecated compatibility names: `EVIDENCE_BUNDLE_PREDICATE_TYPE` still
+names v0, and `statement_from_manifest` still constructs v0 statements. The v1 producer entrypoint
+is `statement_for_bundle` (or its `_with_limits` variant). These API names do not alter the wire
+version rules above.

--- a/docs/attestation/evidence-bundle/v1.md
+++ b/docs/attestation/evidence-bundle/v1.md
@@ -130,8 +130,11 @@ strings exactly; an equivalent instant written with a different offset or fracti
 not interchangeable in this predicate.
 
 The field list fixes the shape, not a constant serialized byte size: identifiers and producer
-metadata remain strings. The semantic root covers the event content-hash inputs defined by the
-evidence contract; equal roots do not assert that all event metadata or archive bytes are equal.
+metadata remain strings. The semantic root covers the ordered content-hash inputs of the events
+the bundle retained, as defined by the evidence contract. Changing those retained inputs can
+change the root. Merely choosing a different export detail option does not guarantee a different
+root when the retained inputs are unchanged. The root does not identify every possible export of
+a run, and equal roots do not assert that all event metadata or archive bytes are equal.
 
 ## Example
 
@@ -189,3 +192,7 @@ The Rust library retains deprecated compatibility names: `EVIDENCE_BUNDLE_PREDIC
 names v0, and `statement_from_manifest` still constructs v0 statements. The v1 producer entrypoint
 is `statement_for_bundle` (or its `_with_limits` variant). These API names do not alter the wire
 version rules above.
+
+[ADR-049](../../architecture/ADR-049-attestation-extent.md) records an accepted optional-extension
+decision whose implementation is pending. It does not change the v1.0 fields or current parsing
+rules documented on this page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,6 +188,7 @@ nav:
     - Privileged MCP Action Profile (v0): profiles/privileged-mcp-action/v0.md
     - Privileged-Action Evidence Index: reference/privileged-action-evidence.md
     - Receipt Families: reference/receipt-families.md
+    - Evidence Bundle Attestation (v1): attestation/evidence-bundle/v1.md
     - Receipt Schema Registry: reference/receipt-schemas/README.md
     - mcp-eval.yaml: reference/config/eval-yaml.md
     - Policy Files: reference/config/policies.md


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: none active; standalone issue #2832.
- Slice: publish the existing v1 predicate specification, bind its URI to the source page, and record the pending optional extent decision.
- Builder: Codex/corpus102_final_review. Governing design author/coordinator: Codex/root.
- Independent final review: Codex/plimsoll115_review READY on the final head after reviewing source and retained execution evidence; [published review](https://github.com/Rul1an/assay/pull/2835#issuecomment-5570529286).
- Final head: `d35ec307b825b338ad63082972da14c4af1fe438`.
- Boundaries: applies ADR-044 decision 3; preserves ADR-042/043.

## Behavior

The predicate identifier currently has no served specification. This adds the existing v1.0 contract at its documentation path and a unit test that derives that path from the actual emitted URI constant, then checks the page's declaration. Missing-page and changed-URI controls exercise the same helper. The constant's docstring now distinguishes local binding from deployment.

ADR-049 records the pending optional extent contract: recomputed retained counts, explicitly labelled producer-reported summaries, missing-data semantics, bounded aggregation and unchanged public Rust layouts through additive APIs. The specification continues to describe shipped v1.0 behavior. No production execution logic or predicate fields change in this PR.

Refs #2832. The issue remains open until post-merge documentation deployment and a fetch of the actual predicate URI establish that the page is served.

## Non-Claims

- [x] No scalar trust score or whole-action verdict.
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan.
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim.

No extent implementation, CLI consumer, release or live-host verification ships here. A generated documentation route is not a deployed-page result.

## Test Evidence

Measured on the exact head above in `/Users/roelschuurkes/wt-codex-attestation-v1-spec`, with Rust/Cargo 1.96.0:

- Focused URI tests: 3 passed, including both refusal controls.
- Complete `assay-evidence` suite, including doctests: 691 passed, 0 failed, 4 fixture/corpus generators ignored. This total includes the URI tests.
- Clippy for all `assay-evidence` targets with warnings denied: passed.
- Formatting, normal commit hooks and diff hygiene: passed.
- Strict documentation build, changed-page links/JSON and generated canonical route: passed with Python 3.14.3, MkDocs 1.6.1 and Material 9.5.28 from checked-in requirements.

Generated `attestation/evidence-bundle/v1/index.html` SHA256: `0408215ab87c8bedb1c5aa449d28641557ca4356c5b340ef84b2a69fd426aa06`.

Earlier capacity refusals were retained separately; subsequent successful execution did not overwrite them. Negative controls are executed tests, not a claim that source mutations were run. Required hosted checks on this exact head are green. Post-merge deployment and the public URI fetch remain pending.

## Review Quorum

- [x] One substantive non-building review on this final head, with completed execution evidence assessed.
- [x] Every actionable finding fixed or technically disposed.
- [x] Current-head required checks, including any delegated proof, green.

Optional automated reviews add evidence but do not establish quorum.
