### PR TITLE
feat(evidence): ship artifact-bound attestation verification command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `assay evidence verify-attestation` checks an explicitly supplied Ed25519 public key,
+  DSSE attestation and completed evidence archive through the canonical v1 verifier.
+  Its success JSON distinguishes signature verification and artifact matching; bounded
+  input reads and static refusal messages preserve the evidence boundary (#2831).
 - `assay evidence show --format json` includes `content_hash_scope`, supplied by the
   shared public `assay_evidence::crypto::id::content_hash_scope()` API. It describes
   the reader's hash inputs and separates event-file, run-root and archive integrity

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -35,6 +35,7 @@ exclude = [
     "tests/doctor_text_render_contract.rs",
     "tests/cli_describe_contract.rs",
     "tests/stdout_json_write_contract.rs",
+    "tests/evidence_verify_attestation_cli.rs",
     "tests/mcp_preflight_contract.rs",
     "tests/recovery_argv_publisher_parity.rs",
 ]

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -23,6 +23,7 @@ pub mod skill_supply_chain;
 pub mod skill_supply_chain_capture;
 pub mod store_status;
 pub mod tool_decision_truth;
+pub mod verify_attestation;
 pub mod verify_privileged_mcp_action;
 pub mod verify_side_effects;
 pub mod verify_skill_supply_chain;
@@ -41,6 +42,9 @@ pub enum EvidenceCmd {
     Export(EvidenceExportArgs),
     /// Verify a bundle's integrity and provenance
     Verify(EvidenceVerifyArgs),
+    /// Verify a signed v1 attestation against the complete evidence archive
+    #[command(name = "verify-attestation")]
+    VerifyAttestation(verify_attestation::VerifyAttestationArgs),
     /// Verify SEP-2787/server execution-record fixture pairing
     #[command(name = "verify-mcp-records")]
     VerifyMcpRecords(mcp_execution_records::McpExecutionRecordArgs),
@@ -200,6 +204,7 @@ pub async fn run(args: crate::cli::args::EvidenceArgs) -> Result<i32> {
         EvidenceCmd::Lint(a) => lint::cmd_lint(a),
         EvidenceCmd::Diff(a) => diff::cmd_diff(a),
         EvidenceCmd::Attest(a) => attest::cmd_attest(a),
+        EvidenceCmd::VerifyAttestation(a) => verify_attestation::cmd_verify_attestation(a),
         EvidenceCmd::Push(a) => push::cmd_push(a).await,
         EvidenceCmd::Pull(a) => pull::cmd_pull(a).await,
         EvidenceCmd::List(a) => list::cmd_list(a).await,

--- a/crates/assay-cli/src/cli/commands/evidence/verify_attestation.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/verify_attestation.rs
@@ -1,0 +1,100 @@
+//! Full artifact-attestation verification with bounded local input and explicit outcome.
+use crate::output_write::write_stdout_json;
+use anyhow::{anyhow, Result};
+use assay_common::limits::{LimitKind, LimitReader};
+use assay_evidence::attestation::{verify_attestation_for_bundle_with_limits, DsseEnvelope};
+use assay_evidence::VerifyLimits;
+use clap::Args;
+use ed25519_dalek::pkcs8::DecodePublicKey;
+use ed25519_dalek::VerifyingKey;
+use serde::Serialize;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+const MAX_ENVELOPE_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_PUBLIC_KEY_BYTES: u64 = 16 * 1024;
+
+#[derive(Debug, Args, Clone)]
+pub struct VerifyAttestationArgs {
+    /// Completed evidence archive (.tar.gz) to match.
+    #[arg(long)]
+    pub bundle: PathBuf,
+    /// DSSE envelope containing the signed v1 Statement.
+    #[arg(long)]
+    pub attestation: PathBuf,
+    /// Explicit Ed25519 SPKI public PEM; no key discovery or private-key fallback.
+    #[arg(long)]
+    pub key: PathBuf,
+}
+
+#[derive(Serialize)]
+struct AttestationVerificationReport {
+    schema: &'static str,
+    outcome: &'static str,
+    signature_verified: bool,
+    subject_matched: bool,
+    artifact_sha256: String,
+    predicate_type: String,
+    subject_name: String,
+}
+
+/// Every input uses the same stream ceiling. Error context is static: underlying file,
+/// parser and verification errors can contain paths or attacker-controlled values.
+fn read_bounded(path: &Path, limit: u64, context: &'static str) -> Result<Vec<u8>> {
+    let file = File::open(path).map_err(|_| anyhow!(context))?;
+    let mut bytes = Vec::new();
+    LimitReader::new(file, limit, LimitKind::SourceBytes)
+        .read_to_end(&mut bytes)
+        .map_err(|_| anyhow!(context))?;
+    Ok(bytes)
+}
+
+pub fn cmd_verify_attestation(args: VerifyAttestationArgs) -> Result<i32> {
+    let limits = VerifyLimits::default();
+    let bundle = read_bounded(
+        &args.bundle,
+        limits.max_bundle_bytes,
+        "read bundle within input limit",
+    )?;
+    let encoded = read_bounded(
+        &args.attestation,
+        MAX_ENVELOPE_BYTES,
+        "read attestation within input limit",
+    )?;
+    let pem = read_bounded(
+        &args.key,
+        MAX_PUBLIC_KEY_BYTES,
+        "read public key within input limit",
+    )?;
+
+    // Typed deserialization skips unknown members without applying its recursion counter
+    // to their values. Check syntax/depth first, drop that allocation, then parse ORIGINAL
+    // bytes so duplicate known fields cannot disappear through Value's object map.
+    drop(
+        serde_json::from_slice::<serde_json::Value>(&encoded)
+            .map_err(|_| anyhow!("invalid DSSE envelope"))?,
+    );
+    let envelope: DsseEnvelope =
+        serde_json::from_slice(&encoded).map_err(|_| anyhow!("invalid DSSE envelope"))?;
+    let pem = std::str::from_utf8(&pem).map_err(|_| anyhow!("invalid Ed25519 public PEM"))?;
+    let key = VerifyingKey::from_public_key_pem(pem)
+        .map_err(|_| anyhow!("invalid Ed25519 public PEM"))?;
+
+    // This is the one canonical full verification path. A checked signature alone is
+    // artifact-unmatched and must never become this command's success report.
+    let verified = verify_attestation_for_bundle_with_limits(&envelope, &key, &bundle, limits)
+        .map_err(|_| anyhow!("attestation verification failed"))?;
+    let report = AttestationVerificationReport {
+        schema: "assay.evidence.attestation.verify.v1",
+        outcome: "attestation_verified",
+        signature_verified: true,
+        subject_matched: true,
+        artifact_sha256: verified.artifact_sha256,
+        predicate_type: verified.statement.predicate_type,
+        subject_name: verified.statement.subject[0].name.clone(),
+    };
+    let json = serde_json::to_string(&report)
+        .map_err(|_| anyhow!("serialize attestation verification report"))?;
+    Ok(write_stdout_json(&json))
+}

--- a/crates/assay-cli/tests/evidence_verify_attestation_cli.rs
+++ b/crates/assay-cli/tests/evidence_verify_attestation_cli.rs
@@ -1,0 +1,325 @@
+//! Real CLI contract for full signed-archive verification; no live host or key discovery.
+#[path = "../../../tests/support/bounded_process.rs"]
+#[allow(dead_code)]
+mod bounded_process;
+
+use assay_evidence::attestation::{
+    sign_statement, statement_for_bundle, DsseEnvelope, InTotoStatement,
+};
+use assay_evidence::bundle::BundleWriter;
+use assay_evidence::types::{EvidenceEvent, ProducerMeta};
+use bounded_process::{run_bounded, ProcessLimits};
+use ed25519_dalek::pkcs8::{spki::der::pem::LineEnding, EncodePublicKey};
+use ed25519_dalek::SigningKey;
+use serde_json::{json, Value};
+use std::fs::{self, File};
+use std::io::Write;
+use std::process::{Command, Output};
+use std::time::Duration;
+
+struct Fixture {
+    dir: tempfile::TempDir,
+    bytes: Vec<u8>,
+    signing: SigningKey,
+}
+
+impl Fixture {
+    fn new(producer_name: String) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let producer = ProducerMeta {
+            name: producer_name,
+            version: "test".into(),
+            git: None,
+        };
+        let mut writer = BundleWriter::new(File::create(dir.path().join("bundle.tar.gz")).unwrap())
+            .with_producer(producer.clone());
+        writer.add_event(
+            EvidenceEvent::new(
+                "assay.test.event",
+                "urn:assay:test",
+                "verify_run",
+                0,
+                json!({}),
+            )
+            .with_producer(&producer),
+        );
+        writer.finish().unwrap();
+        let bytes = fs::read(dir.path().join("bundle.tar.gz")).unwrap();
+        fs::write(dir.path().join("bundle.tar.gz"), &bytes).unwrap();
+        let signing = SigningKey::from_bytes(&[7; 32]);
+        fs::write(
+            dir.path().join("key.pem"),
+            signing
+                .verifying_key()
+                .to_public_key_pem(LineEnding::LF)
+                .unwrap(),
+        )
+        .unwrap();
+        let f = Self {
+            dir,
+            bytes,
+            signing,
+        };
+        f.write_statement(statement_for_bundle(&f.bytes).unwrap());
+        f
+    }
+    fn small() -> Self {
+        Self::new("assay-cli-test".into())
+    }
+    fn write_statement(&self, statement: InTotoStatement) {
+        let envelope = sign_statement(&statement, &self.signing).unwrap();
+        fs::write(
+            self.dir.path().join("attestation.json"),
+            serde_json::to_vec(&envelope).unwrap(),
+        )
+        .unwrap();
+    }
+    fn run(&self) -> Output {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_assay"));
+        cmd.current_dir(self.dir.path()).args([
+            "evidence",
+            "verify-attestation",
+            "--bundle",
+            "bundle.tar.gz",
+            "--attestation",
+            "attestation.json",
+            "--key",
+            "key.pem",
+        ]);
+        for (name, _) in std::env::vars_os() {
+            if name
+                .to_string_lossy()
+                .to_ascii_uppercase()
+                .starts_with("ASSAY_")
+            {
+                cmd.env_remove(name);
+            }
+        }
+        run_bounded(
+            cmd,
+            &[],
+            ProcessLimits::new(Duration::from_secs(60), 4096, 4096),
+            "attestation verification CLI",
+        )
+        .expect("bounded CLI run")
+    }
+    fn refuse(&self, context: &str) {
+        let output = self.run();
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "{context}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "{context}: refusal emitted success JSON"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(context),
+            "wrong refusal: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn matching_archive_returns_one_typed_matched_outcome() {
+    let f = Fixture::small();
+    let output = f.run();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let statement = statement_for_bundle(&f.bytes).unwrap();
+    assert_eq!(
+        result,
+        json!({"schema":"assay.evidence.attestation.verify.v1", "outcome":"attestation_verified", "signature_verified":true,"subject_matched":true,"artifact_sha256":statement.subject[0].digest["sha256"],"predicate_type":statement.predicate_type,"subject_name":statement.subject[0].name})
+    );
+}
+
+#[test]
+fn wrong_signature_key_is_refused_without_success_output() {
+    let f = Fixture::small();
+    let wrong = SigningKey::from_bytes(&[9; 32]);
+    fs::write(
+        f.dir.path().join("key.pem"),
+        wrong
+            .verifying_key()
+            .to_public_key_pem(LineEnding::LF)
+            .unwrap(),
+    )
+    .unwrap();
+    f.refuse("attestation verification failed");
+}
+
+#[test]
+fn valid_archive_with_other_container_bytes_is_refused() {
+    let f = Fixture::small();
+    let mut other = f.bytes.clone();
+    other.extend_from_slice(b"trailing");
+    // Prove the witness passes ordinary bundle validation before testing artifact matching.
+    statement_for_bundle(&other).expect("changed container is still a valid bundle");
+    fs::write(f.dir.path().join("bundle.tar.gz"), other).unwrap();
+    f.refuse("attestation verification failed");
+}
+
+#[test]
+fn signed_legacy_unknown_version_and_derived_field_mismatch_are_refused() {
+    let f = Fixture::small();
+    for variant in ["legacy", "unknown", "schema", "derived"] {
+        let mut statement = statement_for_bundle(&f.bytes).unwrap();
+        match variant {
+            "legacy" => {
+                statement.predicate_type = "https://assay.dev/attestation/evidence-bundle/v0".into()
+            }
+            "unknown" => {
+                statement.predicate_type =
+                    "https://docs.getassay.dev/attestation/evidence-bundle/v999".into()
+            }
+            "schema" => statement.predicate["schema_version"] = json!(999),
+            _ => statement.predicate["run"]["run_id"] = json!("different-run"),
+        }
+        f.write_statement(statement);
+        f.refuse("attestation verification failed");
+    }
+}
+
+#[test]
+fn malformed_outer_json_is_refused() {
+    let f = Fixture::small();
+    fs::write(f.dir.path().join("attestation.json"), "{").unwrap();
+    f.refuse("invalid DSSE envelope");
+}
+
+#[test]
+fn trailing_outer_json_is_refused() {
+    let f = Fixture::small();
+    let path = f.dir.path().join("attestation.json");
+    let original = fs::read_to_string(&path).unwrap();
+    fs::write(path, format!("{original} false")).unwrap();
+    f.refuse("invalid DSSE envelope");
+}
+
+#[test]
+fn duplicate_known_outer_field_is_refused_even_if_last_value_is_valid() {
+    let f = Fixture::small();
+    let path = f.dir.path().join("attestation.json");
+    let original = fs::read_to_string(&path).unwrap();
+    fs::write(
+        path,
+        original.replacen('{', "{\"payload\":\"duplicate\",", 1),
+    )
+    .unwrap();
+    f.refuse("invalid DSSE envelope");
+}
+
+#[test]
+fn deeply_nested_unknown_outer_field_is_refused_on_an_otherwise_valid_envelope() {
+    let f = Fixture::small();
+    let path = f.dir.path().join("attestation.json");
+    let original = fs::read_to_string(&path).unwrap();
+    let with_depth = |depth| {
+        original.replacen(
+            '{',
+            &format!("{{\"extra\":{}0{},", "[".repeat(depth), "]".repeat(depth)),
+            1,
+        )
+    };
+    fs::write(&path, with_depth(2)).unwrap();
+    assert!(
+        f.run().status.success(),
+        "a shallow unknown field is compatible"
+    );
+    fs::write(path, with_depth(140)).unwrap();
+    f.refuse("invalid DSSE envelope");
+}
+
+#[test]
+fn base64_payload_larger_than_one_mib_keeps_valid_statement_compatibility() {
+    let f = Fixture::new("x".repeat(800_000));
+    let raw = fs::read(f.dir.path().join("attestation.json")).unwrap();
+    let envelope: DsseEnvelope = serde_json::from_slice(&raw).unwrap();
+    assert!(
+        envelope.payload.len() > 1024 * 1024,
+        "witness must cross outer strict-string ceiling"
+    );
+    let output = f.run();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn envelope_ceiling_is_inclusive_and_next_byte_is_refused() {
+    let f = Fixture::small();
+    let path = f.dir.path().join("attestation.json");
+    let mut raw = fs::read(&path).unwrap();
+    raw.resize(32 * 1024 * 1024, b' ');
+    fs::write(&path, &raw).unwrap();
+    assert!(
+        f.run().status.success(),
+        "valid JSON at the input ceiling must be accepted"
+    );
+    File::options()
+        .append(true)
+        .open(&path)
+        .unwrap()
+        .write_all(b" ")
+        .unwrap();
+    f.refuse("read attestation within input limit");
+}
+
+#[test]
+fn public_key_source_ceiling_refuses_before_pem_decoding() {
+    let f = Fixture::small();
+    File::create(f.dir.path().join("key.pem"))
+        .unwrap()
+        .set_len(16 * 1024 + 1)
+        .unwrap();
+    f.refuse("read public key within input limit");
+}
+
+#[test]
+fn bundle_source_ceiling_refuses_before_archive_decoding() {
+    let f = Fixture::small();
+    File::create(f.dir.path().join("bundle.tar.gz"))
+        .unwrap()
+        .set_len(100 * 1024 * 1024 + 1)
+        .unwrap();
+    f.refuse("read bundle within input limit");
+}
+
+#[test]
+fn private_key_is_not_a_public_key_fallback() {
+    use ed25519_dalek::pkcs8::EncodePrivateKey;
+    let f = Fixture::small();
+    fs::write(
+        f.dir.path().join("key.pem"),
+        f.signing.to_pkcs8_pem(LineEnding::LF).unwrap().as_bytes(),
+    )
+    .unwrap();
+    f.refuse("invalid Ed25519 public PEM");
+}
+
+#[test]
+fn attacker_values_are_not_echoed_through_library_error_chains() {
+    let f = Fixture::small();
+    let mut envelope: Value =
+        serde_json::from_slice(&fs::read(f.dir.path().join("attestation.json")).unwrap()).unwrap();
+    envelope["payloadType"] = json!("ATTACKER_SECRET_2831");
+    fs::write(
+        f.dir.path().join("attestation.json"),
+        serde_json::to_vec(&envelope).unwrap(),
+    )
+    .unwrap();
+    let output = f.run();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("ATTACKER_SECRET_2831"));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("attestation verification failed"));
+}

--- a/crates/assay-cli/tests/stdout_json_write_contract.rs
+++ b/crates/assay-cli/tests/stdout_json_write_contract.rs
@@ -921,3 +921,45 @@ fn every_sink_case_reader_gone_is_exit_three() {
         offenders.join("; ")
     );
 }
+
+#[test]
+fn verify_attestation_success_document_reports_closed_stdout_as_exit_three() {
+    use assay_evidence::attestation::{sign_statement, statement_for_bundle};
+    use ed25519_dalek::pkcs8::{spki::der::pem::LineEnding, EncodePublicKey};
+    let dir = tempfile::tempdir().unwrap();
+    let bundle = skill_supply_chain_bundle(dir.path());
+    let bytes = std::fs::read(&bundle).unwrap();
+    let signing = ed25519_dalek::SigningKey::from_bytes(&[7; 32]);
+    let envelope = sign_statement(&statement_for_bundle(&bytes).unwrap(), &signing).unwrap();
+    let attestation = dir.path().join("attestation.json");
+    let key = dir.path().join("public.pem");
+    std::fs::write(&attestation, serde_json::to_vec(&envelope).unwrap()).unwrap();
+    std::fs::write(
+        &key,
+        signing
+            .verifying_key()
+            .to_public_key_pem(LineEnding::LF)
+            .unwrap(),
+    )
+    .unwrap();
+    let command = || {
+        let mut cmd = assay_command(dir.path());
+        cmd.args(["evidence", "verify-attestation", "--bundle"])
+            .arg(&bundle)
+            .arg("--attestation")
+            .arg(&attestation)
+            .arg("--key")
+            .arg(&key);
+        cmd
+    };
+    let positive = run_bounded(command(), &[], LIMITS, "verify-attestation positive").unwrap();
+    assert!(
+        positive.status.success(),
+        "{}",
+        String::from_utf8_lossy(&positive.stderr)
+    );
+    let result: Value = serde_json::from_slice(&positive.stdout).unwrap();
+    assert_eq!(result["outcome"], "attestation_verified");
+    let closed = run_reader_already_gone(command(), "verify-attestation reader gone");
+    assert_infra_write_failure(&closed, "verify-attestation reader gone");
+}

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -51,6 +51,7 @@ assay.doctor_report.v0 | crates/assay-cli/src/cli/commands/doctor/implementation
 assay.enforcement_health.v0 | crates/assay-cli/src/cli/commands/monitor_next/enforcement_health.rs | -
 assay.enforcement_health.v1 | crates/assay-cli/src/enforcement_health_v1.rs | -
 assay.enforcement_health_projection.v0 | crates/assay-cli/src/cli/commands/project_enforcement_health.rs | -
+assay.evidence.attestation.verify.v1 | crates/assay-cli/src/cli/commands/evidence/verify_attestation.rs | -
 assay.evidence.schema.list.v1 | crates/assay-cli/src/cli/commands/evidence/schema/write.rs | crates/assay-cli/src/cli/commands/evidence/schema/reports.rs
 assay.evidence.schema.show.v1 | crates/assay-cli/src/cli/commands/evidence/schema/write.rs | crates/assay-cli/src/cli/commands/evidence/schema/reports.rs
 assay.evidence.schema.validation.v1 | crates/assay-cli/src/cli/commands/evidence/schema/write.rs | crates/assay-cli/src/cli/commands/evidence/schema/reports.rs

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -565,3 +565,42 @@ To compare the resulting Trust Basis artifact against another run, use
 - [P45b OpenFeature decision receipt Trust Basis claim plan](../../architecture/PLAN-P45B-DECISION-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md)
 - [P41 OpenFeature decision receipt import plan](../../architecture/PLAN-P41-OPENFEATURE-EVALUATION-DETAILS-DECISION-RECEIPT-IMPORT-2026q2.md)
 - [P31 Promptfoo receipt import plan](../../architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md)
+
+## Verify an artifact attestation
+
+```bash
+assay evidence verify-attestation \
+  --bundle evidence.tar.gz \
+  --attestation attestation.json \
+  --key public-key.pem
+```
+
+The command verifies the DSSE signature with the explicitly supplied Ed25519 SPKI public
+PEM, then matches the complete compressed archive and every defined v1 predicate field
+through the canonical attestation verifier. It does not discover keys or accept a private
+key as a substitute. The v0 predicate and unknown predicate versions are refused.
+
+Successful stdout is one JSON document with schema `assay.evidence.attestation.verify.v1`,
+outcome `attestation_verified`, `signature_verified: true`, `subject_matched: true`,
+`artifact_sha256`, `predicate_type` and `subject_name`. The archive digest is lowercase
+SHA-256 hexadecimal without a prefix; it is distinct from the semantic run root.
+
+Exit 0 means the full attestation matched. Input, signature, integrity, version and resource
+refusals exit 2 with a bounded static explanation on stderr and no success JSON. A stdout
+write or flush failure exits 3. There is no signature-only fallback.
+
+Input streams are bounded before unbounded materialization or decoding: the encoded DSSE
+envelope is limited to 32 MiB (33,554,432 bytes), public PEM to 16 KiB (16,384 bytes), and
+archive source to the default 100 MiB (104,857,600 bytes). Default bundle-verification limits
+also apply to decoded contents, manifest, events, lines, paths and nesting. These are local
+refusal budgets, not a promise that every envelope below them is valid or accepted.
+
+Outer JSON is parsed once for syntax and nesting under the standard JSON recursion limit,
+then that temporary value is dropped and the original bytes are parsed as a typed DSSE
+envelope. This small double-parse cost preserves duplicate-known-field refusal without
+applying the decoded Statement's string ceiling to its base64 transport. The canonical
+verifier independently applies strict parsing to the decoded signed Statement.
+
+Key selection remains the caller's trust policy. Verification does not establish a trust
+root, transparency inclusion, observation completeness, provider outcomes or live host
+activity. See the [v1 predicate contract](../../attestation/evidence-bundle/v1.md).


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: no programme active; standalone #2831.
- Slice: ship the consumer command for the existing artifact-bound attestation verifier.
- Builder: Codex/corpus102_final_review; governing implementation decisions by Codex/root.
- Reviewer: Codex/plimsoll115_review, independent non-builder; fresh full eight-path review of this final head is READY, with no actionable findings. Reviewed the source and retained writer execution evidence; did not rerun tests. Canonical record to be relayed separately by Rul1an. Optional automation is not quorum.
- Final head SHA: 858e781e2022bc569427cb1ec2df44df22ebb096; base d270c9e96c2a0d8894f257f9c4b41de8fa93d9d3.
- ADR invariants affected: ADR-042 bounded claims, ADR-043 hostile-input limits, ADR-044 signature versus artifact-match distinction.

## Behavior

Recipients can now run `assay evidence verify-attestation --bundle PATH --attestation PATH --key PATH` with an explicit Ed25519 SPKI public key. The command calls the existing full with-limits verifier and reports success only when both the signature and completed archive subject match. The report names those conditions separately and carries the verified archive digest; no signature-only success path is introduced.

Bundle, envelope and key reads are bounded before parsing/verification. The outer envelope retains normal JSON depth checks and duplicate-known-field refusal without imposing the decoded statement's smaller string limit on its base64 transport. Canonical signed-statement and predicate-version rules remain unchanged. Input/verification refusal exits2; failure to deliver stdout exits3; delivered matched success exits0. Error contexts omit untrusted values.

## Non-Claims

- [x] No scalar trust score or whole-action verdict.
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan.
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim.
- No trust-root selection, key discovery, transparency service, private-key fallback, extent implementation, or public Rust API change.
- Merge, release and installed-host proof are separate from local checks. Hosted CI remains pending.

## Test Evidence

Initial implementation measurements at `e297dbd6139880faaf723c65ab9ee66237f7c569`, worktree `/Users/roelschuurkes/wt-codex-2831-verify-attestation`, Rust/Cargo1.96.0.

### RED

Before implementation, the real CLI integration witness failed because `verify-attestation` was an unrecognized subcommand. This was a behavioral failure, not a compilation/setup failure.

### GREEN

`cargo test -p assay-cli --bin assay --test evidence_verify_attestation_cli --test stdout_json_write_contract --test cli_json_identities`: bin625 passed/2 ignored; identities15 passed; attestation CLI29 passed/1 ignored; stdout contract32 passed/1 ignored. Existing ignored helper/generator cases remain explicitly ignored, not counted as executed. All suites had zero failures.

Affected bin/integration clippy with `-D warnings`, `cargo fmt --all -- --check`, `git diff --check`, public-string inspection and normal commit hooks passed. No broad integration discovery, Docker or model/host execution.

Four behavioral mutations were killed: signature verification bypass, whole-archive digest comparison bypass, unknown-version guard bypass, and source-read limit bypass. A comment-only no-op passed. Each overlay was restored byte-for-byte. Mutations ran before commit; source/patch hashes and an explicit committed-source equivalence record bind those measured bytes to the initial implementation commit `e297dbd6139880faaf723c65ab9ee66237f7c569`. They are not claimed to have been rerun at the final SHA. Tests and clippy were rerun separately at the initial implementation head `e297dbd6139880faaf723c65ab9ee66237f7c569`.

## Review Quorum

- [x] One non-building agent review on this exact head.
- [x] All actionable findings disposed in the independent final-head review.
- Delegated proof: not claimed; required hosted checks must establish the applicable gates.

Optional automated reviews can add evidence, but do not count toward or block quorum.

Closes #2831.

### Evidence retention correction

After the independent review, the historical pre-implementation RED.log was accidentally overwritten during unrelated local tooling work. The contemporaneous RED receipt and exit record remain, and the reviewer had examined the original log before its loss. A subsequent full manifest audit confirmed 89 of 90 artifacts unchanged; only that log is missing. It has not been reconstructed or presented as retained. The retained test results at `e297dbd6139880faaf723c65ab9ee66237f7c569` and mutation artifacts remain intact. The reviewer reconfirmed the code verdict with this evidence limitation in an additive review.

### Packaging repair and current-head verification

CI caught that the new workspace integration test includes shared support outside the crate. The manifest now excludes that workspace-only test from the published source package, alongside existing tests with the same requirement. The test remains available to workspace CI; production sources remain packaged. This is the only change after `e297dbd6139880faaf723c65ab9ee66237f7c569`.

At current head `858e781e2022bc569427cb1ec2df44df22ebb096`, the publish-shape check, offline package file listing, fmt and diff checks passed. The real CLI integration target passed 29 tests with one existing helper ignored, using Rust/Cargo 1.96.0 and one buildjob. Earlier bin/identities/stdout totals and mutation results above retain their original provenance; they were not rerun or relabelled as current-head results. Hosted CI must run on this new head.
