### PR TITLE
fix(mcp): expose typed tool failures in structuredContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `assay-mcp-server` mirrors typed errors from selected tool calls into
+  `structuredContent`, preserving the existing JSON text and `isError` (#2815).
+  Both placements use the same bounded error value, including optional details.
+  This additive change is for the next minor release; ordinary policy denials,
+  successful results and JSON-RPC protocol errors retain their existing shape.
+  It adds no output schema or error vocabulary and establishes no host proof.
 - `assay evidence show --format json` includes `content_hash_scope`, supplied by the
   shared public `assay_evidence::crypto::id::content_hash_scope()` API. It describes
   the reader's hash inputs and separates event-file, run-root and archive integrity

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -24,12 +24,12 @@ fn fail_closed_tool_result(code: &'static str, message: &'static str) -> Result<
     tools::ToolError::new(code, message).result()
 }
 
-fn classify_tool_result(result: &Value) -> (bool, bool) {
+fn classify_tool_result(result: &Value) -> (bool, bool, bool) {
     let has_error = result.get("error").is_some();
     let explicit_allowed = result.get("allowed").and_then(Value::as_bool);
     let allowed = explicit_allowed.unwrap_or(false);
     let is_error = has_error || explicit_allowed == Some(false);
-    (allowed, is_error)
+    (allowed, is_error, has_error)
 }
 
 fn next_rid() -> String {
@@ -419,7 +419,7 @@ impl Server {
 
                             let dur = start.elapsed().as_millis() as u64;
                             // Log outcome
-                            let (allowed, is_error) = classify_tool_result(&result);
+                            let (allowed, is_error, has_error) = classify_tool_result(&result);
                             if let Some(err) = result.get("error") {
                                 let code = err.get("code").and_then(|v| v.as_str()).unwrap_or("");
                                 tracing::info!(
@@ -486,10 +486,15 @@ impl Server {
                             // MCP Compliance: wrap every tool outcome in CallToolResult.
                             let json_text =
                                 serde_json::to_string_pretty(&result).unwrap_or_default();
-                            let mcp_result = serde_json::json!({
+                            let mut mcp_result = serde_json::json!({
                                 "content": [{"type": "text", "text": json_text}],
                                 "isError": is_error
                             });
+                            // Mirror the already-bounded ToolError value, not a second serializer.
+                            // A plain policy denial is isError too, but has no typed error to mirror.
+                            if has_error {
+                                mcp_result["structuredContent"] = result;
+                            }
                             JsonRpcResponse::ok(req.id.clone(), mcp_result)
                         }
                     }
@@ -521,22 +526,22 @@ mod claims_boundary_tests {
     #[test]
     fn tool_result_classification_separates_decision_from_mcp_error() {
         for (result, expected) in [
-            (serde_json::json!({"allowed": true}), (true, false)),
-            (serde_json::json!({"allowed": false}), (false, true)),
+            (serde_json::json!({"allowed": true}), (true, false, false)),
+            (serde_json::json!({"allowed": false}), (false, true, false)),
             (
                 serde_json::json!({"allowed": false, "error": {"code": "E_INTERNAL"}}),
-                (false, true),
+                (false, true, true),
             ),
             // Defence: an error object without `allowed` is still an MCP error. Production
             // `ToolError::result` always sets both, so this row is the only independent
             // witness for the `has_error` arm.
             (
                 serde_json::json!({"error": {"code": "E_INTERNAL"}}),
-                (false, true),
+                (false, true, true),
             ),
             // Report tools return data rather than a policy decision. Preserve the existing
             // decision telemetry while keeping their successful MCP result non-error.
-            (serde_json::json!({"report": {}}), (false, false)),
+            (serde_json::json!({"report": {}}), (false, false, false)),
         ] {
             assert_eq!(classify_tool_result(&result), expected, "result: {result}");
         }

--- a/crates/assay-mcp-server/tests/outer_fallback_contract.rs
+++ b/crates/assay-mcp-server/tests/outer_fallback_contract.rs
@@ -59,6 +59,15 @@ fn assert_fixed_failure(response: &Value, code: &str, message: &str) {
     let result = response.get("result").expect("CallToolResult response");
     assert_eq!(result["isError"], true, "response: {response}");
     let payload = tool_payload(response);
+    assert_eq!(
+        result.get("structuredContent"),
+        Some(&payload),
+        "selected failure must mirror the bounded text payload"
+    );
+    assert!(
+        payload["error"].get("details").is_none(),
+        "fixed fallback must not manufacture optional details"
+    );
     assert_eq!(payload["allowed"], false, "payload: {payload}");
     assert_eq!(payload["error"]["code"], code, "payload: {payload}");
     assert_eq!(payload["error"]["message"], message, "payload: {payload}");
@@ -97,8 +106,49 @@ fn report_tools_keep_successful_mcp_results() {
     for response in [&coverage, &explanation] {
         assert_eq!(response["result"]["isError"], false, "response: {response}");
         assert!(tool_payload(response).get("error").is_none());
+        assert!(response["result"].get("structuredContent").is_none());
     }
     assert!(conn.shutdown().success());
+}
+
+#[test]
+fn typed_error_projection_is_consistent_across_accepted_revisions() {
+    // Literal supported revisions: not derived from the implementation's list.
+    for version in ["2024-11-05", "2025-06-18", "2025-11-25"] {
+        let (mut conn, root) = spawn_server(None);
+        fs::write(root.path().join("policy.yaml"), "blocklist: [Blocked]\n")
+            .expect("write decision policy");
+        let initialized = conn.request(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": version,
+                "capabilities": {},
+                "clientInfo": {"name": "typed-error-contract", "version": "1"}
+            }),
+            1,
+        );
+        assert_eq!(initialized["result"]["protocolVersion"], version);
+
+        let failure = call_tool(&mut conn, "assay_check_args", serde_json::json!({}), 2);
+        assert_fixed_failure(&failure, "E_INTERNAL", "Tool execution failed");
+        for (id, tool, expected_allowed) in [(3, "Blocked", false), (4, "Allowed", true)] {
+            let response = call_tool(
+                &mut conn,
+                "assay_policy_decide",
+                serde_json::json!({"tool": tool, "policy": "policy.yaml"}),
+                id,
+            );
+            let payload = tool_payload(&response);
+            assert_eq!(payload["allowed"], expected_allowed);
+            assert!(payload.get("error").is_none());
+            assert_eq!(response["result"]["isError"], !expected_allowed);
+            assert!(
+                response["result"].get("structuredContent").is_none(),
+                "ordinary decision must not gain typed-error projection: {response}"
+            );
+        }
+        assert!(conn.shutdown().success());
+    }
 }
 
 #[test]

--- a/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
+++ b/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
@@ -111,6 +111,11 @@ fn assert_parse_error_with_policy(
     policy_root: &Path,
     policy_filename: Option<&str>,
 ) {
+    assert_eq!(
+        result.get("structuredContent"),
+        Some(body),
+        "{label}: typed structuredContent must equal the bounded text payload"
+    );
     let mut body_keys: Vec<&str> = body
         .as_object()
         .unwrap_or_else(|| panic!("{label}: decoded tool body must be an object; body={body}"))


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: none active; standalone issue #2815.
- Slice: expose existing typed tool errors in MCP structuredContent.
- Builder: Codex / host_schema_gap_triage; coordinator: Codex root.
- Reviewer: Codex / corpus102_final_review, non-building source/evidence reviewer. Rul1an is the prospective relay publisher, not the reviewer.
- Final head SHA: 4d7140d5de01db83c37b760ce303c7e45e5cb315.
- ADR invariants affected: preserve policy decision vs. typed failure and bounded error output.

## Behavior

A malformed policy already returns a bounded typed error in the tool result's JSON text. Clients reading structuredContent currently miss that error. Selected typed failures now expose the same JSON value in both locations, including numeric diagnostic details. Ordinary policy denials, successful results and JSON-RPC protocol errors keep their existing shapes.

## Non-Claims

- [x] No scalar trust score or whole-action verdict.
- [x] No generic identity, delegation, federation, HTTP/OAuth or broad MCP scan.
- [x] No provider-outcome, compliance, certification, partnership or safe-agent claim.
- No installed-host proof, new error vocabulary or output schema. Additive next-minor change; no release published by this PR.

## Test Evidence

### RED

The retained actual-stdio regression first failed because structuredContent was absent for an E_POLICY_PARSE error with positive numeric diagnostic details. This is the behavioral trigger; compiler/setup failures are not the RED witness.

### GREEN

At 4d7140d5de01db83c37b760ce303c7e45e5cb315, in /Users/roelschuurkes/wt-codex-2815-typed-error-projection with Rust/Cargo 1.96.0: the three focused suites pass 23 tests; the full affected MCP crate passes 499 tests with two explicitly ignored descendant-helper occurrences that the descendant tests invoke as child processes. Formatting and affected all-target clippy with -D warnings pass.

Retained mutations at reviewed predecessor d39266ea190b008d1926185d803640b214b6e091 remove the projection, diverge its structured error code, and broaden selection to ordinary policy denial: each fails the named behavioral assertion; no-op controls pass. These are predecessor measurements, not newly executed mutations. The three Rust source/test blobs remain identical to that predecessor. The new main merge changed CHANGELOG.md and received a fresh four-path review; no prior review carry is claimed.

## Review Quorum

- [x] Fresh independent review by Codex / corpus102_final_review on the final head; retained final-head logs and hashes inspected.
- [x] No outstanding actionable review finding.
- [ ] Confirm current required CI and any delegated proof before merge.

Closes #2815. Required hosted CI remains pending; local checks and review do not establish landing or installed-host behavior.
