### PR TITLE
feat(evidence): verify artifact-derived attestation extent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Optional artifact-derived attestation extent under the existing `evidence-bundle/v1` Type URI
+  (#2833): retained event-type counts and explicitly producer-reported or not-stated summary counts.
+  Additive library APIs opt producers in and expose checked extent; existing artifact verifiers
+  check present extent while legacy producers and public Rust result layouts remain unchanged.
+  Absent/null extent retains legacy semantics. Counts and histogram growth are bounded; verification
+  does not establish observation completeness, provider outcomes, or producer identity. CLI opt-in
+  and extent presentation remain separate.
 - `assay evidence verify-attestation` checks an explicitly supplied Ed25519 public key,
   DSSE attestation and completed evidence archive through the canonical v1 verifier.
   Its success JSON distinguishes signature verification and artifact matching; bounded

--- a/crates/assay-evidence/src/attestation.rs
+++ b/crates/assay-evidence/src/attestation.rs
@@ -42,6 +42,30 @@ use std::collections::BTreeMap;
 
 /// in-toto Statement type URI (v1).
 const STATEMENT_TYPE: &str = "https://in-toto.io/Statement/v1";
+pub(crate) mod extent;
+pub use extent::{EvidenceExtent, Observed, ObservedCounts};
+
+/// The original artifact match plus optional, checked extent. Private fields preserve evolution.
+#[derive(Debug)]
+pub struct AttestationVerifiedWithExtent {
+    verified: AttestationVerified,
+    extent: Option<EvidenceExtent>,
+}
+impl AttestationVerifiedWithExtent {
+    /// Signature and artifact match, preserving the original public result shape.
+    pub fn verified(&self) -> &AttestationVerified {
+        &self.verified
+    }
+    /// Checked extent; absent/null input remains not stated.
+    pub fn extent(&self) -> Option<&EvidenceExtent> {
+        self.extent.as_ref()
+    }
+    /// Consume the additive result without changing the legacy result type.
+    pub fn into_parts(self) -> (AttestationVerified, Option<EvidenceExtent>) {
+        (self.verified, self.extent)
+    }
+}
+
 /// DSSE payload type for in-toto statements.
 const IN_TOTO_PAYLOAD_TYPE: &str = "application/vnd.in-toto+json";
 /// The v1 evidence-bundle predicate type.
@@ -117,6 +141,38 @@ pub fn statement_for_bundle_with_limits(
         &verified.result.manifest.bundle_id,
         &predicate,
     ))
+}
+
+/// Explicitly opt into the artifact-derived extent projection (specification revision 1.1).
+pub fn statement_for_bundle_with_extent(bundle_bytes: &[u8]) -> Result<InTotoStatement> {
+    statement_for_bundle_with_extent_and_limits(bundle_bytes, VerifyLimits::default())
+}
+
+/// Extent-aware producer under the caller's existing bundle limits.
+pub fn statement_for_bundle_with_extent_and_limits(
+    bundle_bytes: &[u8],
+    limits: VerifyLimits,
+) -> Result<InTotoStatement> {
+    let verified =
+        crate::bundle::writer::verify_bundle_verbose_with_extent(bundle_bytes, limits, true)
+            .context("the bundle to attest does not verify")?;
+    let predicate = predicate_from_verified(&verified)?;
+    let mut statement = statement_from_parts(
+        bundle_bytes,
+        &verified.result.manifest.bundle_id,
+        &predicate,
+    );
+    let extent = verified
+        .extent
+        .context("requested extent was not derived")?;
+    statement.predicate["extent"] = serde_json::to_value(extent)?;
+    // Validate the actual canonical output, including variable legacy metadata and histogram keys.
+    // An in-memory object check alone cannot prove compatibility with the signed-payload parser.
+    let bytes = jcs::to_vec(&statement).context("canonicalize extent statement")?;
+    let text = std::str::from_utf8(&bytes).context("extent statement must be UTF-8")?;
+    crate::json_strict::from_str_strict::<InTotoStatement>(text)
+        .map_err(|_| anyhow::anyhow!("extent statement exceeds strict signed-payload bounds"))?;
+    Ok(statement)
 }
 
 /// Assemble the statement once every part is known to come from the same verified bytes.
@@ -463,6 +519,36 @@ pub fn verify_attestation_for_bundle_with_limits(
     bundle_bytes: &[u8],
     limits: VerifyLimits,
 ) -> Result<AttestationVerified> {
+    Ok(verify_attestation_for_bundle_with_extent_and_limits(
+        envelope,
+        trusted_key,
+        bundle_bytes,
+        limits,
+    )?
+    .verified)
+}
+
+/// Verify present extent while exposing its checked projection alongside the original result.
+pub fn verify_attestation_for_bundle_with_extent(
+    envelope: &DsseEnvelope,
+    trusted_key: &VerifyingKey,
+    bundle_bytes: &[u8],
+) -> Result<AttestationVerifiedWithExtent> {
+    verify_attestation_for_bundle_with_extent_and_limits(
+        envelope,
+        trusted_key,
+        bundle_bytes,
+        VerifyLimits::default(),
+    )
+}
+
+/// Canonical artifact-backed verifier. Legacy APIs discard only the new result projection.
+pub fn verify_attestation_for_bundle_with_extent_and_limits(
+    envelope: &DsseEnvelope,
+    trusted_key: &VerifyingKey,
+    bundle_bytes: &[u8],
+    limits: VerifyLimits,
+) -> Result<AttestationVerifiedWithExtent> {
     let verified = verify_envelope_signature(envelope, trusted_key)?;
     let statement = verified.statement;
 
@@ -501,6 +587,13 @@ pub fn verify_attestation_for_bundle_with_limits(
         .get("sha256")
         .context("subject digest has no sha256 entry")?;
 
+    let claimed_extent = statement
+        .predicate
+        .get("extent")
+        .filter(|value| !value.is_null())
+        .map(extent::parse)
+        .transpose()?;
+
     let predicate: EvidenceBundlePredicate =
         serde_json::from_value(statement.predicate.clone()).context("parse v1 predicate")?;
     if predicate.schema_version != 1 {
@@ -519,8 +612,12 @@ pub fn verify_attestation_for_bundle_with_limits(
     //
     // Everything above this line reads the statement the signature already covered; nothing above
     // it touches `bundle_bytes`.
-    let verified = crate::bundle::writer::verify_bundle_verbose_with_limits(bundle_bytes, limits)
-        .context("the attested bundle does not verify")?;
+    let verified = crate::bundle::writer::verify_bundle_verbose_with_extent(
+        bundle_bytes,
+        limits,
+        claimed_extent.is_some(),
+    )
+    .context("the attested bundle does not verify")?;
     let result = &verified.result;
 
     // Value-free: the holder has both the envelope and the bytes, so echoing the two digests adds
@@ -555,10 +652,22 @@ pub fn verify_attestation_for_bundle_with_limits(
         }
     }
 
-    Ok(AttestationVerified {
-        statement,
-        predicate,
-        artifact_sha256: actual,
+    if let Some(attested) = &claimed_extent {
+        extent::check(
+            attested,
+            verified
+                .extent
+                .as_ref()
+                .context("requested extent was not derived")?,
+        )?;
+    }
+    Ok(AttestationVerifiedWithExtent {
+        verified: AttestationVerified {
+            statement,
+            predicate,
+            artifact_sha256: actual,
+        },
+        extent: verified.extent,
     })
 }
 

--- a/crates/assay-evidence/src/attestation/extent.rs
+++ b/crates/assay-evidence/src/attestation/extent.rs
@@ -1,0 +1,335 @@
+//! Optional artifact-derived extent (ADR-049). Ordinary verification never allocates this state.
+use anyhow::{bail, Context, Result};
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+use crate::types::EvidenceEvent;
+
+const MAX_COUNT: u64 = 9_007_199_254_740_991;
+const MAX_KEY_BYTES: usize = 1024 * 1024;
+const PROFILE: &str = "assay.profile.finished";
+const SANDBOX: &str = "assay.sandbox.summary";
+
+/// Recomputed retained-event counts and explicitly qualified summary assertions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct EvidenceExtent {
+    retained_events_by_type: BTreeMap<String, u64>,
+    observed: Observed,
+}
+
+impl EvidenceExtent {
+    /// Exact retained event types, in sorted order; missing types are not synthesized as zero.
+    pub fn retained_events_by_type(&self) -> &BTreeMap<String, u64> {
+        &self.retained_events_by_type
+    }
+
+    /// Producer-reported summary assertions, or explicitly not stated.
+    pub fn observed(&self) -> &Observed {
+        &self.observed
+    }
+}
+
+/// Qualification of the recognized summary; not independent host observation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Observed {
+    basis: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_type: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    counts: Option<ObservedCounts>,
+}
+
+impl Observed {
+    /// Either `producer_reported` or `not_stated`.
+    pub fn basis(&self) -> &str {
+        self.basis
+    }
+    /// Selected summary type, if any.
+    pub fn source_type(&self) -> Option<&str> {
+        self.source_type
+    }
+    /// Counts read from the selected producer-authored summary.
+    pub fn counts(&self) -> Option<&ObservedCounts> {
+        self.counts.as_ref()
+    }
+}
+
+/// Entry cardinalities asserted by a summary. Missing network means not stated.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ObservedCounts {
+    files: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    network: Option<u64>,
+    processes: u64,
+    sandbox_degradations: u64,
+}
+
+impl ObservedCounts {
+    /// Reported file-entry cardinality.
+    pub fn files(&self) -> u64 {
+        self.files
+    }
+    /// Reported network-entry cardinality, absent for sandbox summaries.
+    pub fn network(&self) -> Option<u64> {
+        self.network
+    }
+    /// Reported program-entry cardinality, not hit counts.
+    pub fn processes(&self) -> u64 {
+        self.processes
+    }
+    /// Reported degradation-vector length.
+    pub fn sandbox_degradations(&self) -> u64 {
+        self.sandbox_degradations
+    }
+}
+
+// One numeric conversion rule for both source families, claimed counts and histogram additions.
+fn count(value: &Value, field: &'static str) -> Result<u64> {
+    value
+        .as_u64()
+        .filter(|n| *n <= MAX_COUNT)
+        .with_context(|| format!("invalid {field}: expected integer in 0..2^53-1"))
+}
+
+#[derive(Default)]
+struct Histogram {
+    counts: BTreeMap<String, u64>,
+    key_bytes: usize,
+}
+
+impl Histogram {
+    fn add(&mut self, key: &str, amount: u64) -> Result<()> {
+        let previous = self.counts.get(key).copied();
+        let next = previous
+            .unwrap_or(0)
+            .checked_add(amount)
+            .context("extent.retained_events_by_type count overflow")?;
+        let next = count(&Value::from(next), "extent.retained_events_by_type")?;
+        if previous.is_none() {
+            if self.counts.len() >= crate::json_strict::MAX_KEYS_PER_OBJECT {
+                bail!("extent.retained_events_by_type key count limit");
+            }
+            let bytes = self
+                .key_bytes
+                .checked_add(key.len())
+                .context("extent.retained_events_by_type key bytes overflow")?;
+            if bytes > MAX_KEY_BYTES {
+                bail!("extent.retained_events_by_type key bytes limit");
+            }
+            // All bounds precede the new-key allocation and insertion.
+            self.counts.insert(key.to_owned(), next);
+            self.key_bytes = bytes;
+        } else {
+            *self.counts.get_mut(key).expect("existing histogram key") = next;
+        }
+        Ok(())
+    }
+}
+
+fn source_counts(payload: &Value, profile: bool) -> Result<ObservedCounts> {
+    let (files, processes, degradations) = if profile {
+        (
+            "files_count",
+            "processes_count",
+            "sandbox_degradation_count",
+        )
+    } else {
+        ("fs_count", "exec_count", "degradation_count")
+    };
+    Ok(ObservedCounts {
+        files: count(&payload[files], "extent.observed.counts.files")?,
+        network: if profile {
+            Some(count(
+                &payload["network_count"],
+                "extent.observed.counts.network",
+            )?)
+        } else {
+            None
+        },
+        processes: count(&payload[processes], "extent.observed.counts.processes")?,
+        sandbox_degradations: count(
+            &payload[degradations],
+            "extent.observed.counts.sandbox_degradations",
+        )?,
+    })
+}
+
+/// Collected only within the existing canonical verification pass.
+#[derive(Default)]
+pub(crate) struct Collector {
+    histogram: Histogram,
+    profile: Option<ObservedCounts>,
+    sandbox: Option<ObservedCounts>,
+}
+
+impl Collector {
+    pub(crate) fn observe(&mut self, event: &EvidenceEvent) -> Result<()> {
+        self.histogram.add(&event.type_, 1)?;
+        let slot = match event.type_.as_str() {
+            PROFILE => &mut self.profile,
+            SANDBOX => &mut self.sandbox,
+            _ => return Ok(()),
+        };
+        if slot.is_some() {
+            bail!("extent.observed repeated recognized summary");
+        }
+        // Even an unselected lower-ranked summary is validated.
+        *slot = Some(source_counts(&event.payload, event.type_ == PROFILE)?);
+        Ok(())
+    }
+
+    pub(crate) fn finish(self) -> EvidenceExtent {
+        let selected = self
+            .profile
+            .map(|counts| (PROFILE, counts))
+            .or_else(|| self.sandbox.map(|counts| (SANDBOX, counts)));
+        let observed = match selected {
+            Some((source_type, counts)) => Observed {
+                basis: "producer_reported",
+                source_type: Some(source_type),
+                counts: Some(counts),
+            },
+            None => Observed {
+                basis: "not_stated",
+                source_type: None,
+                counts: None,
+            },
+        };
+        EvidenceExtent {
+            retained_events_by_type: self.histogram.counts,
+            observed,
+        }
+    }
+}
+
+/// Parse only recognized members; histogram keys remain data, never ignored extensions.
+pub(crate) fn parse(value: &Value) -> Result<EvidenceExtent> {
+    let object = value
+        .as_object()
+        .context("invalid extent: expected object")?;
+    let entries = object
+        .get("retained_events_by_type")
+        .and_then(Value::as_object)
+        .context("invalid extent.retained_events_by_type")?;
+    let mut histogram = Histogram::default();
+    for (key, value) in entries {
+        histogram.add(key, count(value, "extent.retained_events_by_type")?)?;
+    }
+    let observed = object
+        .get("observed")
+        .and_then(Value::as_object)
+        .context("invalid extent.observed")?;
+    let observed = match observed.get("basis").and_then(Value::as_str) {
+        Some("not_stated") => {
+            if observed.contains_key("source_type") || observed.contains_key("counts") {
+                bail!("invalid extent.observed: not_stated contradicts source_type or counts");
+            }
+            Observed {
+                basis: "not_stated",
+                source_type: None,
+                counts: None,
+            }
+        }
+        Some("producer_reported") => {
+            let source_type = match observed.get("source_type").and_then(Value::as_str) {
+                Some(PROFILE) => PROFILE,
+                Some(SANDBOX) => SANDBOX,
+                _ => bail!("invalid extent.observed.source_type"),
+            };
+            let counts = observed
+                .get("counts")
+                .filter(|v| v.is_object())
+                .context("invalid extent.observed.counts")?;
+            if source_type == SANDBOX && counts.get("network").is_some() {
+                bail!("invalid extent.observed.counts.network: sandbox does not state network");
+            }
+            let counts = ObservedCounts {
+                files: count(&counts["files"], "extent.observed.counts.files")?,
+                network: if source_type == PROFILE {
+                    Some(count(&counts["network"], "extent.observed.counts.network")?)
+                } else {
+                    None
+                },
+                processes: count(&counts["processes"], "extent.observed.counts.processes")?,
+                sandbox_degradations: count(
+                    &counts["sandbox_degradations"],
+                    "extent.observed.counts.sandbox_degradations",
+                )?,
+            };
+            Observed {
+                basis: "producer_reported",
+                source_type: Some(source_type),
+                counts: Some(counts),
+            }
+        }
+        _ => bail!("invalid extent.observed.basis"),
+    };
+    Ok(EvidenceExtent {
+        retained_events_by_type: histogram.counts,
+        observed,
+    })
+}
+
+pub(crate) fn check(attested: &EvidenceExtent, derived: &EvidenceExtent) -> Result<()> {
+    // Exhaustive destructures bind the mismatch inventory to the private type layouts.
+    let EvidenceExtent {
+        retained_events_by_type: a,
+        observed: ao,
+    } = attested;
+    let EvidenceExtent {
+        retained_events_by_type: d,
+        observed: do_,
+    } = derived;
+    let Observed {
+        basis: ab,
+        source_type: ast,
+        counts: ac,
+    } = ao;
+    let Observed {
+        basis: db,
+        source_type: dst,
+        counts: dc,
+    } = do_;
+    let mismatch = if a != d {
+        Some("extent.retained_events_by_type")
+    } else if ab != db {
+        Some("extent.observed.basis")
+    } else if ast != dst {
+        Some("extent.observed.source_type")
+    } else {
+        match (ac, dc) {
+            (Some(a), Some(d)) => {
+                let ObservedCounts {
+                    files: af,
+                    network: an,
+                    processes: ap,
+                    sandbox_degradations: ad,
+                } = a;
+                let ObservedCounts {
+                    files: df,
+                    network: dn,
+                    processes: dp,
+                    sandbox_degradations: dd,
+                } = d;
+                if af != df {
+                    Some("extent.observed.counts.files")
+                } else if an != dn {
+                    Some("extent.observed.counts.network")
+                } else if ap != dp {
+                    Some("extent.observed.counts.processes")
+                } else if ad != dd {
+                    Some("extent.observed.counts.sandbox_degradations")
+                } else {
+                    None
+                }
+            }
+            (None, None) => None,
+            _ => Some("extent.observed.counts"),
+        }
+    };
+    if let Some(field) = mismatch {
+        bail!("predicate field `{field}` disagrees with the bundle it is attached to");
+    }
+    Ok(())
+}

--- a/crates/assay-evidence/src/bundle/writer.rs
+++ b/crates/assay-evidence/src/bundle/writer.rs
@@ -254,6 +254,15 @@ pub(crate) fn verify_bundle_verbose_with_limits<R: Read>(
     writer_next::verify::verify_bundle_verbose_with_limits(reader, limits)
 }
 
+/// Internal opt-in projection through the same bounded verification pass.
+pub(crate) fn verify_bundle_verbose_with_extent<R: Read>(
+    reader: R,
+    limits: VerifyLimits,
+    with_extent: bool,
+) -> Result<VerifiedBundle> {
+    writer_next::verify::verify_bundle_verbose_with_extent(reader, limits, with_extent)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/assay-evidence/src/bundle/writer_next/verify.rs
+++ b/crates/assay-evidence/src/bundle/writer_next/verify.rs
@@ -86,6 +86,7 @@ pub(crate) struct VerifiedBundle {
     /// first and a last event. Typed rather than rendered — the values are compared as instants
     /// and formatted once, at the edge that needs a string.
     pub(crate) time_window: (DateTime<Utc>, DateTime<Utc>),
+    pub(crate) extent: Option<crate::attestation::EvidenceExtent>,
 }
 
 /// Verify a bundle's integrity and contract compliance.
@@ -127,6 +128,14 @@ pub(crate) fn verify_bundle_verbose_with_limits<R: Read>(
     reader: R,
     limits: VerifyLimits,
 ) -> Result<VerifiedBundle> {
+    verify_bundle_verbose_with_extent(reader, limits, false)
+}
+
+pub(crate) fn verify_bundle_verbose_with_extent<R: Read>(
+    reader: R,
+    limits: VerifyLimits,
+    with_extent: bool,
+) -> Result<VerifiedBundle> {
     // Snapshot the whole source under the ceiling before parsing anything.
     //
     // Streaming the ceiling into the gzip/tar walker only bounds the prefix those layers choose
@@ -147,11 +156,16 @@ pub(crate) fn verify_bundle_verbose_with_limits<R: Read>(
             .with_context("Bundle source")
     })?;
 
-    verify_bundle_snapshot(&source, limits)
+    verify_bundle_snapshot(&source, limits, with_extent)
 }
 
 /// Verify a bundle from bytes already bounded and materialized by the caller.
-fn verify_bundle_snapshot(source: &[u8], limits: VerifyLimits) -> Result<VerifiedBundle> {
+fn verify_bundle_snapshot(
+    source: &[u8],
+    limits: VerifyLimits,
+    with_extent: bool,
+) -> Result<VerifiedBundle> {
+    let mut extent = with_extent.then(crate::attestation::extent::Collector::default);
     let reader = std::io::Cursor::new(source);
 
     let decoder = GzDecoder::new(reader);
@@ -459,6 +473,9 @@ fn verify_bundle_snapshot(source: &[u8], limits: VerifyLimits) -> Result<Verifie
                     .into());
                 }
                 content_hashes.push(computed_hash);
+                if let Some(collector) = &mut extent {
+                    collector.observe(&event)?;
+                }
 
                 match prev_seq {
                     None => {
@@ -705,5 +722,6 @@ fn verify_bundle_snapshot(source: &[u8], limits: VerifyLimits) -> Result<Verifie
             computed_run_root,
         },
         time_window,
+        extent: extent.map(crate::attestation::extent::Collector::finish),
     })
 }

--- a/crates/assay-evidence/tests/attestation_extent.rs
+++ b/crates/assay-evidence/tests/attestation_extent.rs
@@ -1,0 +1,609 @@
+//! Artifact-backed extent contracts. Synthetic archives assembled independently of BundleWriter.
+use assay_evidence::attestation::{
+    sign_statement, statement_for_bundle, verify_attestation_for_bundle,
+};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use ed25519_dalek::SigningKey;
+use serde_json::json;
+use std::io::Read;
+
+const RAW_LARGE_INTEGER: &str = "H4sIAAAAAAAC/+2V32/aMBDHed5fgfy0asBsx47j/B17mpDQxT9KOnBYHLpWFf/77BSooH3cOm27TyKZ3J3tu0v4eguh9S4Oi7vYhcnvgSZKIcYxcT0yKvjp97M9WWgxmdLJO7CPA/TT6eQ/5YnA5rbr22G9jaR+IgZCF0hN7kyc995UqpJkRtYQ18kY18BlmZ77rhvOzx9NFwwMeRhcGFY5ePppuiTLZViSmxtymJFmH+zGrVp7nlVbx5WAohReWVNwzpqqlFZI4NBI6kF7ywtVKGBUGWkrpbU0kgFTrJLC+ZSGu8/7mW4fUjZsRny7cWMVoyMugs1fdTY0j0P2yKKakR0MuZjLmNmpuHN+BSsFbzj3ttFCcpkSUeA8LUqwnDnKGZiGKZWyF41qGFQlVIwJz0FrpQ05pLp3fWf3xvU5h9s29+z4kacNA2xdzuMhd22e8huS8d71sR3fAF2kK/eu34fnxh0j05pdrj7bL17Er2hpNGu3hdU5DXaYIP8wF/+CP6X/xWv95xz1/530P0Z4PGr3hc7XjGmrjS20bkrTCOCUVcLpkqvC21I2pQJojPOl5VwXmqtKWS0rwYGlYC+SnIyLXwvfaNy1Lak9bKI7Gc5SeSWJF95rfTy6kxa+JZGjLzrTuyFe7hbdd1LTGbEwQBbn8eg4HSWaUsW05lIoQbUukla74UfXfzsF0FHZjYvxZVKyRQi26R5W1t32kFZOiZ69h+e9jo0eHndZ+2G327RmDPx8PIZelVHnImO3702ese9DPRZQXzYp7px56Q0bOzO04wHDKS/nVM+p+kJpPd5fs/eYQl5skXbKHVj4NrRx7Sw5fEBtRBAEQRAEQRAEQRAEQRAEQRAEQRAE+Zv4CY5jM7kAKAAA";
+const ORDINARY_PROFILE: &str = "H4sIAAAAAAAC/+2VwY6bMBCGc+5TRD511SS1DcbAc/RURYrM2GzYJoZis93VKu9em5BUZHtst2o7XyI5zAz2zED+OSrb1Mb5zYNr7eL3QANZmo5r4HZlNOWX32d7sNBksaSLN2BwXvXL5eI/5YWow33bN35/dKR8IaBsa0lJHsCt+xpymQuyInvl9sHo9oqLLFz3beuv1++htaB8XLyxfheDlx+WW7Ld2i25uyOnFakGqw9m1+jrXSUHngDVRUVFlcmshlpBkhYZcAGyEjSjaQ5KSm4qWSgptM4qzrkSVZUZk0BIwzzG86AdbMiGrUjdHMxYxehwG6vjWx0N1bOPHsGTFemUj8XMY1aX4q75QSZpImtZSCkEqMIAp7WsBdBUy8RwVVRMpwXLWZYyXVEpOKPMcIBCKpYDOYW6u77VA5g+5nDfxJ5NL3k40KqjiXk8xa6tQ34+GB9N75rxCdBN+MTe9YM9N26KDHu2NTnbZw/iV7TUwd4c1e6aBjstkH+Y2b/gT+k/S17pP2eo/2+k/86p50m7ZzpfUhGUgSlIM4A0iElW66AbhYC8rrQRJs9FrSqZFTwPwqpB5ZJSHcySihDOgpyMm98K32jsmoaUtTo4czFcpfJGEmfeW32c3EELfyaRo88Z6I1389Oc+UpKuiJaeRXFeRwdl1EShoQ1/lvbf7lY6CjlYJz7ERVsTlldtU87be57FbYKmV29p/PmU2f9cxfFXnXdoYEx8OM0d17lXcaqXDv0EO8YeluOGZfzrrjOwI9msLEVvhknCqc8W9NiTeUnSsvx+zl6pxTiZptwUix5Uze2cXujyekdiiGCIAiCIAiCIAiCIAiCIAiCIAiCIMhfzHc8zA2BACgAAA==";
+
+#[test]
+fn raw_large_integer_archive_is_ordinary_valid() {
+    let bytes = STANDARD.decode(RAW_LARGE_INTEGER).unwrap();
+    let mut archive = tar::Archive::new(flate2::read::GzDecoder::new(bytes.as_slice()));
+    let mut found = false;
+    for entry in archive.entries().unwrap() {
+        let mut entry = entry.unwrap();
+        if entry.path().unwrap().as_ref() == std::path::Path::new("events.ndjson") {
+            let mut raw = String::new();
+            entry.read_to_string(&mut raw).unwrap();
+            assert!(raw.contains("9007199254740993"));
+            let event: serde_json::Value = serde_json::from_str(raw.trim()).unwrap();
+            assert_eq!(
+                event["data"]["files_count"].as_u64(),
+                Some(9007199254740993)
+            );
+            found = true;
+        }
+    }
+    assert!(found, "raw NDJSON member must exist");
+    let result = assay_evidence::bundle::verify_bundle(bytes.as_slice())
+        .expect("independent archive must pass ordinary verification before extent refusal");
+    assert_eq!(result.event_count, 1);
+}
+
+#[test]
+fn signed_false_extent_is_refused_by_existing_consumer() {
+    let bytes = STANDARD.decode(ORDINARY_PROFILE).unwrap();
+    let mut statement = statement_for_bundle(&bytes).expect("ordinary archive accepted");
+    statement.predicate["extent"] = json!({
+        "retained_events_by_type": {"assay.profile.finished": 2},
+        "observed": {"basis": "producer_reported", "source_type": "assay.profile.finished", "counts": {"files": 3, "network": 0, "processes": 0, "sandbox_degradations": 0}}
+    });
+    let key = SigningKey::from_bytes(&[7; 32]);
+    let envelope = sign_statement(&statement, &key).expect("sign deliberately false histogram");
+    let failure = verify_attestation_for_bundle(&envelope, &key.verifying_key(), &bytes)
+        .expect_err("existing canonical consumer must refuse signed false extent");
+    assert!(
+        failure
+            .to_string()
+            .contains("extent.retained_events_by_type"),
+        "named extent comparison: {failure}"
+    );
+}
+
+use assay_evidence::attestation::{
+    statement_for_bundle_with_extent, statement_for_bundle_with_extent_and_limits,
+    verify_attestation_for_bundle_with_extent, verify_envelope_signature,
+};
+use assay_evidence::bundle::VerifyLimits;
+use assay_evidence::types::EvidenceEvent;
+use serde_json::Value;
+
+// Independent raw NDJSON assembly: content hashes use the published algorithm, while event
+// serialization preserves integer tokens instead of passing them through BundleWriter's JCS.
+fn pack(rows: Vec<(&str, Value)>) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+    use std::io::Write;
+    let mut hashes = Vec::new();
+    let mut body = Vec::new();
+    for (seq, (kind, payload)) in rows.into_iter().enumerate() {
+        let mut event = EvidenceEvent::new(
+            kind,
+            "urn:assay:extent-test",
+            "extent-proof",
+            seq as u64,
+            payload,
+        )
+        .with_time("2026-09-07T00:00:00Z".parse().unwrap());
+        let hash = assay_evidence::crypto::id::compute_content_hash(&event).unwrap();
+        event.content_hash = Some(hash.clone());
+        hashes.push(hash);
+        serde_json::to_writer(&mut body, &event).unwrap();
+        body.push(b'\n');
+    }
+    let root = assay_evidence::crypto::id::compute_run_root(&hashes);
+    let manifest = json!({"schema_version":1,"bundle_id":root,"run_id":"extent-proof","run_root":root,"event_count":hashes.len(),"producer":{"name":"extent-test","version":"0.0.0","git":"0000000"},"algorithms":{"canon":"jcs-rfc8785","hash":"sha256","root":"sha256(concat(content_hash + \"\\n\"))"},"files":{"events.ndjson":{"path":"events.ndjson","sha256":format!("sha256:{}",hex::encode(Sha256::digest(&body))),"bytes":body.len()}}});
+    let mut tar = tar::Builder::new(Vec::new());
+    for (name, bytes) in [
+        ("manifest.json", serde_json::to_vec(&manifest).unwrap()),
+        ("events.ndjson", body),
+    ] {
+        let mut header = tar::Header::new_gnu();
+        header.set_path(name).unwrap();
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_mtime(0);
+        header.set_cksum();
+        tar.append(&header, bytes.as_slice()).unwrap();
+    }
+    let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    gz.write_all(&tar.into_inner().unwrap()).unwrap();
+    gz.finish().unwrap()
+}
+fn profile(n: Value) -> Value {
+    json!({"files_count":n,"network_count":2,"processes_count":3,"sandbox_degradation_count":4})
+}
+fn sandbox() -> Value {
+    json!({"fs_count":5,"exec_count":6,"degradation_count":7})
+}
+fn extent(bytes: &[u8]) -> Value {
+    statement_for_bundle_with_extent(bytes).unwrap().predicate["extent"].clone()
+}
+fn signed_check(
+    bytes: &[u8],
+    changed: Value,
+) -> anyhow::Result<assay_evidence::attestation::AttestationVerifiedWithExtent> {
+    let mut statement = statement_for_bundle(bytes).unwrap();
+    statement.predicate["extent"] = changed;
+    let key = SigningKey::from_bytes(&[7; 32]);
+    let envelope = sign_statement(&statement, &key).unwrap();
+    verify_attestation_for_bundle_with_extent(&envelope, &key.verifying_key(), bytes)
+}
+fn refusal(bytes: &[u8], changed: Value, field: &str) {
+    let error = signed_check(bytes, changed).expect_err("signed extent must refuse");
+    assert!(
+        format!("{error:#}").contains(field),
+        "expected {field}, got {error:#}"
+    );
+}
+fn legacy_accepts(bytes: &[u8]) {
+    assay_evidence::bundle::verify_bundle(bytes).expect("ordinary accepted set preserved");
+    let key = SigningKey::from_bytes(&[7; 32]);
+    let statement = statement_for_bundle(bytes).expect("legacy producer accepted");
+    assert!(statement.predicate.get("extent").is_none());
+    let envelope = sign_statement(&statement, &key).unwrap();
+    assert!(
+        verify_attestation_for_bundle_with_extent(&envelope, &key.verifying_key(), bytes)
+            .unwrap()
+            .extent()
+            .is_none()
+    );
+    assert!(signed_check(bytes, Value::Null).unwrap().extent().is_none());
+}
+
+#[test]
+fn every_known_extent_field_is_checked_after_signing() {
+    let bytes = pack(vec![("assay.profile.finished", profile(json!(1)))]);
+    let correct = extent(&bytes);
+    for (pointer, bad, field) in [
+        (
+            "/retained_events_by_type/assay.profile.finished",
+            json!(2),
+            "extent.retained_events_by_type",
+        ),
+        (
+            "/observed/counts/files",
+            json!(9),
+            "extent.observed.counts.files",
+        ),
+        (
+            "/observed/counts/network",
+            json!(9),
+            "extent.observed.counts.network",
+        ),
+        (
+            "/observed/counts/processes",
+            json!(9),
+            "extent.observed.counts.processes",
+        ),
+        (
+            "/observed/counts/sandbox_degradations",
+            json!(9),
+            "extent.observed.counts.sandbox_degradations",
+        ),
+    ] {
+        let mut changed = correct.clone();
+        *changed.pointer_mut(pointer).unwrap() = bad;
+        refusal(&bytes, changed, field);
+    }
+    let mut basis = correct.clone();
+    basis["observed"] = json!({"basis":"not_stated"});
+    refusal(&bytes, basis, "extent.observed.basis");
+    let mut source = correct.clone();
+    source["observed"]["source_type"] = json!("assay.sandbox.summary");
+    source["observed"]["counts"]
+        .as_object_mut()
+        .unwrap()
+        .remove("network");
+    refusal(&bytes, source, "extent.observed.source_type");
+    let mut surplus = correct.clone();
+    surplus["retained_events_by_type"]["unseen-type"] = json!(0);
+    refusal(&bytes, surplus, "extent.retained_events_by_type");
+    let mut missing = correct.clone();
+    missing["retained_events_by_type"] = json!({});
+    refusal(&bytes, missing, "extent.retained_events_by_type");
+    let mut unknown = correct;
+    unknown["future"] = json!(true);
+    unknown["observed"]["future"] = json!(true);
+    unknown["observed"]["counts"]["future"] = json!(true);
+    signed_check(&bytes, unknown).unwrap();
+}
+
+#[test]
+fn tagged_observed_required_shapes_and_presence_are_checked() {
+    let bytes = pack(vec![("assay.profile.finished", profile(json!(1)))]);
+    let correct = extent(&bytes);
+    for changed in [
+        json!({}),
+        json!([]),
+        json!(false),
+        json!({"observed":null}),
+        json!({"retained_events_by_type":null,"observed":{"basis":"not_stated"}}),
+    ] {
+        refusal(&bytes, changed, "extent");
+    }
+    for value in [
+        Value::Null,
+        json!({}),
+        json!({"basis":"unknown"}),
+        json!({"basis":"producer_reported","source_type":"assay.profile.finished","counts":null}),
+        json!({"basis":"not_stated","counts":null}),
+        json!({"basis":"not_stated","source_type":null}),
+    ] {
+        let mut changed = correct.clone();
+        changed["observed"] = value;
+        refusal(&bytes, changed, "extent.observed");
+    }
+    for field in ["files", "network", "processes", "sandbox_degradations"] {
+        let mut changed = correct.clone();
+        changed["observed"]["counts"]
+            .as_object_mut()
+            .unwrap()
+            .remove(field);
+        refusal(&bytes, changed, &format!("extent.observed.counts.{field}"));
+        let mut changed = correct.clone();
+        changed["observed"]["counts"][field] = Value::Null;
+        refusal(&bytes, changed, &format!("extent.observed.counts.{field}"));
+    }
+    legacy_accepts(&bytes);
+}
+
+#[test]
+fn ranked_sources_validate_both_orders_and_omit_sandbox_network() {
+    for rows in [
+        vec![
+            ("assay.profile.finished", profile(json!(1))),
+            ("assay.sandbox.summary", sandbox()),
+        ],
+        vec![
+            ("assay.sandbox.summary", sandbox()),
+            ("assay.profile.finished", profile(json!(1))),
+        ],
+    ] {
+        let bytes = pack(rows);
+        let result = extent(&bytes);
+        assert_eq!(result["observed"]["source_type"], "assay.profile.finished");
+        assert_eq!(result["observed"]["counts"]["files"], 1);
+        signed_check(&bytes, result).unwrap();
+    }
+    let bytes = pack(vec![
+        ("assay.sandbox.summary", sandbox()),
+        ("assay.coding_agent.evidence_pack.v0", json!({})),
+    ]);
+    let result = extent(&bytes);
+    assert_eq!(result["observed"]["source_type"], "assay.sandbox.summary");
+    assert_eq!(
+        result["observed"]["counts"],
+        json!({"files":5,"processes":6,"sandbox_degradations":7})
+    );
+    assert_eq!(
+        result["retained_events_by_type"]["assay.coding_agent.evidence_pack.v0"],
+        1
+    );
+    for extra in [json!(0), Value::Null] {
+        let mut changed = result.clone();
+        changed["observed"]["counts"]["network"] = extra;
+        refusal(&bytes, changed, "extent.observed.counts.network");
+    }
+    assert!(!serde_json::to_string(&result).unwrap().contains("null"));
+    let unknown = pack(vec![("arbitrary.event", json!({"files_count":9000}))]);
+    assert_eq!(
+        extent(&unknown),
+        json!({"retained_events_by_type":{"arbitrary.event":1},"observed":{"basis":"not_stated"}})
+    );
+}
+
+#[test]
+fn repeated_and_malformed_unselected_summaries_refuse_only_extent_mode() {
+    for kind in ["assay.profile.finished", "assay.sandbox.summary"] {
+        let payload = if kind == "assay.profile.finished" {
+            profile(json!(1))
+        } else {
+            sandbox()
+        };
+        for second in [payload.clone(), json!({})] {
+            let bytes = pack(vec![(kind, payload.clone()), (kind, second)]);
+            legacy_accepts(&bytes);
+            let error = statement_for_bundle_with_extent(&bytes).unwrap_err();
+            assert!(format!("{error:#}").contains("repeated recognized summary"));
+            refusal(
+                &bytes,
+                json!({"retained_events_by_type":{kind:2},"observed":{"basis":"not_stated"}}),
+                "repeated recognized summary",
+            );
+        }
+    }
+    for rows in [
+        vec![
+            ("assay.profile.finished", profile(json!(1))),
+            ("assay.sandbox.summary", json!({})),
+        ],
+        vec![
+            ("assay.sandbox.summary", json!({})),
+            ("assay.profile.finished", profile(json!(1))),
+        ],
+    ] {
+        let bytes = pack(rows);
+        legacy_accepts(&bytes);
+        let error = statement_for_bundle_with_extent(&bytes).unwrap_err();
+        assert!(format!("{error:#}").contains("extent.observed.counts.files"));
+    }
+}
+
+#[test]
+fn counts_preserve_exact_signed_max_and_refuse_out_of_domain_raw_inputs() {
+    for value in [0, 9_007_199_254_740_991u64] {
+        let bytes = pack(vec![("assay.profile.finished", profile(json!(value)))]);
+        let statement = statement_for_bundle_with_extent(&bytes).unwrap();
+        let key = SigningKey::from_bytes(&[7; 32]);
+        let envelope = sign_statement(&statement, &key).unwrap();
+        let actual: Value =
+            serde_json::from_slice(&STANDARD.decode(&envelope.payload).unwrap()).unwrap();
+        assert_eq!(
+            actual["predicate"]["extent"]["observed"]["counts"]["files"].as_u64(),
+            Some(value)
+        );
+        verify_envelope_signature(&envelope, &key.verifying_key()).unwrap();
+        verify_attestation_for_bundle_with_extent(&envelope, &key.verifying_key(), &bytes).unwrap();
+    }
+    for bad in [
+        json!(9_007_199_254_740_992u64),
+        json!(9_007_199_254_740_993u64),
+        json!(-1),
+        json!(0.5),
+        json!("1"),
+        Value::Null,
+    ] {
+        let bytes = pack(vec![("assay.profile.finished", profile(bad))]);
+        legacy_accepts(&bytes);
+        let error = statement_for_bundle_with_extent(&bytes).unwrap_err();
+        assert!(format!("{error:#}").contains("extent.observed.counts.files"));
+    }
+    let bytes = STANDARD.decode(RAW_LARGE_INTEGER).unwrap();
+    legacy_accepts(&bytes);
+    let error = statement_for_bundle_with_extent(&bytes).unwrap_err();
+    assert!(format!("{error:#}").contains("extent.observed.counts.files"));
+}
+
+#[test]
+fn retained_detail_changes_histogram_without_upgrading_reported_counts() {
+    let summary = pack(vec![("assay.profile.finished", profile(json!(7)))]);
+    let detailed = pack(vec![
+        ("assay.profile.finished", profile(json!(7))),
+        ("assay.fs.access", json!({"hits":999})),
+    ]);
+    let nothing = pack(vec![("assay.profile.finished", profile(json!(0)))]);
+    let a = extent(&summary);
+    let b = extent(&detailed);
+    let c = extent(&nothing);
+    assert_eq!(a["observed"], b["observed"]);
+    assert_ne!(a["retained_events_by_type"], b["retained_events_by_type"]);
+    assert_ne!(a, c);
+    assert_eq!(b["observed"]["counts"]["files"], 7);
+    assert_eq!(b["observed"]["counts"]["processes"], 3);
+}
+
+#[test]
+fn histogram_cardinality_max_and_max_plus_one_are_bounded() {
+    let max = assay_evidence::json_strict::MAX_KEYS_PER_OBJECT;
+    for n in [max, max + 1] {
+        let keys: Vec<_> = (0..n).map(|i| format!("type.{i:05}")).collect();
+        let bytes = pack(keys.iter().map(|s| (s.as_str(), json!({}))).collect());
+        legacy_accepts(&bytes);
+        let result = statement_for_bundle_with_extent(&bytes);
+        if n == max {
+            let statement = result.unwrap();
+            assert_eq!(
+                statement.predicate["extent"]["retained_events_by_type"]
+                    .as_object()
+                    .unwrap()
+                    .len(),
+                max
+            );
+            let key = SigningKey::from_bytes(&[7; 32]);
+            let env = sign_statement(&statement, &key).unwrap();
+            verify_attestation_for_bundle_with_extent(&env, &key.verifying_key(), &bytes).unwrap();
+        } else {
+            assert!(format!("{:#}", result.unwrap_err()).contains("key count limit"));
+        }
+    }
+}
+
+#[test]
+fn histogram_utf8_bytes_max_and_max_plus_one_are_bounded() {
+    for extra in [false, true] {
+        let keys: Vec<_> = (0..1024)
+            .map(|i| {
+                format!(
+                    "{i:04}{}{}",
+                    "é".repeat(510),
+                    if extra && i == 0 { "x" } else { "" }
+                )
+            })
+            .collect();
+        assert_eq!(
+            keys.iter().map(String::len).sum::<usize>(),
+            1024 * 1024 + usize::from(extra)
+        );
+        let bytes = pack(keys.iter().map(|s| (s.as_str(), json!({}))).collect());
+        legacy_accepts(&bytes);
+        let result = statement_for_bundle_with_extent(&bytes);
+        if extra {
+            assert!(format!("{:#}", result.unwrap_err()).contains("key bytes limit"));
+        } else {
+            let statement = result.unwrap();
+            let key = SigningKey::from_bytes(&[7; 32]);
+            let env = sign_statement(&statement, &key).unwrap();
+            verify_attestation_for_bundle_with_extent(&env, &key.verifying_key(), &bytes).unwrap();
+        }
+    }
+}
+
+#[test]
+fn extent_producer_keeps_bundle_limit_before_archive_work() {
+    let bytes = STANDARD.decode(ORDINARY_PROFILE).unwrap();
+    let limits = VerifyLimits {
+        max_bundle_bytes: bytes.len() as u64 - 1,
+        ..VerifyLimits::default()
+    };
+    assert!(statement_for_bundle_with_extent_and_limits(&bytes, limits).is_err());
+}
+
+#[test]
+fn existing_public_struct_literals_and_destructures_remain_usable() {
+    use assay_evidence::attestation::{AttestationVerified, EvidenceBundlePredicate};
+    use assay_evidence::bundle::VerifyResult;
+    let bytes = STANDARD.decode(ORDINARY_PROFILE).unwrap();
+    let VerifyResult {
+        manifest,
+        event_count,
+        computed_run_root,
+    } = assay_evidence::bundle::verify_bundle(bytes.as_slice()).unwrap();
+    let rebuilt = VerifyResult {
+        manifest,
+        event_count,
+        computed_run_root,
+    };
+    assert_eq!(rebuilt.event_count, 1);
+    let key = SigningKey::from_bytes(&[7; 32]);
+    let envelope = sign_statement(&statement_for_bundle(&bytes).unwrap(), &key).unwrap();
+    let AttestationVerified {
+        statement,
+        predicate,
+        artifact_sha256,
+    } = verify_attestation_for_bundle(&envelope, &key.verifying_key(), &bytes).unwrap();
+    let EvidenceBundlePredicate {
+        schema_version,
+        semantic_equivalence,
+        run,
+    } = predicate;
+    let rebuilt = AttestationVerified {
+        statement,
+        predicate: EvidenceBundlePredicate {
+            schema_version,
+            semantic_equivalence,
+            run,
+        },
+        artifact_sha256,
+    };
+    assert_eq!(rebuilt.predicate.schema_version, 1);
+    let VerifyLimits {
+        max_bundle_bytes,
+        max_decode_bytes,
+        max_manifest_bytes,
+        max_events_bytes,
+        max_events,
+        max_line_bytes,
+        max_path_len,
+        max_json_depth,
+    } = VerifyLimits::default();
+    let rebuilt = VerifyLimits {
+        max_bundle_bytes,
+        max_decode_bytes,
+        max_manifest_bytes,
+        max_events_bytes,
+        max_events,
+        max_line_bytes,
+        max_path_len,
+        max_json_depth,
+    };
+    assert_eq!(rebuilt, VerifyLimits::default());
+}
+
+#[test]
+fn both_summary_families_validate_every_count_before_signing() {
+    for (kind, fields, initial) in [
+        (
+            "assay.profile.finished",
+            vec![
+                "files_count",
+                "network_count",
+                "processes_count",
+                "sandbox_degradation_count",
+            ],
+            profile(json!(1)),
+        ),
+        (
+            "assay.sandbox.summary",
+            vec!["fs_count", "exec_count", "degradation_count"],
+            sandbox(),
+        ),
+    ] {
+        for field in fields {
+            let projected = match field {
+                "files_count" | "fs_count" => "files",
+                "network_count" => "network",
+                "processes_count" | "exec_count" => "processes",
+                "sandbox_degradation_count" | "degradation_count" => "sandbox_degradations",
+                _ => unreachable!(),
+            };
+            for accepted in [0, 9_007_199_254_740_991u64] {
+                let mut payload = initial.clone();
+                payload[field] = json!(accepted);
+                let bytes = pack(vec![(kind, payload)]);
+                let statement = statement_for_bundle_with_extent(&bytes).unwrap();
+                let key = SigningKey::from_bytes(&[7; 32]);
+                let env = sign_statement(&statement, &key).unwrap();
+                let actual: Value =
+                    serde_json::from_slice(&STANDARD.decode(&env.payload).unwrap()).unwrap();
+                assert_eq!(
+                    actual["predicate"]["extent"]["observed"]["counts"][projected].as_u64(),
+                    Some(accepted)
+                );
+                verify_attestation_for_bundle_with_extent(&env, &key.verifying_key(), &bytes)
+                    .unwrap();
+            }
+            for bad in [
+                Value::Null,
+                json!("1"),
+                json!(-1),
+                json!(0.5),
+                json!(9_007_199_254_740_992u64),
+                json!(9_007_199_254_740_993u64),
+            ] {
+                let mut payload = initial.clone();
+                payload[field] = bad;
+                let bytes = pack(vec![(kind, payload)]);
+                legacy_accepts(&bytes);
+                let err = statement_for_bundle_with_extent(&bytes).unwrap_err();
+                assert!(format!("{err:#}").contains("expected integer in 0..2^53-1"));
+            }
+            let mut missing = initial.clone();
+            missing.as_object_mut().unwrap().remove(field);
+            let bytes = pack(vec![(kind, missing)]);
+            assert!(statement_for_bundle_with_extent(&bytes).is_err());
+        }
+    }
+    let bytes = STANDARD.decode(ORDINARY_PROFILE).unwrap();
+    let correct = extent(&bytes);
+    for bad in [
+        Value::Null,
+        json!("1"),
+        json!(-1),
+        json!(0.5),
+        json!(9_007_199_254_740_992u64),
+    ] {
+        let mut changed = correct.clone();
+        changed["retained_events_by_type"]["assay.profile.finished"] = bad;
+        refusal(&bytes, changed, "extent.retained_events_by_type");
+    }
+}
+
+#[test]
+fn identical_old_reader_signed_bytes_are_checked_by_new_reader() {
+    use sha2::{Digest, Sha256};
+    // Exact DSSE bytes retained from the frozen d270 old-reader acceptance control.
+    // They are not re-signed or regenerated here. The key is the declared synthetic fixture key.
+    let envelope_bytes=STANDARD.decode("eyJwYXlsb2FkIjoiZXlKZmRIbHdaU0k2SW1oMGRIQnpPaTh2YVc0dGRHOTBieTVwYnk5VGRHRjBaVzFsYm5RdmRqRWlMQ0p3Y21Wa2FXTmhkR1VpT25zaVpYaDBaVzUwSWpwN0ltOWljMlZ5ZG1Wa0lqcDdJbUpoYzJseklqb2ljSEp2WkhWalpYSmZjbVZ3YjNKMFpXUWlMQ0pqYjNWdWRITWlPbnNpWm1sc1pYTWlPak1zSW01bGRIZHZjbXNpT2pBc0luQnliMk5sYzNObGN5STZNQ3dpYzJGdVpHSnZlRjlrWldkeVlXUmhkR2x2Ym5NaU9qQjlMQ0p6YjNWeVkyVmZkSGx3WlNJNkltRnpjMkY1TG5CeWIyWnBiR1V1Wm1sdWFYTm9aV1FpZlN3aWNtVjBZV2x1WldSZlpYWmxiblJ6WDJKNVgzUjVjR1VpT25zaVlYTnpZWGt1Y0hKdlptbHNaUzVtYVc1cGMyaGxaQ0k2TW4xOUxDSnlkVzRpT25zaVpYWmxiblJmWTI5MWJuUWlPakVzSW5CeWIyUjFZMlZ5SWpwN0ltZHBkQ0k2SWpBd01EQXdNREFpTENKdVlXMWxJam9pWlhoMFpXNTBMWFJsYzNRaUxDSjJaWEp6YVc5dUlqb2lNQzR3TGpBaWZTd2ljblZ1WDJsa0lqb2laWGgwWlc1MExYQnliMjltSWl3aWRHbHRaVjkzYVc1a2IzY2lPbnNpWlc1a0lqb2lNakF5Tmkwd09TMHdOMVF3TURvd01Eb3dNRm9pTENKemRHRnlkQ0k2SWpJd01qWXRNRGt0TURkVU1EQTZNREE2TURCYUluMTlMQ0p6WTJobGJXRmZkbVZ5YzJsdmJpSTZNU3dpYzJWdFlXNTBhV05mWlhGMWFYWmhiR1Z1WTJVaU9uc2lZV3huYjNKcGRHaHRJam9pWVhOellYa3RjblZ1TFhKdmIzUXRkakVpTENKMllXeDFaU0k2SW5Ob1lUSTFOam95WXpJell6QmtPV0l3TldJMk56Wm1ZMlpoWXpNME9UWmpNalZqTjJJMU1EWXdORGhqWVRjM01tVmlOemxoTnpWa1pEWmlNakl5WVRWaVlqWmxaVE5qSW4xOUxDSndjbVZrYVdOaGRHVlVlWEJsSWpvaWFIUjBjSE02THk5a2IyTnpMbWRsZEdGemMyRjVMbVJsZGk5aGRIUmxjM1JoZEdsdmJpOWxkbWxrWlc1alpTMWlkVzVrYkdVdmRqRWlMQ0p6ZFdKcVpXTjBJanBiZXlKa2FXZGxjM1FpT25zaWMyaGhNalUySWpvaVpUWXlNMlJtWkdaaE5UY3laV0ZrTnprNU4yVTJOR1l6TXpWaU56UTBNekpoTnpZNE1qUmxOMlEyTlRVM09URm1aV1JsWWpWaE5HUmtOalk1TVdJMllpSjlMQ0p1WVcxbElqb2ljMmhoTWpVMk9qSmpNak5qTUdRNVlqQTFZalkzTm1aalptRmpNelE1Tm1NeU5XTTNZalV3TmpBME9HTmhOemN5WldJM09XRTNOV1JrTm1JeU1qSmhOV0ppTm1WbE0yTWlmVjE5IiwicGF5bG9hZFR5cGUiOiJhcHBsaWNhdGlvbi92bmQuaW4tdG90bytqc29uIiwic2lnbmF0dXJlcyI6W3sia2V5aWQiOiJzaGEyNTY6MzI0YmUyZGVhOGJjNDQ0NjFiMDIzM2U1MWZhNDg5MDJlZDZiMWNjNjcxZTc3MzlhZjI1NTFlMGJmZTY4ZjU0ZSIsInNpZyI6InhIS1dVUHdNd2YrRStYMUdrMnFuSW1mS0M2S3lkTW0rSVpUV3dpMElycWVycm5kM2lRWGtMMExqRjI4cWRvenRrYmxJY3NrZ25LZjVQSThDUkNoVERnPT0ifV19").unwrap();
+    assert_eq!(
+        hex::encode(Sha256::digest(&envelope_bytes)),
+        "d70c4ac82c15e9b4eb4c67e6f758509a1a160f359520c1a62cafdf0923faa761"
+    );
+
+    let envelope: assay_evidence::attestation::DsseEnvelope =
+        serde_json::from_slice(&envelope_bytes).unwrap();
+    let key = SigningKey::from_bytes(&[7; 32]);
+    verify_envelope_signature(&envelope, &key.verifying_key())
+        .expect("same old-reader witness has valid signature");
+    let bytes = STANDARD.decode(ORDINARY_PROFILE).unwrap();
+    let error = verify_attestation_for_bundle(&envelope, &key.verifying_key(), &bytes)
+        .expect_err("new reader checks the same extent old reader ignored");
+    assert!(
+        error.to_string().contains("extent.retained_events_by_type"),
+        "{error}"
+    );
+}

--- a/docs/attestation/evidence-bundle/v1.md
+++ b/docs/attestation/evidence-bundle/v1.md
@@ -1,7 +1,7 @@
 # Predicate type: Assay evidence bundle
 
 - Type URI: `https://docs.getassay.dev/attestation/evidence-bundle/v1`
-- Version: 1.0
+- Version: 1.1
 - Predicate name: Assay evidence bundle
 
 ## Purpose
@@ -65,12 +65,12 @@ itself authenticate the producer metadata asserted in a run as an external ident
 
 The statement has `_type`, `subject`, `predicateType`, and `predicate`. The predicate has three
 required members: `schema_version`, `semantic_equivalence`, and `run`. All nested fields listed
-below are required too.
+below are required too, except the explicitly optional extent projection and its source-dependent fields.
 
 ### Parsing Rules
 
 1. `_type` must equal `https://in-toto.io/Statement/v1`. `predicateType` must equal the Type URI
-   above. `predicate.schema_version` must be the integer `1`. The document version `1.0` is not a
+   above. `predicate.schema_version` must be the integer `1`. The document version `1.1` is not a
    separate statement field. An unrecognized predicate major version is refused, never reported
    as verified.
 2. Unknown fields within the known predicate major version are ignored. This does not mean their
@@ -91,6 +91,38 @@ below are required too.
    metadata from the verified manifest, and derives the time window from the events. A field
    mismatch is a refusal, not a warning. A zero-event bundle is refused, so the time window has no
    null case.
+
+7. Optional `predicate.extent` is absent or null for **not stated**, preserving legacy verification.
+   A present non-null value must be an object with `retained_events_by_type` and a tagged `observed`
+   object. New extent producers emit an object and no null within it. Missing or malformed required
+   structures refuse. Unknown structured members remain ignored; every histogram key is data and
+   participates in exact comparison, including surplus or zero-valued entries.
+8. `observed.basis` is either `not_stated` (no known `source_type` or `counts` member may be present)
+   or `producer_reported` (both are required). A producer-reported source names one of the two
+   summary types below. All its required counts must exist. Sandbox `network` is omitted and an
+   attested sandbox network member refuses, including null. Missing/unknown basis refuses.
+9. Recognize exactly `assay.profile.finished` before `assay.sandbox.summary`, independent of event
+   order. Validate both when present, including the unselected lower-ranked source. Refuse repeated
+   instances of either recognized type, even if identical. No recognized summary produces
+   `observed: {"basis":"not_stated"}`. `assay.coding_agent.evidence_pack.v0` contributes only to
+   the retained histogram. Malformed/repeated summary refusals apply only when deriving extent or
+   checking present non-null extent; ordinary and absent/null-extent verification retain their
+   acceptance rules.
+10. Every extent count is an integer in `0..9007199254740991` (`0..2^53-1`). This representation
+    ceiling prevents loss through JCS number normalization; it is not host-resource policy.
+    Histogram cardinality uses the strict parser's `MAX_KEYS_PER_OBJECT` (currently 10,000), and
+    aggregate decoded UTF-8 key bytes are limited to 1 MiB. Checked arithmetic and both key bounds
+    apply before new-key allocation/insertion. The producer checks its actual canonical Statement
+    bytes against the consumer's strict parser; legacy metadata strings still contribute to size.
+
+The extent claim boundary is specification prose, not a signed `support_ceiling` field. Retained
+counts are recomputed from artifact events. Observed counts are producer assertions read from
+verified payloads; matching them does not independently establish their truth, activity of one
+run, observation completeness, or an export option. Profile counts are aggregated entry
+cardinalities and degradation-vector length, not total runs, hit totals, or independent observations.
+An older reader can accept a signed extent while ignoring it: that is verification of its known
+fields only. Admission requiring checked extent needs an extent-checking reader and a present
+non-null checked extent. Absent, null or ignored extent is not an affirmative claim.
 
 These rules describe verification of the artifact and its declared metadata. They do not prove
 observation completeness, policy correctness, safe execution, or an external action's outcome.
@@ -140,12 +172,31 @@ change the root. Merely choosing a different export detail option does not guara
 root when the retained inputs are unchanged. The root does not identify every possible export of
 a run, and equal roots do not assert that all event metadata or archive bytes are equal.
 
+### Optional extent fields (revision 1.1)
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `predicate.extent.retained_events_by_type` | sorted object of counts | Exact types and counts of all retained events; only encountered types are emitted. |
+| `predicate.extent.observed.basis` | string | `producer_reported` or `not_stated`. |
+| `predicate.extent.observed.source_type` | string, required for producer_reported | Selected recognized summary type; absent for not_stated. |
+| `predicate.extent.observed.counts` | object, required for producer_reported | Source-dependent entry counts; absent for not_stated. |
+
+| Summary type | `files` | `network` | `processes` | `sandbox_degradations` |
+| --- | --- | --- | --- | --- |
+| `assay.profile.finished` | `files_count` | `network_count` | `processes_count` | `sandbox_degradation_count` |
+| `assay.sandbox.summary` | `fs_count` | omitted: not stated | `exec_count` | `degradation_count` |
+
+All mapped source fields are required exact-domain integers. Selection rank is deterministic,
+not a ranking of trust. Program-entry counts remain entry counts, not sums of per-program hits.
+Derivation reads generic verified event payloads and does not substitute the older typed profile
+summary decoder. A mismatch names a static field path without echoing supplied values.
+
 ## Example
 
 This complete in-toto Statement is technically illustrative JSON, **not real evidence**. Its
 identifiers and digest values are invented; no archive or signature is supplied, and it is not a
 verification fixture. A real producer must derive these values from the same verified archive.
-This is the statement carried inside a DSSE envelope, not the envelope itself.
+This is the statement carried inside a DSSE envelope, not the envelope itself. It illustrates the still-supported v1.0 producer shape, with extent absent.
 
 ```json
 {
@@ -197,6 +248,12 @@ names v0, and `statement_from_manifest` still constructs v0 statements. The v1 p
 is `statement_for_bundle` (or its `_with_limits` variant). These API names do not alter the wire
 version rules above.
 
-[ADR-049](../../architecture/ADR-049-attestation-extent.md) records an accepted optional-extension
-decision whose implementation is pending. It does not change the v1.0 fields or current parsing
-rules documented on this page.
+Version 1.1 implements the optional extension decided in
+[ADR-049](../../architecture/ADR-049-attestation-extent.md) without changing the Type URI, schema
+major, legacy fields, or existing public Rust struct layouts. `statement_for_bundle_with_extent`
+and `statement_for_bundle_with_extent_and_limits` explicitly opt producers in; legacy producers
+continue emitting v1.0. `verify_attestation_for_bundle_with_extent` and its
+`_with_extent_and_limits` variant expose optional checked extent alongside the original result.
+Existing artifact-verification APIs check present extent too, discarding only the additive result
+projection. All use the same canonical verification pass. Signature-only verification remains
+artifact-unmatched. This library change does not opt the CLI producer in or change CLI presentation.


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: no active programme; standalone issue #2833.
- Slice: optional artifact-derived attestation extent, implementing accepted ADR-049.
- Builder: `codex/corpus102_final_review`; coordination and governing decision by Codex/root.
- Reviewers: Antigravity independently reviewed the final head and returned READY; the corrected publication carrier is validated. The builder's checks do not count toward quorum; any relay account is separately identified as publisher.
- Final head SHA: `58deebcac1b76a4940b8e9f51441deddbecbfc3e`.
- Base: `14053b6584ab5fdbdac21a159a02fb2ecd59ab7a`; branch `codex/2833-attestation-extent`, worktree `wt-codex-2833-attestation-extent`.
- ADR invariants affected: ADR-042/043 claim boundaries and canonical evidence verification; ADR-049 extent derivation, resource limits and compatibility.

## Behavior

A valid signature can cover incorrect extent claims. Artifact verification now rejects present, non-null extent when its retained-event histogram or recognized summary counts disagree with the verified archive. Additive library APIs let producers opt into extent and let consumers obtain its checked projection. Existing artifact-verification APIs perform the same extent check, while legacy producers and existing public Rust struct layouts remain unchanged.

One optional collector runs within the canonical verified-event pass. Profile summaries rank before sandbox summaries regardless of order; both are validated, repeated recognized summaries refuse extent derivation, and sandbox network counts remain unstated. Counts use the exact integer domain `0..2^53-1`; histogram key count and decoded UTF-8 bytes are bounded before new-key allocation. Absent/null extent retains legacy semantics. The specification describes these boundaries without upgrading producer-reported counts into independently observed host facts.

This changes exactly seven files: the attestation module and new extent module, two canonical bundle-verifier integration files, one integration-test file, the predicate specification and changelog. The normal merge from main preserves the separate MCP typed-error changelog entry.

Closes #2833. CLI producer opt-in and extent presentation remain separate #2834 work.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim
- Producer-reported counts do not establish observation completeness, producer identity or independently observed activity. Missing, null or ignored extent is not affirmative evidence.
- No CLI extent-output or CLI producer-opt-in claim. Existing canonical consumers enforce present extent through the library change.
- Local checks are not hosted CI, deployment or live host proof. Review publication and reviewer authentication are separate from review content.

## Test Evidence

### RED

Before production edits, the test overlay on base `658ab4152d82c986e3838d4e46369454874fa39c` confirmed that an independently assembled archive containing raw integer `9007199254740993` passes ordinary bundle verification. The signed false-extent test then failed at its expected refusal assertion because the existing canonical consumer accepted the signed mismatch. These are historical source-hash-bound measurements, not runs attributed to the final commit.

Eight historical mutations each reached the named behavioral assertion: remove extent comparison, zero histogram counts, zero observed counts, admit repeated summaries, reverse source ranking, remove the count ceiling, remove the key-count bound, and remove the key-byte bound. The no-op control passed all 14 tests. Literal patches, before/after source, raw logs and exact restoration hashes are retained. The key-count mutation tests the early capacity refusal; a later strict-payload refusal is not described as unsafe acceptance. These mutations were not rerun at the final SHA.

The old-reader control used the full source tree at `d270c9e96c2a0d8894f257f9c4b41de8fa93d9d3`, with only its bounded test overlay. It accepted a signed false extent. The new-reader test checks the exact same 1,431 envelope bytes (SHA256 `d70c4ac82c15e9b4eb4c67e6f758509a1a160f359520c1a62cafdf0923faa761`), confirms the signature independently, and requires the canonical consumer's histogram-mismatch refusal. It does not regenerate or re-sign an equivalent envelope.

### GREEN

The following were measured on committed head `58deebcac1b76a4940b8e9f51441deddbecbfc3e` in the named worktree, using Rust/Cargo 1.96.0 on aarch64-apple-darwin, offline dependency access, one build job and that worktree's own target:

| Command | Observed result |
| --- | --- |
| `cargo test --locked -p assay-evidence --test attestation_extent` | 14 passed, 0 failed, 0 ignored |
| `cargo test --locked -p assay-evidence` | 705 passed, 0 failed, 4 explicitly ignored generator tests; includes the focused tests |
| `cargo clippy --locked -p assay-evidence --all-targets -- -D warnings` | Exit 0 |
| `cargo semver-checks check-release -p assay-evidence --baseline-rev 14053b6584ab5fdbdac21a159a02fb2ecd59ab7a` | Tool 0.50.0: 223 checks passed, 31 skipped, exit 0; current-main baseline, not the hosted release-tag baseline |
| `cargo fmt --all -- --check` | Exit 0 |

The four ignored tests are `generate_test_bundle_fixture`, `write_mcp_lint_demo_bundles`, `generate_test_bundle` and `generate_seed_corpus`; they are not counted as passes. Every executed final check ended without a guard stop. Source hashes, toolchain, exact commands and raw-log hashes are retained in the final evidence manifest.

The strict local documentation build also passed and its generated route contains the extent rules. That build is bound to the unchanged specification file hash and predates the final commit; it is not a deployment claim. Diff whitespace checks and normal commit hooks passed. Hosted integration checks remain pending publication.

## Review Quorum

- [x] One non-building agent review on the final head
- [x] Every actionable finding is fixed or has a technical disposition
- [ ] Any delegated proof targets this exact head SHA

Antigravity reviewed the final source and retained execution evidence. Its READY verdict is bound to 58deebcac1b76a4940b8e9f51441deddbecbfc3e; it did not independently execute the writer tests. Historical production/test files match the final code; CHANGELOG differs, so no historical whole-tree equivalence is claimed. Publisher/relay identity must remain distinct from the actual reviewer. Optional automated reviews can add evidence, but do not count toward or block quorum.
