### PR TITLE
fix(mcp): require successful tools/list pages for complete catalogues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ All notable changes to this project will be documented in this file.
   producer or establish evidence completeness.
 
 ### Fixed
+- Failed or malformed `tools/list` pages no longer contribute tools or establish a complete
+  observed proxy catalogue (#2840). Admission requires an absent error member, an array-valued
+  tools result and an absent or string cursor. Successful empty catalogues remain complete;
+  a failed refresh preserves the earlier complete snapshot and records the incomplete refresh.
 - `assay-mcp-server` reports a pre-parse message-size refusal as JSON-RPC error
   `-32000`, with a null request id and `data.kind: transport_limit`, rather than a
   tool result. The session remains available for subsequent requests (#2779).

--- a/crates/assay-mcp-server/src/proxy/observer.rs
+++ b/crates/assay-mcp-server/src/proxy/observer.rs
@@ -115,13 +115,19 @@ impl Observer {
         if !self.list_req_ids.contains_key(&id) {
             return false;
         }
-        if let Some(tools) = v.pointer("/result/tools").and_then(|t| t.as_array()) {
-            self.acc.extend(tools.iter().cloned());
-        }
-        let has_next = v
-            .pointer("/result/nextCursor")
-            .map(|c| !c.is_null())
-            .unwrap_or(false);
+        // Only a successful, well-shaped page can contribute tools or complete a chain.
+        // Presence of error (including null) rejects mixed result/error responses.
+        let tools = match v.pointer("/result/tools").and_then(Value::as_array) {
+            Some(tools)
+                if v.get("error").is_none()
+                    && v.pointer("/result/nextCursor").is_none_or(Value::is_string) =>
+            {
+                tools
+            }
+            _ => return false,
+        };
+        self.acc.extend(tools.iter().cloned());
+        let has_next = v.pointer("/result/nextCursor").is_some();
         if has_next {
             self.outstanding_cursor = true;
             return false;

--- a/crates/assay-mcp-server/tests/proxy_manifest_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_manifest_e2e.rs
@@ -295,3 +295,253 @@ fn artifact_write_failure_exits_nonzero() {
     );
     assert!(!manifest.exists());
 }
+
+// #2840: finite scripted responses drive the real proxy observer and artifact writer.
+fn spawn_list_responses(pages: &[Value], manifest: &Path, health: &Path) -> Conn {
+    let script = r#"
+import json, os, sys
+pages = iter(json.loads(os.environ['ASSAY_TEST_LIST_RESPONSES']))
+for line in sys.stdin:
+    request = json.loads(line)
+    if request.get('method') == 'initialize':
+        response = {'result': {'protocolVersion': request['params']['protocolVersion'],
+                    'capabilities': {}, 'serverInfo': {'name': 'scripted', 'version': '1'}}}
+    elif request.get('method') == 'tools/list':
+        response = next(pages)
+    else:
+        continue
+    response.update({'jsonrpc': '2.0', 'id': request['id']})
+    print(json.dumps(response), flush=True)
+"#;
+    let child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .arg("proxy")
+        .args(["--upstream-command", python()])
+        .args(["--upstream-arg", "-u", "--upstream-arg", "-c"])
+        .args(["--upstream-arg", script])
+        .args(["--mcp-manifest-observed-out", manifest.to_str().unwrap()])
+        .args(["--proxy-observation-health-out", health.to_str().unwrap()])
+        .env(
+            "ASSAY_TEST_LIST_RESPONSES",
+            serde_json::to_string(pages).unwrap(),
+        )
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn proxy with finite scripted upstream");
+    Conn::attach(child)
+}
+
+fn list_response(p: &mut Conn, id: u64, cursor: Option<&str>) -> Value {
+    let params = cursor.map_or_else(
+        || serde_json::json!({}),
+        |c| serde_json::json!({"cursor": c}),
+    );
+    p.request("tools/list", params, id)
+}
+
+fn scripted_tool() -> Value {
+    serde_json::json!({"name": "retained", "description": "test", "inputSchema": {"type": "object"}})
+}
+
+#[test]
+fn tools_list_error_cannot_emit_complete_catalogue() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("manifest.json");
+    let health = dir.path().join("health.json");
+    let error = serde_json::json!({"error": {"code": -32603, "message": "request failed"}});
+    let mut p = spawn_list_responses(std::slice::from_ref(&error), &manifest, &health);
+    handshake(&mut p);
+    let response = list_response(&mut p, 2, None);
+    let midrun_exists = manifest.try_exists();
+    let exit = p.shutdown();
+    assert!(exit.success());
+    assert_eq!(response["error"], error["error"]);
+    assert!(
+        !midrun_exists.expect("inspect mid-run artifact"),
+        "failed tools/list must not emit a complete manifest mid-run"
+    );
+    let m = read_artifact(&manifest);
+    assert_eq!(m["observed"]["tools_list_complete"], "partial");
+    assert_eq!(m["observed"]["tool_count"], 0);
+    assert_eq!(
+        read_artifact(&health)["manifest_observation"]["emitted_state_source"],
+        "best_partial"
+    );
+}
+
+#[test]
+fn tools_list_malformed_page_cannot_emit_complete_catalogue() {
+    let malformed = [
+        serde_json::json!({}),
+        serde_json::json!({"result": null}),
+        serde_json::json!({"result": {}}),
+        serde_json::json!({"result": {"tools": null}}),
+        serde_json::json!({"result": {"tools": "wrong"}}),
+        serde_json::json!({"result": {"tools": {}}}),
+        serde_json::json!({"result": {"tools": []}, "error": {"code": -32603, "message": "failed"}}),
+        serde_json::json!({"result": {"tools": []}, "error": null}),
+    ];
+    for (case, page) in malformed.into_iter().enumerate() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("manifest.json");
+        let health = dir.path().join("health.json");
+        let mut p = spawn_list_responses(std::slice::from_ref(&page), &manifest, &health);
+        handshake(&mut p);
+        let response = list_response(&mut p, 2, None);
+        let midrun_exists = manifest.try_exists();
+        let exit = p.shutdown();
+        assert!(exit.success());
+        assert_eq!(
+            response["id"], 2,
+            "case {case} must reach the real observer and relay"
+        );
+        for (key, value) in page.as_object().unwrap() {
+            assert_eq!(
+                &response[key], value,
+                "malformed response remains transparent, case {case}"
+            );
+        }
+        assert!(
+            !midrun_exists.expect("inspect mid-run artifact"),
+            "malformed tools/list must not emit complete, case {case}"
+        );
+        assert_eq!(
+            read_artifact(&manifest)["observed"]["tools_list_complete"],
+            "partial",
+            "case {case}"
+        );
+    }
+}
+
+#[test]
+fn tools_list_successful_empty_page_is_complete() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("manifest.json");
+    let health = dir.path().join("health.json");
+    let mut p = spawn_list_responses(
+        &[serde_json::json!({"result": {"tools": []}})],
+        &manifest,
+        &health,
+    );
+    handshake(&mut p);
+    let response = list_response(&mut p, 2, None);
+    let midrun_bytes = std::fs::read(&manifest);
+    let exit = p.shutdown();
+    assert!(exit.success());
+    assert_eq!(response["result"]["tools"], serde_json::json!([]));
+    let m: Value = serde_json::from_slice(&midrun_bytes.expect("mid-run complete artifact"))
+        .expect("mid-run JSON");
+    assert_eq!(m["status"], "observed");
+    assert_eq!(m["observed"]["tools_list_complete"], "complete");
+    assert_eq!(m["observed"]["tool_count"], 0);
+    assert!(m["observed"]["manifest_digest"].is_string());
+    assert_eq!(read_artifact(&manifest), m);
+}
+
+#[test]
+fn tools_list_second_page_error_keeps_partial_catalogue() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("manifest.json");
+    let health = dir.path().join("health.json");
+    let pages = [
+        serde_json::json!({"result": {"tools": [scripted_tool()], "nextCursor": "next"}}),
+        serde_json::json!({"error": {"code": -32603, "message": "page failed"}}),
+    ];
+    let mut p = spawn_list_responses(&pages, &manifest, &health);
+    handshake(&mut p);
+    let first = list_response(&mut p, 2, None);
+    let after_first_exists = manifest.try_exists();
+    let second = list_response(&mut p, 3, Some("next"));
+    let after_error_exists = manifest.try_exists();
+    let exit = p.shutdown();
+    assert!(exit.success());
+    assert_eq!(first["result"]["nextCursor"], "next");
+    assert!(!after_first_exists.expect("inspect first-page artifact"));
+    assert_eq!(second["error"]["code"], -32603);
+    assert!(
+        !after_error_exists.expect("inspect mid-run artifact"),
+        "page2 error must not finalize prior pages as complete"
+    );
+    let m = read_artifact(&manifest);
+    assert_eq!(m["observed"]["tools_list_complete"], "partial");
+    assert_eq!(m["observed"]["tool_count"], 1);
+    assert_eq!(m["observed"]["tool_digests"][0]["name"], "retained");
+}
+
+#[test]
+fn tools_list_failed_refresh_preserves_prior_complete_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("manifest.json");
+    let health = dir.path().join("health.json");
+    let pages = [
+        serde_json::json!({"result": {"tools": [scripted_tool()]}}),
+        serde_json::json!({"error": {"code": -32603, "message": "refresh failed"}}),
+    ];
+    let mut p = spawn_list_responses(&pages, &manifest, &health);
+    handshake(&mut p);
+    let _ = list_response(&mut p, 2, None);
+    let prior_bytes = std::fs::read(&manifest);
+    let response = list_response(&mut p, 3, None);
+    let after_error_bytes = std::fs::read(&manifest);
+    let exit = p.shutdown();
+    assert!(exit.success());
+    let prior_bytes = prior_bytes.expect("initial complete artifact");
+    let prior: Value = serde_json::from_slice(&prior_bytes).expect("initial JSON");
+    assert_eq!(prior["observed"]["tools_list_complete"], "complete");
+    assert_eq!(prior["observed"]["tool_count"], 1);
+    assert_eq!(response["error"]["code"], -32603);
+    assert_eq!(
+        after_error_bytes.expect("mid-run preserved artifact"),
+        prior_bytes,
+        "failed refresh must preserve complete snapshot bytes"
+    );
+    assert_eq!(
+        read_artifact(&manifest),
+        prior,
+        "latest complete remains a prior snapshot, not a successful refresh"
+    );
+    let h = read_artifact(&health);
+    assert_eq!(
+        h["manifest_observation"]["emitted_state_source"],
+        "latest_complete"
+    );
+    assert_eq!(
+        h["manifest_observation"]["later_incomplete_chain_observed"],
+        true
+    );
+    assert_eq!(h["manifest_observation"]["observed_list_operations"], 2);
+}
+
+#[test]
+fn tools_list_malformed_cursor_is_not_an_admitted_page() {
+    for cursor in [
+        Value::Null,
+        serde_json::json!(false),
+        serde_json::json!(1),
+        serde_json::json!({}),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("manifest.json");
+        let health = dir.path().join("health.json");
+        let page =
+            serde_json::json!({"result": {"tools": [scripted_tool()], "nextCursor": cursor}});
+        let mut p = spawn_list_responses(std::slice::from_ref(&page), &manifest, &health);
+        handshake(&mut p);
+        let response = list_response(&mut p, 2, None);
+        let midrun_exists = manifest.try_exists();
+        let exit = p.shutdown();
+        assert!(exit.success());
+        assert_eq!(response["result"], page["result"]);
+        assert!(
+            !midrun_exists.expect("inspect mid-run artifact"),
+            "null cursor must not masquerade as a terminal page"
+        );
+        let m = read_artifact(&manifest);
+        assert_eq!(m["observed"]["tools_list_complete"], "partial");
+        assert_eq!(
+            m["observed"]["tool_count"], 0,
+            "a malformed cursor page must not contribute tools, including non-null wrong types"
+        );
+    }
+}


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: none active; standalone fix.
- Slice: successful-page admission for observed tools/list catalogues (#2840).
- Builder: codex/corpus102_final_review.
- Reviewer: Planck final-head review pending; any later relay by Rul1an identifies the actual reviewer separately.
- Final head: bceadfd903911e4b8d5477b23b05b84bb4458ca6.
- ADR boundary: preserve the distinction between failed discovery and a complete observed catalogue.

## Behavior

A matching tools/list error or malformed page could write a complete observed catalogue mid-session. One admission in the observer now requires an absent error member, array-valued result.tools, and an absent or string nextCursor before collecting tools or completing the operation. The proxy still relays the response. A successful empty list remains complete; a failed refresh preserves the earlier complete snapshot and reports the incomplete refresh through existing health metadata.

Fixes #2840 for this successful-page admission contract. Leaves #2751 open: cursor-generation/correlation and later-page recovery after skipped or rejected pages are not redesigned. This change does not establish that every possible pagination chain is complete; the existing later-valid-page behavior is a separate limitation, not proof that the rejected page was successfully observed.

## Non-Claims

- [x] No scalar trust score or whole-action verdict.
- [x] No identity, delegation, federation, authentication or broad MCP scan.
- [x] No provider-outcome, compliance, certification, partnership or safe-agent claim.
- [x] No full Tool descriptor/JSON-RPC schema validator or cursor-chain redesign.

## Test Evidence

All local Rust measurements used Rust1.96.0, the writer-owned codex/2840-tools-list-admission worktree and its own target. No hosted CI or installed-host proof is claimed here.

### RED

Before the production change, the actual proxy test tools_list_error_cannot_emit_complete_catalogue failed the mid-run manifest assertion; the successful empty-list control passed. This was measured on baseline24b8ca1a5ad05019ecc9262d032665936e617df1 plus retained test source dc478d9b2427e09fb09885642efeda5a28b481d60d770bc771ec1330e5da4048, not on the final commit.

### GREEN and mutation provenance

- On final commit bceadfd903911e4b8d5477b23b05b84bb4458ca6: all17 proxy_manifest_e2e tests passed; cargo fmt --all -- --check passed in a separate non-building check. The guarded sequence refused its fmt step on a growing-swap startup sample; a separately permitted non-building fmt check returned 0.
- Earlier affected crate measurement:505 passed,0 failed,2 explicitly ignored. This used baseline24b8 plus retained repair bytes: observer670758d2896bfbd7b0d347746b186684f5671212f07bd810da9f1cc96315c4d3 and test2a09726fd6600f05ea090666463daf2e021ce798441c373cc5cfc6648c26db26.
- The no-op / effective admission removal / exact restored-source matrix passed / produced the named behavioral assertion failure / passed on those same pre-borrow repair bytes. Earlier infrastructure and resource refusals are preserved and are not counted as RED.
- Three later test-only clone-to-borrow expressions changed the test hash to ee0935a33feb0ef969cc722b2f7c135720e1ef7e5743dda088d308daa72de006. The full17-test proxy suite and affected all-target clippy with -D warnings passed on these bytes. Commit141d3fff2351a255df70269ef1ff0144d8294dbe preserved them; the final ordinary main merge retained identical runtime and test bytes. The earlier505 and mutation measurements are not represented as final-head reruns.
- Exact three-path scope and public strings checked; no runtime/test change arrived from the main advance. Normal original commit hooks passed; the subsequent ordinary merge matched the predicted whole tree.

## Review Quorum

- [ ] One non-building final-head review: pending published exact-head record.
- [ ] All actionable findings disposed: final review pending; #2751 limitation explicitly retained above.
- [ ] Hosted required checks green: pending PR/CI.

Builder evidence is not independent quorum. Reviewer, relay/publisher and evidence URL must remain separate in the eventual record; reviewer authentication is not inferred from the publisher login.
