### PR TITLE
feat(evidence): expose checked attestation extent in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `evidence attest` now signs artifact-derived v1.1 extent; `evidence verify-attestation` reports the checked extent and its stated/absent status while preserving legacy absent/null predicates, qualified producer counts, and signature/artifact outcome distinctions (#2834).
 - Codex host-proof v7 retains closed error cause discriminants and supplied retry
   intent without diagnostic free text. Historical v6 empty diagnostics remain
   supported without backfilling; diagnostics remain non-clean, and retry intent

--- a/crates/assay-cli/src/cli/commands/evidence/attest.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/attest.rs
@@ -1,7 +1,7 @@
-//! `assay evidence attest` — sign a bundle's manifest as an in-toto/DSSE attestation.
+//! `assay evidence attest` — sign a complete evidence archive as an in-toto/DSSE attestation.
 //!
-//! Wraps `assay_evidence::attestation` (ADR-039): opens and verifies an evidence
-//! bundle, builds an in-toto v1 Statement over its integrity root, and signs it
+//! Wraps `assay_evidence::attestation` (ADR-044/049): opens and verifies an evidence
+//! bundle, builds an in-toto v1 Statement binding its complete archive digest and extent, and signs it
 //! as a DSSE envelope with an Ed25519 key (PKCS#8 PEM, as produced by
 //! `assay mcp tool keygen`). The anchor (transparency log / timestamp) stays
 //! external. Attestation binds who-said-it and the bundle content; it does not
@@ -10,7 +10,7 @@
 use crate::output_write::write_stdout_json;
 use anyhow::{Context, Result};
 use assay_common::limits::{LimitKind, LimitReader};
-use assay_evidence::attestation::{sign_statement, statement_for_bundle_with_limits};
+use assay_evidence::attestation::{sign_statement, statement_for_bundle_with_extent_and_limits};
 use assay_evidence::VerifyLimits;
 use clap::Args;
 use ed25519_dalek::pkcs8::DecodePrivateKey;
@@ -103,7 +103,7 @@ fn run(args: AttestArgs) -> Result<i32> {
     // 4. Build the statement from the bounded bytes. Verification, predicate derivation and the
     //    subject name all happen inside that one call, against these bytes, so the CLI has no way
     //    to pair a predicate with an artifact it does not describe.
-    let statement = statement_for_bundle_with_limits(&bundle_bytes, limits)?;
+    let statement = statement_for_bundle_with_extent_and_limits(&bundle_bytes, limits)?;
     let envelope = sign_statement(&statement, &key).context("sign in-toto statement")?;
     let json = serde_json::to_string_pretty(&envelope).context("serialize DSSE envelope")?;
 

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -85,7 +85,7 @@ pub enum EvidenceCmd {
     Lint(lint::LintArgs),
     /// Diff two bundles and report changes
     Diff(diff::DiffArgs),
-    /// Sign a bundle's manifest as an in-toto/DSSE attestation
+    /// Sign a complete evidence archive as an in-toto/DSSE attestation
     Attest(attest::AttestArgs),
     /// Upload a bundle to remote storage (BYOS)
     Push(push::PushArgs),

--- a/crates/assay-cli/src/cli/commands/evidence/verify_attestation.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/verify_attestation.rs
@@ -2,7 +2,9 @@
 use crate::output_write::write_stdout_json;
 use anyhow::{anyhow, Result};
 use assay_common::limits::{LimitKind, LimitReader};
-use assay_evidence::attestation::{verify_attestation_for_bundle_with_limits, DsseEnvelope};
+use assay_evidence::attestation::{
+    verify_attestation_for_bundle_with_extent_and_limits, DsseEnvelope, EvidenceExtent,
+};
 use assay_evidence::VerifyLimits;
 use clap::Args;
 use ed25519_dalek::pkcs8::DecodePublicKey;
@@ -37,6 +39,8 @@ struct AttestationVerificationReport {
     artifact_sha256: String,
     predicate_type: String,
     subject_name: String,
+    extent_stated: bool,
+    extent: Option<EvidenceExtent>,
 }
 
 /// Every input uses the same stream ceiling. Error context is static: underlying file,
@@ -83,8 +87,10 @@ pub fn cmd_verify_attestation(args: VerifyAttestationArgs) -> Result<i32> {
 
     // This is the one canonical full verification path. A checked signature alone is
     // artifact-unmatched and must never become this command's success report.
-    let verified = verify_attestation_for_bundle_with_limits(&envelope, &key, &bundle, limits)
-        .map_err(|_| anyhow!("attestation verification failed"))?;
+    let checked =
+        verify_attestation_for_bundle_with_extent_and_limits(&envelope, &key, &bundle, limits)
+            .map_err(|_| anyhow!("attestation verification failed"))?;
+    let (verified, extent) = checked.into_parts();
     let report = AttestationVerificationReport {
         schema: "assay.evidence.attestation.verify.v1",
         outcome: "attestation_verified",
@@ -93,6 +99,8 @@ pub fn cmd_verify_attestation(args: VerifyAttestationArgs) -> Result<i32> {
         artifact_sha256: verified.artifact_sha256,
         predicate_type: verified.statement.predicate_type,
         subject_name: verified.statement.subject[0].name.clone(),
+        extent_stated: extent.is_some(),
+        extent,
     };
     let json = serde_json::to_string(&report)
         .map_err(|_| anyhow!("serialize attestation verification report"))?;

--- a/crates/assay-cli/tests/evidence_verify_attestation_cli.rs
+++ b/crates/assay-cli/tests/evidence_verify_attestation_cli.rs
@@ -9,7 +9,7 @@ use assay_evidence::attestation::{
 use assay_evidence::bundle::BundleWriter;
 use assay_evidence::types::{EvidenceEvent, ProducerMeta};
 use bounded_process::{run_bounded, ProcessLimits};
-use ed25519_dalek::pkcs8::{spki::der::pem::LineEnding, EncodePublicKey};
+use ed25519_dalek::pkcs8::{spki::der::pem::LineEnding, EncodePrivateKey, EncodePublicKey};
 use ed25519_dalek::SigningKey;
 use serde_json::{json, Value};
 use std::fs::{self, File};
@@ -136,7 +136,7 @@ fn matching_archive_returns_one_typed_matched_outcome() {
     let statement = statement_for_bundle(&f.bytes).unwrap();
     assert_eq!(
         result,
-        json!({"schema":"assay.evidence.attestation.verify.v1", "outcome":"attestation_verified", "signature_verified":true,"subject_matched":true,"artifact_sha256":statement.subject[0].digest["sha256"],"predicate_type":statement.predicate_type,"subject_name":statement.subject[0].name})
+        json!({"schema":"assay.evidence.attestation.verify.v1", "outcome":"attestation_verified", "signature_verified":true,"subject_matched":true,"artifact_sha256":statement.subject[0].digest["sha256"],"predicate_type":statement.predicate_type,"subject_name":statement.subject[0].name,"extent_stated":false,"extent":null})
     );
 }
 
@@ -322,4 +322,169 @@ fn attacker_values_are_not_echoed_through_library_error_chains() {
     assert!(output.stdout.is_empty());
     assert!(!String::from_utf8_lossy(&output.stderr).contains("ATTACKER_SECRET_2831"));
     assert!(String::from_utf8_lossy(&output.stderr).contains("attestation verification failed"));
+}
+
+fn extent_fixture(events: &[(&str, Value)]) -> Fixture {
+    let mut f = Fixture::small();
+    let producer = ProducerMeta {
+        name: "extent-cli-test".into(),
+        version: "test".into(),
+        git: None,
+    };
+    let mut writer = BundleWriter::new(File::create(f.dir.path().join("bundle.tar.gz")).unwrap())
+        .with_producer(producer.clone());
+    for (seq, (kind, data)) in events.iter().enumerate() {
+        writer.add_event(
+            EvidenceEvent::new(
+                *kind,
+                "urn:assay:test",
+                "verify_run",
+                seq as u64,
+                data.clone(),
+            )
+            .with_producer(&producer),
+        );
+    }
+    writer.finish().unwrap();
+    f.bytes = fs::read(f.dir.path().join("bundle.tar.gz")).unwrap();
+    f
+}
+
+#[test]
+fn extent_producer_emits_signed_extent_as_bare_envelope() {
+    let f = Fixture::small();
+    fs::write(
+        f.dir.path().join("private.pem"),
+        f.signing.to_pkcs8_pem(LineEnding::LF).unwrap().as_bytes(),
+    )
+    .unwrap();
+    for out_file in [false, true] {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_assay"));
+        cmd.current_dir(f.dir.path()).args([
+            "evidence",
+            "attest",
+            "--bundle",
+            "bundle.tar.gz",
+            "--key",
+            "private.pem",
+        ]);
+        if out_file {
+            cmd.args(["--out", "produced.json"]);
+        }
+        let output = run_bounded(
+            cmd,
+            &[],
+            ProcessLimits::new(Duration::from_secs(60), 16384, 4096),
+            "extent producer",
+        )
+        .unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let bytes = if out_file {
+            assert!(output.stdout.is_empty());
+            assert_eq!(
+                String::from_utf8(output.stderr).unwrap(),
+                "Attestation: produced.json\n"
+            );
+            fs::read(f.dir.path().join("produced.json")).unwrap()
+        } else {
+            assert!(output.stderr.is_empty());
+            output.stdout
+        };
+        let envelope: DsseEnvelope =
+            serde_json::from_slice(&bytes).expect("stdout/file must be only a bare DSSE envelope");
+        let signed = assay_evidence::attestation::verify_envelope_signature(
+            &envelope,
+            &f.signing.verifying_key(),
+        )
+        .unwrap();
+        assert_eq!(
+            signed.statement.predicate["extent"],
+            json!({"retained_events_by_type":{"assay.test.event":1},"observed":{"basis":"not_stated"}}),
+            "shipped attest must sign derived extent"
+        );
+        assert!(signed.statement.predicate.get("support_ceiling").is_none());
+    }
+}
+
+#[test]
+fn extent_consumer_reports_checked_retained_and_producer_counts() {
+    let f = extent_fixture(&[
+        ("assay.fs.access", json!({"hits":99})),
+        (
+            "assay.profile.finished",
+            json!({"files_count":3,"network_count":2,"processes_count":1,"sandbox_degradation_count":0}),
+        ),
+    ]);
+    let statement =
+        assay_evidence::attestation::statement_for_bundle_with_extent(&f.bytes).unwrap();
+    f.write_statement(statement.clone());
+    let output = f.run();
+    assert_eq!(output.status.code(), Some(0));
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["extent_stated"], true);
+    assert_eq!(
+        report["extent"],
+        json!({"retained_events_by_type":{"assay.fs.access":1,"assay.profile.finished":1},"observed":{"basis":"producer_reported","source_type":"assay.profile.finished","counts":{"files":3,"network":2,"processes":1,"sandbox_degradations":0}}})
+    );
+    assert_eq!(report["signature_verified"], true);
+    assert_eq!(report["subject_matched"], true);
+    let mut false_extent = statement;
+    false_extent.predicate["extent"]["retained_events_by_type"]["assay.fs.access"] = json!(99);
+    f.write_statement(false_extent);
+    f.refuse("attestation verification failed");
+}
+
+#[test]
+fn extent_consumer_preserves_absent_null_and_not_stated() {
+    let f = Fixture::small();
+    for explicit_null in [false, true] {
+        let mut statement = statement_for_bundle(&f.bytes).unwrap();
+        if explicit_null {
+            statement.predicate["extent"] = Value::Null;
+        }
+        f.write_statement(statement);
+        let output = f.run();
+        assert_eq!(output.status.code(), Some(0));
+        let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(report.get("extent_stated"), Some(&json!(false)));
+        assert_eq!(
+            report.get("extent"),
+            Some(&Value::Null),
+            "legacy absence must not become an empty/zero extent"
+        );
+    }
+    f.write_statement(
+        assay_evidence::attestation::statement_for_bundle_with_extent(&f.bytes).unwrap(),
+    );
+    let output = f.run();
+    assert_eq!(output.status.code(), Some(0));
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["extent_stated"], true);
+    assert_eq!(report["extent"]["observed"], json!({"basis":"not_stated"}));
+}
+
+#[test]
+fn extent_sandbox_network_is_absent_not_zero() {
+    let f = extent_fixture(&[(
+        "assay.sandbox.summary",
+        json!({"fs_count":4,"exec_count":2,"degradation_count":0}),
+    )]);
+    f.write_statement(
+        assay_evidence::attestation::statement_for_bundle_with_extent(&f.bytes).unwrap(),
+    );
+    let output = f.run();
+    assert_eq!(output.status.code(), Some(0));
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        report["extent"],
+        json!({"retained_events_by_type":{"assay.sandbox.summary":1},"observed":{"basis":"producer_reported","source_type":"assay.sandbox.summary","counts":{"files":4,"processes":2,"sandbox_degradations":0}}})
+    );
+    assert!(report["extent"]["observed"]["counts"]
+        .get("network")
+        .is_none());
 }

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -566,6 +566,18 @@ To compare the resulting Trust Basis artifact against another run, use
 - [P41 OpenFeature decision receipt import plan](../../architecture/PLAN-P41-OPENFEATURE-EVALUATION-DETAILS-DECISION-RECEIPT-IMPORT-2026q2.md)
 - [P31 Promptfoo receipt import plan](../../architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md)
 
+## Sign an artifact attestation
+
+```bash
+assay evidence attest --bundle evidence.tar.gz --key private-key.pem
+```
+
+The producer verifies the bounded archive and signs its complete archive digest and the
+artifact-derived v1.1 `extent` using the canonical builder. Stdout contains only the bare
+DSSE envelope. With `--out attestation.json`, the envelope is written to that file instead;
+the existing output-path notice goes to stderr. The subject digest binds the archive bytes,
+not just the semantic run root.
+
 ## Verify an artifact attestation
 
 ```bash
@@ -582,8 +594,21 @@ key as a substitute. The v0 predicate and unknown predicate versions are refused
 
 Successful stdout is one JSON document with schema `assay.evidence.attestation.verify.v1`,
 outcome `attestation_verified`, `signature_verified: true`, `subject_matched: true`,
-`artifact_sha256`, `predicate_type` and `subject_name`. The archive digest is lowercase
+`artifact_sha256`, `predicate_type`, `subject_name`, `extent_stated` and `extent`. The archive digest is lowercase
 SHA-256 hexadecimal without a prefix; it is distinct from the semantic run root.
+
+`extent` is the canonical verifier's checked projection, not an unchecked copy of signed
+JSON. It includes `retained_events_by_type` (retained row counts, not hit counts) and
+`observed.basis`. Producer summaries have basis `producer_reported` with `source_type` and
+`counts`; without a recognized summary the basis is `not_stated`. Sandbox summaries do not
+state a network count, so that field remains absent rather than becoming zero. Legacy
+predicates with absent or null extent remain valid and report `extent_stated: false` and
+`extent: null`; a stated, checked extent reports `extent_stated: true`.
+
+Artifact-bound support is an interpretation from the predicate specification, not a signed
+`support_ceiling` field. Neither an extent nor a valid signature establishes observation
+completeness. `signature_verified` and `subject_matched` remain separate statements: this
+command emits success only after both checks, including artifact-derived extent matching.
 
 Exit 0 means the full attestation matched. Input, signature, integrity, version and resource
 refusals exit 2 with a bounded static explanation on stderr and no success JSON. A stdout


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: no active programme; standalone issue #2834.
- Slice: CLI opt-in to the accepted ADR-049 extent APIs.
- Builder: `codex/corpus102_final_review`.
- Reviewers: independent final-head review pending; publisher/relay `Rul1an` is separate from the actual reviewer.
- Final head SHA: `11520ac94c514f14ad6ceca052b86e8a85f50875`.
- ADR invariants affected: ADR-042/043/044/049; bounded artifact verification and qualified evidence projection.

## Behavior

`evidence attest` now signs the artifact-derived extent using the canonical bounded builder. Stdout remains the bare DSSE envelope; `--out` retains its existing stderr path notice.

`evidence verify-attestation` uses the canonical extent-aware verifier and adds `extent_stated` and checked `extent` to `assay.evidence.attestation.verify.v1`. Legacy absent/null extent reports false/null. Retained row counts remain distinct from producer summary counts, `observed.basis` remains explicit, and unstated sandbox network stays absent. Signature verification and artifact matching remain distinct; exits 0/2/3 are preserved. The support ceiling is specification interpretation, not a signed field.

Six paths: producer, consumer, existing integration tests, CLI reference, changelog, plus the expressly authorized Attest docstring in `evidence/mod.rs` to correct obsolete manifest-only help. No other enum/module behavior changed.

Closes #2834.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim

No trust-root, observation-completeness, live-host or outcome proof. No new verification implementation or public Rust library shape. Hosted CI and independent review remain separate landing requirements.

## Test Evidence

### RED

Before production changes, the four named extent CLI tests failed on missing signed extent/report fields. This was measured on base `cce163440da17cef5c7f65ee66f400ac38521dcc` plus test source SHA256 `877d94339a3c27502014d781a03a97aede3088f47cbc943d9e39f95b412ca0a6`.

Four precommit mutations each produced the named assertion failure: legacy producer, legacy consumer with an explicit absent-projection adapter, flattened legacy extent, and synthesized sandbox network zero. No-op and byte-exact restored controls passed. These historical runs bind retained before/after hashes matching the committed source; they are not claimed as final-commit reruns.

### GREEN

Fresh on `11520ac94c514f14ad6ceca052b86e8a85f50875`, worktree `wt-codex-2834-attestation-extent-cli`, Rust/Cargo 1.96.0, own target/jobs1/offline:

- `cargo test --locked -p assay-cli --test evidence_verify_attestation_cli`: **33 passed, 1 intentionally ignored** descendant-spawner helper (re-executed by its parent tests).
- `cargo test --locked -p assay-cli --bin assay cli::commands::evidence::attest::tests`: **5 passed**.
- `cargo test --locked -p assay-cli --test stdout_json_write_contract every_sink_case_`: **2 passed**.
- `cargo test --locked -p assay-cli --test stdout_json_write_contract verify_attestation_success_document_reports_closed_stdout_as_exit_three`: **1 passed**.
- `cargo clippy --locked -p assay-cli --bin assay --test evidence_verify_attestation_cli --test stdout_json_write_contract -- -D warnings`: passed.

Before commit, `cargo fmt --all -- --check`, diff whitespace and public-string review passed on the six source files whose hashes were later confirmed identical at the final commit. These are source-equivalent precommit measurements, not final-SHA reruns. Normal commit and push hooks passed.

## Review Quorum

- [ ] One non-building agent review
- [ ] Every actionable finding is fixed or has a technical disposition
- [ ] Any delegated proof targets this exact head SHA

Optional automated reviews do not count toward quorum. This PR is not authorized for merge by its builder.

