### PR TITLE
fix(deps): upgrade jsonschema with preserved IDN validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
 dependencies = [
  "bit-set 0.8.0",
  "regex-automata",
@@ -1971,12 +1971,12 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+checksum = "e246562084dde8ebbcc943b261c406ce4f68e5032ec28029a251a47d6a295500"
 dependencies = [
- "lazy_static",
  "num",
+ "num-bigint",
 ]
 
 [[package]]
@@ -2743,15 +2743,15 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.4"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257549c093d8f3d043337ba0d507e8eeace2447dfae3f0ee37eb0f57d3df7655"
+checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
 dependencies = [
  "ahash",
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex 0.18.0",
+ "fancy-regex 0.19.1",
  "fraction",
  "getrandom 0.3.4",
  "idna",
@@ -2772,18 +2772,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.9"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91994f45017ed5e66aa8e59b8415f4cb033a6380d7200387b7cf117595fbdf85"
+checksum = "f5d90ea83fa606c96f0b4737ecedf1fa6b624272022edc42039565f8d8af0b78"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.9"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb"
+checksum = "da4ab4cbe58181a117d8c3582844ce20b07184319b51ba6d756596c1c451aebc"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2791,6 +2791,7 @@ dependencies = [
  "num-cmp",
  "num-traits",
  "serde_json",
+ "zmij",
 ]
 
 [[package]]
@@ -3130,9 +3131,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -4223,9 +4224,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.9"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278"
+checksum = "d38a014525040cdc9893361b7419bcf1f43b7ba7055eabaf6d91d6b75caa8b3f"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -6342,6 +6343,6 @@ checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,4 +115,4 @@ aya-log = "0.2"
 object = { version = "=0.36.7", default-features = false, features = ["elf", "read_core", "std"] }
 ratatui = "0.30"
 crossterm = "0.29"
-jsonschema = { version = "0.49", default-features = false }
+jsonschema = { version = "0.52", default-features = false, features = ["idna"] }

--- a/crates/assay-core/tests/jsonschema_semantics_probe.rs
+++ b/crates/assay-core/tests/jsonschema_semantics_probe.rs
@@ -2,6 +2,74 @@
 use serde_json::json;
 
 #[test]
+fn user_draft7_idn_formats_preserve_argument_validation() {
+    use assay_core::policy_engine::{evaluate_tool_args, VerdictStatus};
+
+    for (format, valid, invalid) in [
+        ("idn-hostname", "münchen.example", "bad host.example"),
+        ("idn-email", "user@münchen.example", "missing-at-sign"),
+    ] {
+        let policy = json!({"lookup": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "string",
+            "format": format
+        }});
+        let accepted = evaluate_tool_args(&policy, "lookup", &json!(valid));
+        assert_eq!(
+            accepted.status,
+            VerdictStatus::Allowed,
+            "{format}: {accepted:?}"
+        );
+        let refused = evaluate_tool_args(&policy, "lookup", &json!(invalid));
+        assert_eq!(
+            refused.status,
+            VerdictStatus::Blocked,
+            "{format}: {refused:?}"
+        );
+        assert_eq!(refused.reason_code, "E_ARG_SCHEMA", "{format}");
+        assert!(!refused.details["violations"].as_array().unwrap().is_empty());
+    }
+}
+
+#[test]
+fn user_fractional_multiple_of_accepts_valid_decimal_without_accepting_any_number() {
+    use assay_core::policy_engine::{evaluate_tool_args, VerdictStatus};
+
+    let policy = json!({"amount": {"type": "number", "multipleOf": 0.01}});
+    for valid in [1.25, 1070468.14] {
+        assert_eq!(
+            evaluate_tool_args(&policy, "amount", &json!(valid)).status,
+            VerdictStatus::Allowed
+        );
+    }
+    let refused = evaluate_tool_args(&policy, "amount", &json!(1.255));
+    assert_eq!(refused.status, VerdictStatus::Blocked);
+    assert_eq!(refused.reason_code, "E_ARG_SCHEMA");
+}
+
+#[test]
+fn user_regex_format_checks_ecma_syntax_not_rust_syntax() {
+    use assay_core::policy_engine::{evaluate_tool_args, VerdictStatus};
+
+    let policy = json!({"pattern": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "string",
+        "format": "regex"
+    }});
+    for valid in ["^abc$", "(?=a)"] {
+        assert_eq!(
+            evaluate_tool_args(&policy, "pattern", &json!(valid)).status,
+            VerdictStatus::Allowed
+        );
+    }
+    for invalid in ["(?i)abc", "["] {
+        let refused = evaluate_tool_args(&policy, "pattern", &json!(invalid));
+        assert_eq!(refused.status, VerdictStatus::Blocked, "{invalid}");
+        assert_eq!(refused.reason_code, "E_ARG_SCHEMA");
+    }
+}
+
+#[test]
 fn unresolvable_local_ref_fails_at_build_time() {
     let schema = json!({"$ref": "#/$defs/Missing"});
     let result = jsonschema::validator_for(&schema);

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -641,7 +641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -658,9 +658,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -740,12 +740,12 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.4"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+checksum = "e246562084dde8ebbcc943b261c406ce4f68e5032ec28029a251a47d6a295500"
 dependencies = [
- "lazy_static",
  "num",
+ "num-bigint",
 ]
 
 [[package]]
@@ -1319,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.4"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257549c093d8f3d043337ba0d507e8eeace2447dfae3f0ee37eb0f57d3df7655"
+checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1348,18 +1348,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.9"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91994f45017ed5e66aa8e59b8415f4cb033a6380d7200387b7cf117595fbdf85"
+checksum = "f5d90ea83fa606c96f0b4737ecedf1fa6b624272022edc42039565f8d8af0b78"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.9"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb"
+checksum = "da4ab4cbe58181a117d8c3582844ce20b07184319b51ba6d756596c1c451aebc"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1367,6 +1367,7 @@ dependencies = [
  "num-cmp",
  "num-traits",
  "serde_json",
+ "zmij",
 ]
 
 [[package]]
@@ -1820,7 +1821,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1962,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.9"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278"
+checksum = "d38a014525040cdc9893361b7419bcf1f43b7ba7055eabaf6d91d6b75caa8b3f"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -2136,7 +2137,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2194,7 +2195,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2622,10 +2623,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3057,7 +3058,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Upgrade jsonschema to 0.52.1 and resolve both the root and fuzz lockfiles. Explicitly enable its `idna` feature: with default features disabled, the upgrade otherwise stops rejecting invalid `idn-hostname` and `idn-email` values in user-supplied Draft 7 argument policies. HTTP and file reference resolution remain disabled.

Add behavioral tests through `evaluate_tool_args` for those IDN checks and two upstream correctness changes. Valid decimal multiples such as 1070468.14 for `multipleOf: 0.01` are now accepted, while 1.255 remains rejected. Draft 7 `format: regex` now checks ECMAScript syntax: lookahead remains accepted and Rust-only inline flags such as `(?i)` are rejected. This intentionally changes affected policy verdicts; it is not a claim of unchanged schema semantics.

Replaces the incomplete dependency update proposed in #2847. Keep the original PR open until this replacement lands. The already-landed fuzz UUID 1.26.0 update is preserved. The fuzz lockfile also re-resolves six existing package entries to their permitted windows-sys/getrandom versions; these are resolution changes, not six new package versions.

## Validation

Final head `45e5ea6fe2d655b3e04f8c521f1922a8cb3f8372`, base `30ab5f5da88176ac2a13e512ceb06fa8b41242a0`, Rust 1.96.0, writer worktree `/Users/roelschuurkes/wt-codex-dependabot-jsonschema-052`:

- Locked metadata succeeds for both workspaces, with jsonschema 0.52.1 enabling only `idna`.
- Final-head schema/argument suites: 8 + 4 tests pass. Evidence library: 331 tests pass. No failures or ignored tests.
- The IDN test failed before enabling `idna`. A separate 0.49 dependency-graph comparison preserved IDN behavior and exposed the previous decimal/regex behavior. These were development experiments with recorded source hashes, not measurements of the final committed tree.
- Affected core/metrics library suites, selected CLI schema/package/coverage suites and clippy across core, metrics, CLI and evidence passed on the candidate source before commit. Formatting, diff checks and normal commit hooks passed. Hosted CI and delegated runner proof remain separate requirements.

No policy or evidence format changes, live-model execution or installed-user proof is claimed.
