### PR TITLE
ci: align CodeQL upload lockstep contract

### DIFF
--- a/scripts/ci/check-codeql-upload-sarif-lockstep.py
+++ b/scripts/ci/check-codeql-upload-sarif-lockstep.py
@@ -7,8 +7,8 @@ import re
 import sys
 from pathlib import Path
 
-EXPECTED_SHA = "db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28"
-EXPECTED_TAG = "v4.37.8"
+EXPECTED_SHA = "cdf488f595d80d6e07e03d4674febd5ab45fa938"
+EXPECTED_TAG = "v4.37.9"
 WORKFLOWS = (
     Path(".github/workflows/assay-security.yml"),
     Path(".github/workflows/openssf-scorecard.yml"),

--- a/scripts/ci/test-codeql-upload-sarif-lockstep.sh
+++ b/scripts/ci/test-codeql-upload-sarif-lockstep.sh
@@ -11,6 +11,20 @@ WORKFLOWS=(
   .github/workflows/osv-scanner-scheduled.yml
 )
 
+read -r EXPECTED_SHA EXPECTED_TAG < <(
+  python3 - "$ROOT/$CHECKER" <<'PY'
+import runpy
+import sys
+
+contract = runpy.run_path(sys.argv[1])
+print(contract["EXPECTED_SHA"], contract["EXPECTED_TAG"])
+PY
+)
+if [[ ! "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ || ! "$EXPECTED_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "FAIL: checker returned an invalid expected CodeQL pin" >&2
+  exit 1
+fi
+
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
 
@@ -104,7 +118,7 @@ case_root="$scratch/one-laggard"
 seed "$case_root"
 mutate_once \
   "$case_root/.github/workflows/openssf-scorecard.yml" \
-  "db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28" \
+  "${EXPECTED_SHA}" \
   "d1ba80a13dd99fba24a470575428917156a28b43"
 run_case one-laggard-is-refused "$case_root" 1
 
@@ -112,7 +126,7 @@ case_root="$scratch/tag-drift"
 seed "$case_root"
 mutate_once \
   "$case_root/.github/workflows/assay-security.yml" \
-  "# v4.37.8" \
+  "# ${EXPECTED_TAG}" \
   "# v4.37.5"
 run_case tag-drift-is-refused "$case_root" 1
 
@@ -120,92 +134,92 @@ case_root="$scratch/invoke-bypass"
 seed "$case_root"
 mutate_once \
   "$case_root/.github/workflows/osv-scanner-scheduled.yml" \
-  "uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8" \
+  "uses: github/codeql-action/upload-sarif@${EXPECTED_SHA} # ${EXPECTED_TAG}" \
   "run: echo bypassed-upload"
 run_case invoke-bypass-is-refused "$case_root" 1
 
 case_root="$scratch/extra-callsite"
 seed "$case_root"
-cat >>"$case_root/.github/workflows/assay-security.yml" <<'YAML'
+cat >>"$case_root/.github/workflows/assay-security.yml" <<YAML
 
 # Mutation: a second active upload is outside the closed one-callsite contract.
-uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+uses: github/codeql-action/upload-sarif@${EXPECTED_SHA} # ${EXPECTED_TAG}
 YAML
 run_case extra-callsite-is-refused "$case_root" 1
 
 case_root="$scratch/quoted-duplicate"
 seed "$case_root"
-cat >>"$case_root/.github/workflows/assay-security.yml" <<'YAML'
+cat >>"$case_root/.github/workflows/assay-security.yml" <<YAML
 
 # Mutation: quoted uses values are valid workflow YAML and remain active.
-uses: "github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28" # v4.37.8
+uses: "github/codeql-action/upload-sarif@${EXPECTED_SHA}" # ${EXPECTED_TAG}
 YAML
 run_case quoted-duplicate-is-refused "$case_root" 1
 
 case_root="$scratch/foreign-workflow"
 seed "$case_root"
-cat >"$case_root/.github/workflows/fourth-upload.yml" <<'YAML'
+cat >"$case_root/.github/workflows/fourth-upload.yml" <<YAML
 name: Mutated fourth CodeQL upload
 jobs:
   upload:
     steps:
-      - uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      - uses: github/codeql-action/upload-sarif@${EXPECTED_SHA} # ${EXPECTED_TAG}
 YAML
 run_case foreign-workflow-callsite-is-refused "$case_root" 1
 
 case_root="$scratch/quoted-foreign-workflow"
 seed "$case_root"
-cat >"$case_root/.github/workflows/quoted-upload.yaml" <<'YAML'
+cat >"$case_root/.github/workflows/quoted-upload.yaml" <<YAML
 name: Mutated quoted CodeQL upload
 jobs:
   upload:
     steps:
-      - uses: 'github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28' # v4.37.8
+      - uses: 'github/codeql-action/upload-sarif@${EXPECTED_SHA}' # ${EXPECTED_TAG}
 YAML
 run_case quoted-foreign-workflow-callsite-is-refused "$case_root" 1
 
 case_root="$scratch/flow-mapping-foreign-workflow"
 seed "$case_root"
-cat >"$case_root/.github/workflows/flow-upload.yml" <<'YAML'
+cat >"$case_root/.github/workflows/flow-upload.yml" <<YAML
 name: Mutated flow-mapping CodeQL upload
 on: workflow_dispatch
 jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - {uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28}
+      - {uses: github/codeql-action/upload-sarif@${EXPECTED_SHA}}
 YAML
 run_case flow-mapping-foreign-workflow-is-refused "$case_root" 1
 
 case_root="$scratch/quoted-key-foreign-workflow"
 seed "$case_root"
-cat >"$case_root/.github/workflows/quoted-key-upload.yml" <<'YAML'
+cat >"$case_root/.github/workflows/quoted-key-upload.yml" <<YAML
 name: Mutated quoted-key CodeQL upload
 on: workflow_dispatch
 jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - "uses": github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
+      - "uses": github/codeql-action/upload-sarif@${EXPECTED_SHA}
 YAML
 run_case quoted-key-foreign-workflow-is-refused "$case_root" 1
 
 case_root="$scratch/spaced-colon-foreign-workflow"
 seed "$case_root"
-cat >"$case_root/.github/workflows/spaced-colon-upload.yml" <<'YAML'
+cat >"$case_root/.github/workflows/spaced-colon-upload.yml" <<YAML
 name: Mutated spaced-colon CodeQL upload
 on: workflow_dispatch
 jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses : github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
+      - uses : github/codeql-action/upload-sarif@${EXPECTED_SHA}
 YAML
 run_case spaced-colon-foreign-workflow-is-refused "$case_root" 1
 
 case_root="$scratch/folded-scalar-foreign-workflow"
 seed "$case_root"
-cat >"$case_root/.github/workflows/folded-upload.yml" <<'YAML'
+cat >"$case_root/.github/workflows/folded-upload.yml" <<YAML
 name: Mutated folded-scalar CodeQL upload
 on: workflow_dispatch
 jobs:
@@ -213,73 +227,73 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: >-
-          github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
+          github/codeql-action/upload-sarif@${EXPECTED_SHA}
 YAML
 run_case folded-scalar-foreign-workflow-is-refused "$case_root" 1
 
 case_root="$scratch/unicode-escaped-action"
 seed "$case_root"
-cat >"$case_root/.github/workflows/unicode-escaped-upload.yml" <<'YAML'
+cat >"$case_root/.github/workflows/unicode-escaped-upload.yml" <<YAML
 name: Mutated Unicode-escaped CodeQL upload
 on: workflow_dispatch
 jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: "github/codeql-action/upload-sarif\u0040db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28"
+      - uses: "github/codeql-action/upload-sarif\u0040${EXPECTED_SHA}"
 YAML
 run_case unicode-escaped-action-is-refused "$case_root" 1
 
 case_root="$scratch/hex-escaped-action"
 seed "$case_root"
-cat >"$case_root/.github/workflows/hex-escaped-upload.yml" <<'YAML'
+cat >"$case_root/.github/workflows/hex-escaped-upload.yml" <<YAML
 name: Mutated hex-escaped CodeQL upload
 on: workflow_dispatch
 jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: "github/codeql-action/upload-sarif\x40db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28"
+      - uses: "github/codeql-action/upload-sarif\x40${EXPECTED_SHA}"
 YAML
 run_case hex-escaped-action-is-refused "$case_root" 1
 
 case_root="$scratch/case-variant-action"
 seed "$case_root"
-cat >"$case_root/.github/workflows/case-variant-upload.yml" <<'YAML'
+cat >"$case_root/.github/workflows/case-variant-upload.yml" <<YAML
 name: Mutated case-variant CodeQL upload
 on: workflow_dispatch
 jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHub/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
+      - uses: GitHub/codeql-action/upload-sarif@${EXPECTED_SHA}
 YAML
 run_case case-variant-action-is-refused "$case_root" 1
 
 case_root="$scratch/unicode-escaped-identity"
 seed "$case_root"
-cat >"$case_root/.github/workflows/unicode-identity-upload.yml" <<'YAML'
+cat >"$case_root/.github/workflows/unicode-identity-upload.yml" <<YAML
 name: Mutated Unicode-escaped CodeQL identity
 on: workflow_dispatch
 jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: "\u0067ithub/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28"
+      - uses: "\u0067ithub/codeql-action/upload-sarif@${EXPECTED_SHA}"
 YAML
 run_case unicode-escaped-identity-is-refused "$case_root" 1
 
 case_root="$scratch/escaped-line-break-action"
 seed "$case_root"
-cat >"$case_root/.github/workflows/escaped-break-upload.yml" <<'YAML'
+cat >"$case_root/.github/workflows/escaped-break-upload.yml" <<YAML
 name: Mutated escaped-line-break CodeQL upload
 on: workflow_dispatch
 jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: "github/codeql-action/upload-\
-          sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28"
+      - uses: "github/codeql-action/upload-\\
+          sarif@${EXPECTED_SHA}"
 YAML
 run_case escaped-line-break-action-is-refused "$case_root" 1
 


### PR DESCRIPTION
The CodeQL `upload-sarif` workflows already use the pinned v4.37.9 commit, but the lockstep checker still expected v4.37.8. That made the unchanged repository fail the effective pre-commit guard, including the Kernel Matrix lint job observed on #2856.

This updates the checker to the deployed v4.37.9 SHA and makes its mutation battery read the expected SHA and tag from the checker. The closed workflow-path oracle remains independently enumerated, so a missing governed workflow, narrowed hook scope, extra callsite, malformed reference, or mismatched pin is still refused. No workflow, trigger, permission, or upload behavior changes.

Validation on exact head `14b8ef8588556486333d8ad4f2d6ddf5896b40f4`:

- direct checker: passed for all 3 governed callsites;
- mutation battery: 2 positive cases passed and 17 negative cases were refused;
- normal pre-push hooks: passed, including the effective lockstep hook, shellcheck, `cargo fmt --check`, workspace clippy with warnings denied, and the Linux cross-target compile gate;
- `git diff --check`: passed;
- independent exact-head source review: READY with no actionable findings;
- hosted GitHub Actions: pending.

The earlier writer note saying “18 named mutations” is superseded by the reviewer-verified count above: 19 rows comprise 2 positive and 17 negative cases. These checks establish the checker/test repair; they do not claim upstream uploader runtime behavior.

Current PR head: `fe103db5298a0aae9f097d88a7f4c328c56b57f8`, after merging main `e439d7b7309e7055985263140465c4c97b7a5a29`. The local validation listed above remains attributed to `14b8ef8588556486333d8ad4f2d6ddf5896b40f4`. The independent review was revalidated for the current head through the recorded whole-tree merge equivalence and reviewed-path disjointness checks: [current-head review record](https://github.com/Rul1an/assay/pull/2857#issuecomment-5590531505). Rul1an published the record; codex/Laplace performed the review. Current-head hosted CI is still running; no new local hook result is claimed.
