### PR TITLE
docs(release): freeze the v6.1.0 candidate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ restate or weaken this contract.
 ## Canonical State
 
 - Repository truth is the checked-in code and documentation.
-- The public execution ledger for the active programme is named on this line. **No programme is active.** The previous one, [issue #2764](https://github.com/Rul1an/assay/issues/2764), closed on 2026-09-03.
+- The public execution ledger for the active programme is named on this line: [issue #2863](https://github.com/Rul1an/assay/issues/2863).
 - Keep the number to the ledger line; everywhere else the contract names the role, so the next
   programme costs one edit here rather than one in every section. Name the new ledger there when
   one opens, and say so plainly there when none is active. Nothing enforces that, so it is an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [6.1.0] - 2026-09-08
+## [6.1.0] - 2026-09-09
 
 ### Added
 - Add `assay_evidence` CAP1 relying-party claim-decision APIs for already-conforming
@@ -58,6 +58,12 @@ All notable changes to this project will be documented in this file.
   its replacement content, preventing provenance from the previous value from
   surviving an upsert (#2787, #2805). This is the bounded storage repair; it does
   not introduce the separately planned trace-v7 schema.
+
+### Documentation And Verification
+- Define the deterministic, bounded incident-package v1 contract for future exporters
+  and independent readers (#2853, #2855). The specification fixes original-byte
+  identity, admission, accounting and refusal rules; this release does not implement
+  an incident-package exporter or verifier.
 
 ### Changed
 - The Assay 6.1 source line was opened so post-`v6.0.0` minor-compatible public API work could declare


### PR DESCRIPTION
The Assay 6.1 release candidate did not yet have a current public programme ledger or a final changelog entry for the incident-package v1 specification that landed after the earlier changelog curation. This change binds the active programme to #2863 and freezes the `6.1.0` changelog at the current candidate.

Base: `721b58f760b94ae43bc167a9c2a906e88be548ad`
Head: `0eb5c8006c2bfd2bd9c82fdbd4c9fb34c8c0c849`

Changed paths:
- `AGENTS.md`
- `CHANGELOG.md`

Validation:
- release-blocking gate self-test: PASS
- release-runbook mutation suite: 13 PASS
- release-pin contract: PASS
- tag-tree outward-truth mutations: PASS
- programme-truth contract: PASS
- pre-commit and pre-push hooks including formatting, workspace clippy with warnings denied, and Linux cross-target compile: PASS
- live release gate: expected refusal on open blocker #2864

This PR changes documentation and release coordination only. It does not create a tag, publish packages, change the open state of the release blocker, alter runtime behavior, include PR #2861, or establish installed-user proof. The branch head is not the final merged candidate: the resulting main SHA must receive its own final-candidate checks and exact-head review before the release blocker is resolved.

Programme: #2863
Release blocker: #2864
