### PR TITLE
docs: close the v6.1 programme ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ restate or weaken this contract.
 ## Canonical State
 
 - Repository truth is the checked-in code and documentation.
-- The public execution ledger for the active programme is named on this line: [issue #2863](https://github.com/Rul1an/assay/issues/2863).
+- The public execution ledger for the active programme is named on this line. **No programme is active.** The previous one, [issue #2863](https://github.com/Rul1an/assay/issues/2863), closed on 2026-09-09.
 - Keep the number to the ledger line; everywhere else the contract names the role, so the next
   programme costs one edit here rather than one in every section. Name the new ledger there when
   one opens, and say so plainly there when none is active. Nothing enforces that, so it is an


### PR DESCRIPTION
The v6.1.0 release programme has completed its frozen-candidate publication and separately reviewed install-pin promotion. This one-path transaction changes the canonical agent state from active programme #2863 to no active programme, preserving #2863 as the closed historical ledger.

Exact head: `b74fe388c6af8decdae5a86a19875db08fe78dff`

Validation:
- `bash scripts/ci/test-ci-programme-truth.sh`
- commit and pre-push hooks
- `git diff --check`

This PR contains no product, release, package, workflow or install-surface change.

Closes #2863
