### PR TITLE
release: pin expected PyPI publisher identity

### DIFF
--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -41,6 +41,13 @@ This document outlines the canonical checklist for releasing new versions of Ass
   published tag requires a new version.
 
 ### 2. Permissions Check (Crucial)
+- [ ] **PyPI Trusted Publisher**: In the `assay-it` project Publishing page, require exactly one
+  GitHub publisher: repository `Rul1an/assay`, workflow `release.yml`, environment `pypi`.
+  Remove every other publisher, including the legacy `publish.yml` identity. An empty environment
+  is broader authority and does not match this contract. Before creating a tag, run
+  `python3 scripts/ci/check-release-runbook-truth.py`, compare its expected identity with every
+  owner-visible PyPI publisher row, and retain a redacted receipt containing only the project,
+  repository, workflow, environment, publisher count, observation time, and result.
 - [ ] **Trusted Publishing**: Ensure GitHub Actions OIDC is enabled for the release tag on every current crates.io crate:
   - `assay-common`
   - `assay-registry`

--- a/scripts/ci/check-release-runbook-truth.py
+++ b/scripts/ci/check-release-runbook-truth.py
@@ -146,20 +146,47 @@ def _publish_crates_needs_release(workflow: str) -> bool:
 
 
 def _active_step_uses(job: str) -> list[str]:
-    """Return active direct-step action references from one job mapping."""
-    uses: list[str] = []
+    """Return direct-step actions that have no step-level condition."""
+    step_blocks: list[list[str]] = []
+    current: list[str] = []
+    in_steps = False
     for line in job.splitlines():
         stripped = line.lstrip()
         if not stripped or stripped.startswith("#"):
             continue
         indent = len(line) - len(stripped)
-        if indent == 6 and stripped.startswith("- uses:"):
-            raw = stripped.removeprefix("- uses:")
-        elif indent == 8 and stripped.startswith("uses:"):
-            raw = stripped.removeprefix("uses:")
-        else:
+        if indent == 4 and stripped == "steps:":
+            in_steps = True
             continue
-        uses.append(raw.split(" #", 1)[0].strip(" '\""))
+        if in_steps and indent <= 4:
+            break
+        if not in_steps:
+            continue
+        if indent == 6 and stripped.startswith("- "):
+            if current:
+                step_blocks.append(current)
+            current = [line]
+        elif current and indent > 6:
+            current.append(line)
+    if current:
+        step_blocks.append(current)
+
+    uses: list[str] = []
+    for block in step_blocks:
+        action = ""
+        condition = ""
+        for line in block:
+            stripped = line.strip()
+            if stripped.startswith("- "):
+                stripped = stripped[2:]
+            if stripped.startswith("uses:"):
+                action = stripped.removeprefix("uses:").split(" #", 1)[0].strip(" '\"")
+            elif stripped.startswith("if:"):
+                condition = stripped.removeprefix("if:").split(" #", 1)[0].strip(" '\"")
+        if condition:
+            continue
+        if action:
+            uses.append(action)
     return uses
 
 
@@ -226,7 +253,8 @@ def _optional_lsm_item(docs: str) -> str:
 
 def _pypi_docs_problems(docs: str) -> list[str]:
     try:
-        item = _checklist_item(docs, _PYPI_ITEM_TITLE)
+        visible_docs = re.sub(r"<!--.*?-->", "", docs, flags=re.DOTALL)
+        item = _checklist_item(visible_docs, _PYPI_ITEM_TITLE)
     except AssertionError as exc:
         return [str(exc)]
 

--- a/scripts/ci/check-release-runbook-truth.py
+++ b/scripts/ci/check-release-runbook-truth.py
@@ -2,6 +2,7 @@
 """Docs/workflow contract: release runbook may name only executable release.yml surfaces."""
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
@@ -13,6 +14,11 @@ DOCS = REPO / "docs/reference/release.md"
 _LSM_SMOKE = "lsm-smoke-test"
 _LSM_ITEM_TITLE = "Optional LSM verification"
 _LOCAL_LSM_CMD = "scripts/verify_lsm_docker.sh --release-tag vX.Y.Z"
+_PYPI_ITEM_TITLE = "PyPI Trusted Publisher"
+_PYPI_REPOSITORY = "Rul1an/assay"
+_PYPI_WORKFLOW = "release.yml"
+_PYPI_ENVIRONMENT = "pypi"
+_PYPI_LEGACY_WORKFLOW = "publish.yml"
 _BEFORE_CLAIM = re.compile(
     r"GitHub Release is created before crates publication",
     re.IGNORECASE,
@@ -125,6 +131,33 @@ def _publish_crates_needs_release(workflow: str) -> bool:
     return "release" in _job_needs_ids(job)
 
 
+def _pypi_workflow_problems(workflow: str) -> list[str]:
+    try:
+        jobs = _mapping_block(workflow, "jobs", 0)
+        job = _mapping_block(jobs, "publish-pypi", 2)
+        entries = _child_entries(job)
+    except AssertionError as exc:
+        return [f"release.yml PyPI publisher identity is unavailable ({exc})"]
+
+    problems: list[str] = []
+    environment = entries.get("environment", "").split(" #", 1)[0].strip(" '\"")
+    if environment != _PYPI_ENVIRONMENT:
+        problems.append(
+            f"publish-pypi environment is {environment!r}, expected {_PYPI_ENVIRONMENT!r}"
+        )
+    try:
+        permissions = _child_entries(_mapping_block(job, "permissions", 4))
+    except AssertionError as exc:
+        problems.append(f"publish-pypi permissions are unavailable ({exc})")
+    else:
+        id_token = permissions.get("id-token", "").split(" #", 1)[0].strip(" '\"")
+        if id_token != "write":
+            problems.append("publish-pypi does not grant id-token: write")
+    if "pypa/gh-action-pypi-publish@" not in job:
+        problems.append("publish-pypi does not invoke the PyPI trusted-publishing action")
+    return problems
+
+
 def _watch_ci(docs: str) -> str:
     start = docs.find("**Watch CI**")
     if start < 0:
@@ -147,7 +180,7 @@ def _checklist_item(docs: str, title: str) -> str:
     lines = docs[start:].splitlines(keepends=True)
     collected = [lines[0]]
     for line in lines[1:]:
-        if line.startswith("- ") or line.startswith("#"):
+        if line.startswith(("- ", "#")):
             break
         collected.append(line)
     return "".join(collected)
@@ -155,6 +188,38 @@ def _checklist_item(docs: str, title: str) -> str:
 
 def _optional_lsm_item(docs: str) -> str:
     return _checklist_item(docs, _LSM_ITEM_TITLE)
+
+
+def _pypi_docs_problems(docs: str) -> list[str]:
+    try:
+        item = _checklist_item(docs, _PYPI_ITEM_TITLE)
+    except AssertionError as exc:
+        return [str(exc)]
+
+    problems: list[str] = []
+    required_literals = (
+        f"`{_PYPI_REPOSITORY}`",
+        f"`{_PYPI_WORKFLOW}`",
+        f"`{_PYPI_ENVIRONMENT}`",
+        f"`{_PYPI_LEGACY_WORKFLOW}`",
+    )
+    for literal in required_literals:
+        if literal not in item:
+            problems.append(f"PyPI Trusted Publisher item omits {literal}")
+    lowered = item.lower()
+    if "exactly one" not in lowered:
+        problems.append("PyPI Trusted Publisher item does not require exactly one publisher")
+    if "remove" not in lowered:
+        problems.append("PyPI Trusted Publisher item does not require stale publishers to be removed")
+    if "empty environment" not in lowered:
+        problems.append("PyPI Trusted Publisher item does not reject an empty environment")
+    if "owner-visible" not in lowered or "redacted receipt" not in lowered:
+        problems.append("PyPI Trusted Publisher item omits the redacted owner-visible receipt")
+    return problems
+
+
+def _pypi_publisher_problems(workflow: str, docs: str) -> list[str]:
+    return _pypi_workflow_problems(workflow) + _pypi_docs_problems(docs)
 
 
 def _bullet_mentions_github_release(line: str) -> bool:
@@ -260,7 +325,11 @@ def _docs_problems(docs: str) -> list[str]:
 
 
 def contract_problems(workflow: str, docs: str) -> list[str]:
-    return _workflow_problems(workflow) + _docs_problems(docs)
+    return (
+        _workflow_problems(workflow)
+        + _docs_problems(docs)
+        + _pypi_publisher_problems(workflow, docs)
+    )
 
 
 def main() -> int:
@@ -276,6 +345,19 @@ def main() -> int:
             print(f"FAIL: {problem}", file=sys.stderr)
         return 1
     print("ok   release runbook matches executable release.yml")
+    print(
+        "expected_pypi_trusted_publisher="
+        + json.dumps(
+            {
+                "environment": _PYPI_ENVIRONMENT,
+                "publisher_count": 1,
+                "repository": _PYPI_REPOSITORY,
+                "workflow": _PYPI_WORKFLOW,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
     return 0
 
 

--- a/scripts/ci/check-release-runbook-truth.py
+++ b/scripts/ci/check-release-runbook-truth.py
@@ -19,6 +19,20 @@ _PYPI_REPOSITORY = "Rul1an/assay"
 _PYPI_WORKFLOW = "release.yml"
 _PYPI_ENVIRONMENT = "pypi"
 _PYPI_LEGACY_WORKFLOW = "publish.yml"
+_PYPI_PUBLISH_ACTION = (
+    "pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33"
+)
+_PYPI_LEGACY_REMOVAL_SENTENCE = (
+    "Remove every other publisher, including the legacy `publish.yml` identity."
+)
+_PYPI_SINGLE_PUBLISHER_SENTENCE = (
+    "In the `assay-it` project Publishing page, require exactly one GitHub publisher: "
+    "repository `Rul1an/assay`, "
+    "workflow `release.yml`, environment `pypi`."
+)
+_PYPI_EMPTY_ENVIRONMENT_SENTENCE = (
+    "An empty environment is broader authority and does not match this contract."
+)
 _BEFORE_CLAIM = re.compile(
     r"GitHub Release is created before crates publication",
     re.IGNORECASE,
@@ -131,6 +145,24 @@ def _publish_crates_needs_release(workflow: str) -> bool:
     return "release" in _job_needs_ids(job)
 
 
+def _active_step_uses(job: str) -> list[str]:
+    """Return active direct-step action references from one job mapping."""
+    uses: list[str] = []
+    for line in job.splitlines():
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(stripped)
+        if indent == 6 and stripped.startswith("- uses:"):
+            raw = stripped.removeprefix("- uses:")
+        elif indent == 8 and stripped.startswith("uses:"):
+            raw = stripped.removeprefix("uses:")
+        else:
+            continue
+        uses.append(raw.split(" #", 1)[0].strip(" '\""))
+    return uses
+
+
 def _pypi_workflow_problems(workflow: str) -> list[str]:
     try:
         jobs = _mapping_block(workflow, "jobs", 0)
@@ -153,8 +185,10 @@ def _pypi_workflow_problems(workflow: str) -> list[str]:
         id_token = permissions.get("id-token", "").split(" #", 1)[0].strip(" '\"")
         if id_token != "write":
             problems.append("publish-pypi does not grant id-token: write")
-    if "pypa/gh-action-pypi-publish@" not in job:
-        problems.append("publish-pypi does not invoke the PyPI trusted-publishing action")
+    if _active_step_uses(job).count(_PYPI_PUBLISH_ACTION) != 1:
+        problems.append(
+            "publish-pypi does not invoke the pinned PyPI trusted-publishing action exactly once"
+        )
     return problems
 
 
@@ -206,12 +240,15 @@ def _pypi_docs_problems(docs: str) -> list[str]:
     for literal in required_literals:
         if literal not in item:
             problems.append(f"PyPI Trusted Publisher item omits {literal}")
-    lowered = item.lower()
-    if "exactly one" not in lowered:
+    normalized = " ".join(item.split())
+    lowered = normalized.lower()
+    if _PYPI_SINGLE_PUBLISHER_SENTENCE not in normalized:
         problems.append("PyPI Trusted Publisher item does not require exactly one publisher")
-    if "remove" not in lowered:
-        problems.append("PyPI Trusted Publisher item does not require stale publishers to be removed")
-    if "empty environment" not in lowered:
+    if _PYPI_LEGACY_REMOVAL_SENTENCE not in normalized:
+        problems.append(
+            "PyPI Trusted Publisher item does not require removal of the legacy publish.yml publisher"
+        )
+    if _PYPI_EMPTY_ENVIRONMENT_SENTENCE not in normalized:
         problems.append("PyPI Trusted Publisher item does not reject an empty environment")
     if "owner-visible" not in lowered or "redacted receipt" not in lowered:
         problems.append("PyPI Trusted Publisher item omits the redacted owner-visible receipt")

--- a/scripts/ci/check-release-runbook-truth.py
+++ b/scripts/ci/check-release-runbook-truth.py
@@ -176,13 +176,23 @@ def _active_step_uses(job: str) -> list[str]:
         action = ""
         condition = ""
         for line in block:
-            stripped = line.strip()
-            if stripped.startswith("- "):
-                stripped = stripped[2:]
-            if stripped.startswith("uses:"):
-                action = stripped.removeprefix("uses:").split(" #", 1)[0].strip(" '\"")
-            elif stripped.startswith("if:"):
-                condition = stripped.removeprefix("if:").split(" #", 1)[0].strip(" '\"")
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+            if indent == 6 and stripped.startswith("- "):
+                direct = stripped[2:]
+            elif indent == 8:
+                direct = stripped
+            else:
+                continue
+            match = re.match(r"^([^:]+?)\s*:\s*(.*)$", direct)
+            if match is None:
+                continue
+            key = match.group(1).strip().strip("'\"")
+            value = match.group(2).split(" #", 1)[0].strip(" '\"")
+            if key == "uses":
+                action = value
+            elif key == "if":
+                condition = value
         if condition:
             continue
         if action:

--- a/scripts/ci/test-release-runbook-truth.py
+++ b/scripts/ci/test-release-runbook-truth.py
@@ -132,6 +132,35 @@ class ReleaseRunbookTruthMutations(unittest.TestCase):
         item = contract._optional_lsm_item(mutated)
         self.assertNotIn("not a stable-release requirement", item.lower())
 
+    def test_pypi_publisher_expectation_matches_release_job(self) -> None:
+        self.assertEqual(
+            contract._pypi_publisher_problems(self.workflow, self.docs), []
+        )
+
+    def test_pypi_environment_drift_bites(self) -> None:
+        mutated = replace_once(
+            self.workflow,
+            "    environment: pypi\n",
+            "    environment: release\n",
+        )
+        self.assert_mutation_bites(workflow=mutated)
+
+    def test_runbook_allows_no_legacy_publisher(self) -> None:
+        item = contract._checklist_item(self.docs, "PyPI Trusted Publisher")
+        self.assertIn("exactly one", item)
+        self.assertIn("`Rul1an/assay`", item)
+        self.assertIn("`release.yml`", item)
+        self.assertIn("`pypi`", item)
+        self.assertIn("`publish.yml`", item)
+        self.assertIn("Remove", item)
+
+    def test_pypi_identity_outside_checklist_item_does_not_count(self) -> None:
+        item = contract._checklist_item(self.docs, "PyPI Trusted Publisher")
+        mutated = self.docs.replace("`Rul1an/assay`", "`wrong/repository`", 1)
+        mutated += "\n`Rul1an/assay` remains the expected repository.\n"
+        self.assertNotEqual(item, contract._checklist_item(mutated, "PyPI Trusted Publisher"))
+        self.assert_mutation_bites(docs=mutated)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/ci/test-release-runbook-truth.py
+++ b/scripts/ci/test-release-runbook-truth.py
@@ -181,6 +181,27 @@ class ReleaseRunbookTruthMutations(unittest.TestCase):
         )
         self.assert_mutation_bites(workflow=mutated)
 
+    def test_pypi_publish_action_with_spaced_if_key_does_not_count(self) -> None:
+        mutated = replace_once(
+            self.workflow,
+            "      - name: Publish to PyPI\n"
+            "        uses: pypa/gh-action-pypi-publish@",
+            "      - name: Publish to PyPI\n"
+            "        if : ${{ false }}\n"
+            "        uses: pypa/gh-action-pypi-publish@",
+        )
+        self.assert_mutation_bites(workflow=mutated)
+
+    def test_nested_uses_does_not_count_as_step_action(self) -> None:
+        mutated = replace_once(
+            self.workflow,
+            "        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2\n",
+            "        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b\n"
+            "        env:\n"
+            "          uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33\n",
+        )
+        self.assert_mutation_bites(workflow=mutated)
+
     def test_runbook_allows_no_legacy_publisher(self) -> None:
         item = contract._checklist_item(self.docs, "PyPI Trusted Publisher")
         self.assertIn("exactly one", item)

--- a/scripts/ci/test-release-runbook-truth.py
+++ b/scripts/ci/test-release-runbook-truth.py
@@ -145,6 +145,31 @@ class ReleaseRunbookTruthMutations(unittest.TestCase):
         )
         self.assert_mutation_bites(workflow=mutated)
 
+    def test_pypi_publish_action_removed_bites(self) -> None:
+        mutated = replace_once(
+            self.workflow,
+            "        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2\n",
+            "        run: python3 -m twine upload dist/*\n",
+        )
+        self.assert_mutation_bites(workflow=mutated)
+
+    def test_pypi_publish_action_in_a_comment_does_not_count(self) -> None:
+        mutated = replace_once(
+            self.workflow,
+            "        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2\n",
+            "        # uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33\n"
+            "        run: python3 -m twine upload dist/*\n",
+        )
+        self.assert_mutation_bites(workflow=mutated)
+
+    def test_pypi_publish_action_mutable_ref_bites(self) -> None:
+        mutated = replace_once(
+            self.workflow,
+            "pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33",
+            "pypa/gh-action-pypi-publish@main",
+        )
+        self.assert_mutation_bites(workflow=mutated)
+
     def test_runbook_allows_no_legacy_publisher(self) -> None:
         item = contract._checklist_item(self.docs, "PyPI Trusted Publisher")
         self.assertIn("exactly one", item)
@@ -153,6 +178,30 @@ class ReleaseRunbookTruthMutations(unittest.TestCase):
         self.assertIn("`pypi`", item)
         self.assertIn("`publish.yml`", item)
         self.assertIn("Remove", item)
+
+    def test_runbook_that_keeps_publish_yml_bites_despite_remove_words(self) -> None:
+        mutated = replace_once(
+            self.docs,
+            "  Remove every other publisher, including the legacy `publish.yml` identity. An empty environment\n",
+            "  Keep the legacy `publish.yml` publisher. Remove only unrelated publishers. An empty environment\n",
+        )
+        self.assert_mutation_bites(docs=mutated)
+
+    def test_runbook_that_denies_exactly_one_bites(self) -> None:
+        mutated = replace_once(
+            self.docs,
+            "require exactly one\n  GitHub publisher",
+            "do not require exactly one\n  GitHub publisher",
+        )
+        self.assert_mutation_bites(docs=mutated)
+
+    def test_runbook_that_accepts_empty_environment_bites(self) -> None:
+        mutated = replace_once(
+            self.docs,
+            "An empty environment\n  is broader authority and does not match this contract.",
+            "An empty environment\n  is broader authority and matches this contract.",
+        )
+        self.assert_mutation_bites(docs=mutated)
 
     def test_pypi_identity_outside_checklist_item_does_not_count(self) -> None:
         item = contract._checklist_item(self.docs, "PyPI Trusted Publisher")

--- a/scripts/ci/test-release-runbook-truth.py
+++ b/scripts/ci/test-release-runbook-truth.py
@@ -170,6 +170,17 @@ class ReleaseRunbookTruthMutations(unittest.TestCase):
         )
         self.assert_mutation_bites(workflow=mutated)
 
+    def test_pypi_publish_action_in_disabled_step_does_not_count(self) -> None:
+        mutated = replace_once(
+            self.workflow,
+            "      - name: Publish to PyPI\n"
+            "        uses: pypa/gh-action-pypi-publish@",
+            "      - name: Publish to PyPI\n"
+            "        if: ${{ false }}\n"
+            "        uses: pypa/gh-action-pypi-publish@",
+        )
+        self.assert_mutation_bites(workflow=mutated)
+
     def test_runbook_allows_no_legacy_publisher(self) -> None:
         item = contract._checklist_item(self.docs, "PyPI Trusted Publisher")
         self.assertIn("exactly one", item)
@@ -201,6 +212,21 @@ class ReleaseRunbookTruthMutations(unittest.TestCase):
             "An empty environment\n  is broader authority and does not match this contract.",
             "An empty environment\n  is broader authority and matches this contract.",
         )
+        self.assert_mutation_bites(docs=mutated)
+
+    def test_hidden_runbook_contract_does_not_count(self) -> None:
+        item = contract._checklist_item(self.docs, "PyPI Trusted Publisher")
+        opposite = item.replace(
+            "require exactly one\n  GitHub publisher",
+            "do not require exactly one\n  GitHub publisher",
+        ).replace(
+            "Remove every other publisher, including the legacy `publish.yml` identity.",
+            "Keep the legacy `publish.yml` publisher.",
+        ).replace(
+            "does not match this contract",
+            "matches this contract",
+        )
+        mutated = self.docs.replace(item, f"{opposite}\n  <!-- {item} -->")
         self.assert_mutation_bites(docs=mutated)
 
     def test_pypi_identity_outside_checklist_item_does_not_count(self) -> None:


### PR DESCRIPTION
Part of #2866.

The release preflight derives the expected PyPI Trusted Publisher identity from the current release workflow and prints it as one machine-readable JSON line. The owner runbook requires exactly one publisher for `Rul1an/assay`, workflow `release.yml`, environment `pypi`; it states that an empty environment grants broader authority and that the stale `publish.yml` record must be removed.

Verification at `4e72b52dde211635a5c34808e57a2a90cb0c9343`:

- release-runbook mutation suite: 27/27 PASS
- release-runbook checker: PASS, exact expected identity emitted
- relevant pre-commit hook: PASS
- full pre-push policy set: PASS, including cargo fmt, clippy and the cross-target compile gate
- Python compile and `git diff --check`: PASS
- mutation evidence: removal, comment-only substitution, and mutable-ref substitution of the PyPI action all fail; keeping the legacy publisher, denying the exactly-one rule, and accepting an empty environment all fail; a step-level condition, a spaced `if :` key, a nested `env.uses`, and contract text hidden in an HTML comment also fail; no-op comments remain green

The active workflow already uses job-level `id-token: write`, environment `pypi`, and the pinned PyPA publishing action. This PR does not claim that repository source can inspect PyPI settings. The owner-visible PyPI update and redacted receipt remain separate completion steps for #2866.
