### PR TITLE
test(ci): close required-job skip and count false-greens

### DIFF
--- a/scripts/ci/test-ci-gate-expectations.sh
+++ b/scripts/ci/test-ci-gate-expectations.sh
@@ -225,7 +225,7 @@ echo "ok: a documentation-only run passes with its jobs scoped out"
 
 # The defect: a code-bearing run where a job that should have executed did not. Before this change
 # every one of these was green.
-for job in DEPS_SECURITY CLIPPY RUSTDOC PUBLIC_MSRV PERF TEST; do
+for job in DEPS_SECURITY CLIPPY RUSTDOC PUBLIC_MSRV PERF TEST EVIDENCEREF_LIVE_RESOLVE; do
   out="$(run_gate fail "silently skipped $job" \
     SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok RUSTDOC_RESULT=$ok \
     PUBLIC_MSRV_RESULT=$ok \
@@ -235,6 +235,11 @@ for job in DEPS_SECURITY CLIPPY RUSTDOC PUBLIC_MSRV PERF TEST; do
     "${job}_RESULT=skipped")"
   grep -qi "was skipped, but this run required it" <<<"$out" \
     || fail "$job skipped: the gate failed, but not for the skip — got: $out"
+  # The reason alone does not say which job produced it, so a gate that named the wrong one — or
+  # failed over some other row entirely — read as clean here. The env-var prefix maps to the job id.
+  expected_name="$(printf '%s' "$job" | tr 'A-Z_' 'a-z-')"
+  grep -q "$expected_name was skipped" <<<"$out" \
+    || fail "$job skipped: the gate failed for a skip, but did not name $expected_name — got: $out"
 done
 echo "ok: a code-gated job that silently did not run fails the gate, and is named"
 

--- a/scripts/ci/test-ci-gate-expectations.sh
+++ b/scripts/ci/test-ci-gate-expectations.sh
@@ -21,6 +21,20 @@ fail() {
   exit 1
 }
 
+# Both skip loops assert the same two things about one gate run: that it failed *for the skip*,
+# and that it named the job under test. The name half is matched with -F against the emitted
+# `::error::<name> was skipped` prefix, not as a bare substring: an unanchored match accepted a
+# gate that printed `zz-deps-security` while claiming to check `deps-security`, and would accept
+# a future job id that merely ends with an existing one.
+assert_named_skip() {
+  local job="$1" out="$2" name
+  name="$(printf '%s' "$job" | tr 'A-Z_' 'a-z-')"
+  grep -qi "was skipped, but this run required it" <<<"$out" \
+    || fail "$job skipped: the gate failed, but not for the skip — got: $out"
+  grep -qF -- "::error::${name} was skipped" <<<"$out" \
+    || fail "$job skipped: the gate failed for a skip, but did not name $name — got: $out"
+}
+
 # Pull the gate's `run:` body out of the workflow: everything between the "Evaluate required job
 # results" step's `run: |` and the end of that block. Indentation-based, which is what YAML gives.
 extract_gate() {
@@ -225,7 +239,7 @@ echo "ok: a documentation-only run passes with its jobs scoped out"
 
 # The defect: a code-bearing run where a job that should have executed did not. Before this change
 # every one of these was green.
-for job in DEPS_SECURITY CLIPPY RUSTDOC PUBLIC_MSRV PERF TEST EVIDENCEREF_LIVE_RESOLVE; do
+for job in DEPS_SECURITY CLIPPY RUSTDOC PUBLIC_MSRV PERF TEST; do
   out="$(run_gate fail "silently skipped $job" \
     SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok RUSTDOC_RESULT=$ok \
     PUBLIC_MSRV_RESULT=$ok \
@@ -233,13 +247,7 @@ for job in DEPS_SECURITY CLIPPY RUSTDOC PUBLIC_MSRV PERF TEST EVIDENCEREF_LIVE_R
     MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
     EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false \
     "${job}_RESULT=skipped")"
-  grep -qi "was skipped, but this run required it" <<<"$out" \
-    || fail "$job skipped: the gate failed, but not for the skip — got: $out"
-  # The reason alone does not say which job produced it, so a gate that named the wrong one — or
-  # failed over some other row entirely — read as clean here. The env-var prefix maps to the job id.
-  expected_name="$(printf '%s' "$job" | tr 'A-Z_' 'a-z-')"
-  grep -q "$expected_name was skipped" <<<"$out" \
-    || fail "$job skipped: the gate failed for a skip, but did not name $expected_name — got: $out"
+  assert_named_skip "$job" "$out"
 done
 echo "ok: a code-gated job that silently did not run fails the gate, and is named"
 
@@ -281,7 +289,8 @@ echo "ok: mcp-registry-foundation skipped while touched fails the gate"
 # Unconditional jobs may never be skipped, whatever the scope says. `publish-shape-cli` and
 # `public-crate-policy` join the list with #2230: both were outside `needs:` entirely, so the gate
 # had no opinion about them at all, skipped or failed.
-for job in DISTRIBUTION_BOUNDARY VENDORED_PACKS RELEASE_ASSET_CONTRACT PUBLISH_SHAPE_CLI PUBLIC_CRATE_POLICY; do
+for job in DISTRIBUTION_BOUNDARY VENDORED_PACKS RELEASE_ASSET_CONTRACT PUBLISH_SHAPE_CLI PUBLIC_CRATE_POLICY \
+  EVIDENCEREF_LIVE_RESOLVE; do
   out="$(run_gate fail "unconditional $job skipped" \
     SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=true DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped RUSTDOC_RESULT=skipped \
     PUBLIC_MSRV_RESULT=skipped \
@@ -289,8 +298,7 @@ for job in DISTRIBUTION_BOUNDARY VENDORED_PACKS RELEASE_ASSET_CONTRACT PUBLISH_S
     MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=skipped TEST_RESULT=skipped \
     EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false \
     "${job}_RESULT=skipped")"
-  grep -qi "was skipped, but this run required it" <<<"$out" \
-    || fail "$job: expected the unconditional-skip message, got: $out"
+  assert_named_skip "$job" "$out"
 done
 echo "ok: a job with no condition may not be skipped even on a docs-only run"
 

--- a/scripts/ci/test-ci-job-timeouts-contract.sh
+++ b/scripts/ci/test-ci-job-timeouts-contract.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Contract for evidence-based timeout-minutes on every job in .github/workflows/ci.yml (CI-5B / #2244).
 #
-# Fourteen jobs inherited GitHub's 360-minute default. This gate pins the complete 16-job set and
+# Fourteen jobs inherited GitHub's 360-minute default. This gate pins the complete job set and
 # the per-job timeout class so a missing ceiling, a wrong class, or a restored 360 cannot stay green.
+# The set size is reported from `expected`, never restated: the literal said 16 against a map of 17
+# for as long as it took someone to read it.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -53,7 +55,7 @@ unless actual_ids == expected_ids
   missing = expected_ids - actual_ids
   extra = actual_ids - expected_ids
   abort(
-    "ci.yml job set drifted from the pinned 16-job contract; " \
+    "ci.yml job set drifted from the pinned #{expected.size}-job contract; " \
     "missing=#{missing.inspect} extra=#{extra.inspect}"
   )
 end
@@ -102,7 +104,7 @@ unless rollup["if"] == "always()"
   abort "CI rollup must stay fail-closed with if: always(); got #{rollup['if'].inspect}"
 end
 
-puts "ci-job-timeouts contract=passed (16 jobs; rollup bounded at 10m)"
+puts "ci-job-timeouts contract=passed (#{expected.size} jobs; rollup bounded at 10m)"
 RUBY
 }
 


### PR DESCRIPTION
## Problem and resulting behavior

The `evidenceref-live-resolve` job was added to the required CI rollup in #2861, but its expectation test exercised only the generic `failure` arm. The gate's per-row `case` has three arms, and the `skipped` one is what a broken `if:` condition actually produces, so that arm was unreached for this row.

**Correction to an earlier version of this description.** It said that changing the row from `required` to `optional` left the contract green, and offered that as the gap being closed. That is true of this test script alone but false as a statement about the merge: `check-ci-gate-coverage.py:316` rejects a non-computed expectation, and that guard runs inside the required `CI` job at `ci.yml:1181`. The merge was never open on that mutation. The honest delta is narrower and is the *behaviour of the skipped arm* for this row, which no static guard reads. A gate patched to ignore this job in that arm passed the coverage guard, the timeout contract and the base test, and fails here.

An adversarial review of `70b4be72f` then found two more, both reproduced before being fixed:

- The name assertion failed open. It matched `<name> was skipped` as a bare substring, so a gate emitting `zz-deps-security` satisfied an assertion claiming to check `deps-security`. Matched with `-F` against the `::error::<name> was skipped` prefix now. The same shape would accept a future job id ending with an existing one, and two plausible candidates exist already (`msrv` beside `public-msrv`, `smoke-test` beside `test`).
- The job was in the wrong loop. It has no `if:` and carries the literal `required` expectation, making it structurally unconditional rather than code-gated. In the code-gated loop it was never run with `LIGHTWEIGHT_ONLY=true`, so a gate silently exempting it on a docs-only run passed everything. It is in the unconditional loop now, which pins the stronger property.

Both loops now call one `assert_named_skip` rather than each carrying its own copy of the two greps.

## Scope

- `scripts/ci/test-ci-gate-expectations.sh`
- `scripts/ci/test-ci-job-timeouts-contract.sh`

No workflow behaviour and no product runtime code changes.

**What these two scripts gate.** They are invoked from `.pre-commit-config.yaml` and are not run by `ci.yml`. They reach CI only through `pre-commit run --all-files` in the `Lint (pre-commit)` job, which is not among the required contexts (`CI`, `host-capability-check`, `lane-check/proof`, `review-record-check`). So this PR strengthens a contract that does not itself block a merge. That is pre-existing and not introduced here, but it bounds what the change buys and is worth stating rather than leaving a reader to assume otherwise.

## Verification at `7c166e7d9f13bd518eb4085bf85b47e57808b048`

- CI gate expectations: pass
- CI job-timeout contract: pass, 17 jobs; `--self-test` pass
- CI gate coverage: pass
- `shellcheck` on the changed script: clean
- Mutation, exempting the job on a docs-only run: green before the loop move, red after
- Mutation, gate emits a prefixed wrong name: green before anchoring, red after
- Mutation, skipped arm ignores the job outright: red, and green against the base script
- Removing one timeout-map entry changes the derived count, so the number is not restated
- Full pre-commit and pre-push chains: pass

Note on reading a red run: `fail()` exits, so the loops are first-failure-wins. A failing run evidences one case; only a green run evidences all of them.

The branch author has not written a READY review record and will not. `assay_review_record_check.py:155` rejects a record whose builder and reviewer match, so the gate is unsatisfiable by this branch's author by construction. An exact-head review by someone else, plus the normal required checks, remain required before landing.
