### PR TITLE
docs: state that the assay-sim Quick tier is not wired as a CI gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ domain's reading of it.
 
 ## assay-sim (Attack Simulation)
 
-Suite tiers: `Quick` (<30s, PR gate), `Nightly` (5-15 min), `Stress`, `Chaos` (long-running).
+Suite tiers: `Quick` (<30s; intended as a PR gate, not invoked by any workflow as of 2026-09, see #2174), `Nightly` (5-15 min), `Stress`, `Chaos` (long-running).
 
 ```
 assay sim run --suite quick --seed 42 --target bundle.tar.gz --report sim.json


### PR DESCRIPTION
## Summary

One-line documentation fix to `CLAUDE.md`. The assay-sim tier list described `Quick` as a "PR gate". Nothing wires it as one.

Verified on main `df7a54ff2d7d3ce7f439d1442e0fee30aaa4ccc8` and re-verified before this edit:

- No workflow under `.github/workflows/` invokes `assay sim run`.
- The only `scripts/ci` reference is `test-adr025-closure-evaluate.sh:21`, which calls `assay sim soak`.
- `kernel-matrix.yml:17` names `crates/assay-sim/**` only as a path filter.
- The crate's unit tests run inside the workspace test job. The suite runner itself is not a gate on any required context (`CI`, `host-capability-check`, `lane-check/proof`, `review-record-check`, per `.github/rulesets/main-required-ci-contexts.json`).

The line now reads: `Quick` (<30s; intended as a PR gate, not invoked by any workflow as of 2026-09, see #2174). The other tiers are unchanged.

## Scope

- Docs only. No workflow added, `ci.yml` untouched, `crates/assay-sim` untouched.
- Wiring the suite as a gate is the decision owned by #2174, not this PR.

Refs #2174

🤖 Generated with [Claude Code](https://claude.com/claude-code)
