### PR TITLE
docs: correct the assay-sim Quick tier's CI status and time budget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ domain's reading of it.
 
 ## assay-sim (Attack Simulation)
 
-Suite tiers: `Quick` (<30s, PR gate), `Nightly` (5-15 min), `Stress`, `Chaos` (long-running).
+Suite tiers: `Quick` (<30s; not wired as a CI gate by any workflow as of 2026-09, see #2174), `Nightly` (5-15 min), `Stress`, `Chaos` (long-running).
 
 ```
 assay sim run --suite quick --seed 42 --target bundle.tar.gz --report sim.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,14 +168,17 @@ domain's reading of it.
 
 ## assay-sim (Attack Simulation)
 
-Suite tiers: `Quick`, `Nightly` (5-15 min), `Stress`, `Chaos` (long-running). The default suite
-time budget is 60s (`TimeBudget::default_suite`), raised from 30s because the zip bomb attack can
-exceed 30s on slow CI runners.
+Suite tiers: `Quick` (<30s on typical runners), `Nightly` (5-15 min), `Stress`, `Chaos`
+(long-running). A run's time budget is 60s by default (`--time-budget`,
+`crates/assay-cli/src/cli/args/sim.rs`) and applies per run, not per tier;
+`crates/assay-sim/src/suite.rs` records that 60s was raised from 30s because the zip bomb attack
+can exceed 30s on slow CI runners.
 
-The Quick tier gates pull requests, though no workflow invokes `assay sim run`. `test_quick_suite`
-(`crates/assay-sim/src/lib.rs`) runs the suite under `cargo test --workspace` and fails when any
-attack bypasses verification, and that job feeds the required `CI` context. Codifying the tiers as
-explicit gates is tracked in #2174.
+The Quick tier gates every pull request that touches code, though no workflow invokes
+`assay sim run`. `test_quick_suite` (`crates/assay-sim/src/lib.rs`) runs the suite under
+`cargo test --workspace` and fails when any attack bypasses verification, and that job feeds the
+required `CI` context. It is skipped for docs-only changes, which carry no code the suite could
+exercise. Codifying the tiers as explicit gates is tracked in #2174.
 
 ```
 assay sim run --suite quick --seed 42 --target bundle.tar.gz --report sim.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,14 @@ domain's reading of it.
 
 ## assay-sim (Attack Simulation)
 
-Suite tiers: `Quick` (<30s; not wired as a CI gate by any workflow as of 2026-09, see #2174), `Nightly` (5-15 min), `Stress`, `Chaos` (long-running).
+Suite tiers: `Quick`, `Nightly` (5-15 min), `Stress`, `Chaos` (long-running). The default suite
+time budget is 60s (`TimeBudget::default_suite`), raised from 30s because the zip bomb attack can
+exceed 30s on slow CI runners.
+
+The Quick tier gates pull requests, though no workflow invokes `assay sim run`. `test_quick_suite`
+(`crates/assay-sim/src/lib.rs`) runs the suite under `cargo test --workspace` and fails when any
+attack bypasses verification, and that job feeds the required `CI` context. Codifying the tiers as
+explicit gates is tracked in #2174.
 
 ```
 assay sim run --suite quick --seed 42 --target bundle.tar.gz --report sim.json


### PR DESCRIPTION
## Summary

`CLAUDE.md` described the assay-sim `Quick` tier as a "PR gate". An earlier revision of this PR replaced that with "not wired as a CI gate by any workflow". Both were wrong, in opposite directions. Two independent reviews shaped what the line says now.

The Quick tier **does** gate pull requests that touch code:

- `test_quick_suite` (`crates/assay-sim/src/lib.rs:18`) builds `SuiteConfig { tier: SuiteTier::Quick, .. }`, runs the suite, and asserts `summary.bypassed == 0` and `summary.blocked >= 1`.
- `.github/workflows/ci.yml:745` runs `cargo test --locked --workspace --exclude assay-ebpf --exclude assay-it`, which does not exclude `assay-sim`.
- That step lives in job `test`, which is in the `needs` list of job `ci`, whose name is `CI`.
- `CI` is an active required status check in `.github/rulesets/main-required-ci-contexts.json`.

The qualifier is load-bearing and the line carries it: job `test` is skipped when `lightweight_only` is true, which `scripts/ci/classify-lightweight-changes.sh` sets for docs-only changes. That class carries no code the suite could exercise, so the exception is empty of risk, but the line states it rather than omitting it. What stays narrowly true is that no workflow step invokes `assay sim run`.

Two further corrections came out of review:

- The time budget is cited at the path that sets it. `TimeBudget::default_suite` has no callers anywhere in the tree; the live default is clap's `default_value = "60"` on `--time-budget` in `crates/assay-cli/src/cli/args/sim.rs`, threaded through `commands/sim.rs` into `SuiteConfig::time_budget_secs`. The line also says the budget applies per run rather than per tier, which is what `suite.rs` does: it builds the budget unconditionally, with no match on the tier.
- `<30s` is restored to the Quick entry, qualified as typical-runner behaviour. Deleting it had dropped a fact `docs/architecture/ADR-024-Sim-Engine-Hardening.md:96` still records. A ~30s expected runtime under a 60s budget is coherent.

## Scope

- Docs only. No workflow added, `ci.yml` untouched, `crates/assay-sim` untouched.
- Codifying the tiers as explicit gates stays owned by #2174, not this PR.

Refs #2174

🤖 Generated with [Claude Code](https://claude.com/claude-code)
