### PR TITLE
fix(mcp): drop strategy wording from the E_TOOL_DRIFT deny contract reason

### DIFF
--- a/crates/assay-core/src/mcp/policy/engine_next/fail_closed.rs
+++ b/crates/assay-core/src/mcp/policy/engine_next/fail_closed.rs
@@ -26,7 +26,7 @@ pub(in crate::mcp::policy) fn tool_drift_decision(
         contract: format_deny_contract(
             tool_name,
             "E_TOOL_DRIFT",
-            "Tool metadata or schema has changed without policy update (SOTA Moat)",
+            "Tool metadata or schema has changed without policy update",
         ),
     })
 }


### PR DESCRIPTION
## What

One-line change in `crates/assay-core/src/mcp/policy/engine_next/fail_closed.rs`: the reason string inside the `E_TOOL_DRIFT` deny contract loses a parenthetical of internal strategy language. AGENTS.md asks public strings to stay free of such language, and this repository is public.

## Why this is a wire-visible change, not a dead-string cleanup

The `contract` field of `PolicyDecision::Deny` is read on the proxy-client path. `proxy/client/branches.rs` destructures it and passes it to `make_deny_response`, which emits it as `structuredContent.reason` in the JSON-RPC deny result sent to the MCP client. For a non-dry-run tool-drift deny, the client now sees the shorter reason string. The same branch also writes the whole contract into the audit-log JSONL under the `agentic` field, in both enforce and dry-run mode, so that record carries the shorter string too. No code in the workspace reads that field back, and no digest or decision event is computed over the contract.

Unchanged: the `E_TOOL_DRIFT` code, the decision's own `reason` field, decision events (which take only that `reason`), and every other behaviour. The tool-call-handler path discards the field (`contract: _`), and `assay-mcp-server`'s `check_args` only reads a `violations` key the drift contract does not carry.

## Verification

- A repository-wide grep for the removed wording across `crates/`, `tests/`, `scripts/`, and `docs/` matched only the one source line before the change and nothing after. No test or fixture pins the old text.
- `cargo test -p assay-core mcp::policy`: 28 passed in the lib target.
- Pre-commit (including typos) and pre-push hooks passed on this head.
- Independent adversarial review on this head: verdict READY, two observations. The audit-log surface above was the first; the second is that no test pins the drift contract's `reason` on the wire, which is pre-existing and recorded as a follow-up rather than fixed here, so the reviewed head stays the merge head.

Refs #2232. Unrelated to the open coverage decision there and not to be folded into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





**Exact head**: `e0d16dd2d98c2125844010715f5bfafe3d14ddaa`



**Exact head**: `829ace95f1ff549835f25082f6c9741ef4c53f40`
