### PR TITLE
docs: state the shipped attestation as an in-toto v1 Statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Released surfaces:
 | **External receipts** | Eval outcomes, runtime decisions, and model inventory as bounded receipts with JSON Schema contracts. |
 | **Tool-decision surface** | Each privileged `tools/call` recorded as `assay.tool_decision_surface.v0` — sensitive ids hashed, raw arguments never stored. |
 | **SARIF / CI** | GitHub Action, Security-tab integration, policy gates on PRs. |
-| **Attestation** | Export a bundle as an in-toto / DSSE statement (v0), anchor-pluggable. |
+| **Attestation** | Sign an evidence bundle as a DSSE-wrapped in-toto v1 Statement with the evidence-bundle/v1 predicate. |
 
 ```text
   Agent ──► Assay ──► MCP Server


### PR DESCRIPTION
Documentation only, one README row.

`README.md:86` described the attestation surface as "an in-toto / DSSE statement (v0), anchor-pluggable". What ships is an in-toto v1 Statement carrying the evidence-bundle/v1 predicate. The row now reads:

> Sign an evidence bundle as a DSSE-wrapped in-toto v1 Statement with the evidence-bundle/v1 predicate.

## Verification (main `df7a54ff2d7d3ce7f439d1442e0fee30aaa4ccc8`, re-checked before editing)

All three source lines cited on #2859 are unchanged at that head; no constants moved.

| Layer | Location | Value |
|---|---|---|
| Statement type | `crates/assay-evidence/src/attestation.rs:44` | `STATEMENT_TYPE = "https://in-toto.io/Statement/v1"` |
| Predicate type | `crates/assay-evidence/src/attestation.rs:75-76`, applied at `:202` | `EVIDENCE_BUNDLE_PREDICATE_TYPE_V1 = "https://docs.getassay.dev/attestation/evidence-bundle/v1"` |
| CLI producer | `crates/assay-cli/src/cli/commands/evidence/attest.rs:106` | calls `statement_for_bundle_with_extent_and_limits`, which builds that v1 statement |

The deprecated v0 predicate constant is retained separately for the verifier's refusal path and is not what ships.

**"anchor-pluggable" dropped.** The attest command exposes no anchor selection: its flags are `--bundle`, `--key`, `--out`, and a `--predicate` that is rejected by design (ADR-044). Both module headers describe the anchor as staying external. A README row that names it as a capability advertises something the CLI does not offer.

**Duplicate check.** `grep -rn "statement (v0)" README.md docs crates/assay-cli/README.md` matched only `README.md:86`; neither `docs/` nor the packed crate README carries the wording.

## Scope

- Only `README.md` is staged.
- No change to attestation code, the v0 constant, or the outward-truth scripts. The guard for this class of drift is tracked separately, linked from #2859.
- Committed through the normal hooks, no `--no-verify`.

Closes #2859

🤖 Generated with [Claude Code](https://claude.com/claude-code)
