### PR TITLE
ci: make the gate expectation contract required, and anchor its last five assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1170,6 +1170,7 @@ jobs:
           bash scripts/ci/check-assay-action-pin.sh
           bash scripts/ci/check-assay-action-pin.sh --published
           bash scripts/ci/test-ci-hardening-b1.sh
+          bash scripts/ci/test-ci-gate-expectations.sh
           bash scripts/ci/test-structurizr-export-docker.sh
           python3 scripts/ci/check-conformance-inventory-callsite.py
           python3 scripts/ci/test-conformance-inventory-callsite.py

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -67,6 +67,7 @@ HARDENING_RUN_SCRIPT = (
     "bash scripts/ci/check-assay-action-pin.sh",
     "bash scripts/ci/check-assay-action-pin.sh --published",
     "bash scripts/ci/test-ci-hardening-b1.sh",
+    "bash scripts/ci/test-ci-gate-expectations.sh",
     "bash scripts/ci/test-structurizr-export-docker.sh",
     "python3 scripts/ci/check-conformance-inventory-callsite.py",
     "python3 scripts/ci/test-conformance-inventory-callsite.py",

--- a/scripts/ci/test-ci-gate-expectations.sh
+++ b/scripts/ci/test-ci-gate-expectations.sh
@@ -21,11 +21,15 @@ fail() {
   exit 1
 }
 
-# Both skip loops assert the same two things about one gate run: that it failed *for the skip*,
-# and that it named the job under test. The name half is matched with -F against the emitted
-# `::error::<name> was skipped` prefix, not as a bare substring: an unanchored match accepted a
-# gate that printed `zz-deps-security` while claiming to check `deps-security`, and would accept
-# a future job id that merely ends with an existing one.
+# Every skip assertion states the same two things about one gate run: that it failed *for the
+# skip*, and that it named the job under test. The name half is matched with -F against the
+# emitted `::error::<name> was skipped` prefix, not as a bare substring: an unanchored match
+# accepted a gate that printed `zz-deps-security` while claiming to check `deps-security`, and
+# would accept a future job id that merely ends with an existing one.
+#
+# The two loops call this helper. The single-case sites below whose diagnostic names the scope
+# output under test — three of them share one closing `echo`, so a shared message would not say
+# which case broke — keep their own wording and match the same prefix inline.
 assert_named_skip() {
   local job="$1" out="$2" name
   name="$(printf '%s' "$job" | tr 'A-Z_' 'a-z-')"
@@ -271,8 +275,7 @@ out="$(run_gate fail "ebpf required but skipped" \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED=true EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false)"
-grep -q "ebpf-smoke-ubuntu was skipped" <<<"$out" \
-  || fail "the ebpf case failed for the wrong reason: $out"
+assert_named_skip EBPF_SMOKE_UBUNTU "$out"
 echo "ok: ebpf-smoke-ubuntu skipped while required fails the gate"
 
 # The output the gate did not read at all until now.
@@ -282,8 +285,7 @@ out="$(run_gate fail "registry touched but skipped" \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=true)"
-grep -q "mcp-registry-foundation was skipped" <<<"$out" \
-  || fail "the registry case failed for the wrong reason: $out"
+assert_named_skip MCP_REGISTRY_FOUNDATION "$out"
 echo "ok: mcp-registry-foundation skipped while touched fails the gate"
 
 # Unconditional jobs may never be skipped, whatever the scope says. `publish-shape-cli` and
@@ -366,7 +368,7 @@ out="$(run_gate fail "empty ebpf_smoke_required with the job skipped" \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED= EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false)"
-grep -q "ebpf-smoke-ubuntu was skipped" <<<"$out" \
+grep -qF -- "::error::ebpf-smoke-ubuntu was skipped" <<<"$out" \
   || fail "an empty ebpf_smoke_required must be strict, got: $out"
 
 out="$(run_gate fail "empty mcp_registry_touched with the job skipped" \
@@ -375,7 +377,7 @@ out="$(run_gate fail "empty mcp_registry_touched with the job skipped" \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=)"
-grep -q "mcp-registry-foundation was skipped" <<<"$out" \
+grep -qF -- "::error::mcp-registry-foundation was skipped" <<<"$out" \
   || fail "an empty mcp_registry_touched must be strict, got: $out"
 
 # A wrong-case value is the same class as empty: GitHub compares these outputs as strings, so
@@ -386,7 +388,7 @@ out="$(run_gate fail "wrong-case ebpf_smoke_required" \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED=TRUE EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false)"
-grep -q "ebpf-smoke-ubuntu was skipped" <<<"$out" \
+grep -qF -- "::error::ebpf-smoke-ubuntu was skipped" <<<"$out" \
   || fail "a wrong-case ebpf_smoke_required must be strict, got: $out"
 echo "ok: empty or wrong-case == 'true' outputs are strict, so a disarmed job cannot read green"
 

--- a/scripts/ci/test-ci-hardening-b1.sh
+++ b/scripts/ci/test-ci-hardening-b1.sh
@@ -605,6 +605,7 @@ required = (
     "bash scripts/ci/check-assay-action-pin.sh",
     "bash scripts/ci/check-assay-action-pin.sh --published",
     "bash scripts/ci/test-ci-hardening-b1.sh",
+    "bash scripts/ci/test-ci-gate-expectations.sh",
     "bash scripts/ci/test-structurizr-export-docker.sh",
     "python3 scripts/ci/check-conformance-inventory-callsite.py",
     "python3 scripts/ci/test-conformance-inventory-callsite.py",

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -100,6 +100,7 @@ HARDENING_STEP_COMMANDS = (
     "bash scripts/ci/check-assay-action-pin.sh",
     "bash scripts/ci/check-assay-action-pin.sh --published",
     "bash scripts/ci/test-ci-hardening-b1.sh",
+    "bash scripts/ci/test-ci-gate-expectations.sh",
     "bash scripts/ci/test-structurizr-export-docker.sh",
     "python3 scripts/ci/check-conformance-inventory-callsite.py",
     "python3 scripts/ci/test-conformance-inventory-callsite.py",


### PR DESCRIPTION
Two commits on one thread: an assertion that failed open, and the reason sharpening it
did not yet buy anything.

## 1. Anchor the five remaining skip-name assertions

`7c166e7d9` fixed a fail-open match inside the two skip loops of
`scripts/ci/test-ci-gate-expectations.sh` and left five single-case sites matching the
emitted job name as a bare substring.

Reproduced before fixing. With the gate's emitter in `ci.yml` mutated to print
`zz-${name}`, all five stayed green while claiming to verify the exact name, and the
same run turned the two already-anchored loops red — so the mutation landed, and only
these five accepted it. `check-ci-gate-coverage.py` and
`test-ci-job-timeouts-contract.sh --self-test` both passed under that mutation, so no
existing guard covered it. After the change all five go red, each with its own
diagnostic. The same shape would also have accepted a future job id that merely ends
with an existing one.

`ebpf required but skipped` and `registry touched but skipped` assert exactly what the
loops assert about one gate run, so they call `assert_named_skip`. The three empty and
wrong-case sites name the scope output under test in their own message and share one
closing `echo`, where a shared message would not say which case broke; they keep their
wording and match the same `::error::<name> was skipped` prefix with `-F`.

## 2. Run the contract inside the required CI job

While verifying the above it turned out `test-ci-gate-expectations.sh` was invoked from
no workflow file at all. Its only route to CI was `pre-commit run --all-files` in the
`Lint (pre-commit)` job of `kernel-matrix.yml`, which is not among the required contexts
(`CI`, `lane-check/proof`, `host-capability-check`, `review-record-check`). The contract
it states about the gate's decision logic could not fail a merge, so part 1 was
sharpening an assertion nothing required.

It now runs in the `ci` job's `Verify CI hardening contracts` step, beside the other CI
meta-guards and their self-tests, and ahead of the gate step it judges. `ci` is the
required `CI` context, the step is `set -euo pipefail` with no `continue-on-error`, and
the job is `if: always()`, so the contract is evaluated on every run. The script needs
no network, no `git` and no `gh`; it reads the checked-out `ci.yml` and runs in under a
second.

**It is the discriminator, not a second opinion.** Under the `zz-${name}` mutation every
guard already in that job stays green — `check-ci-gate-coverage.py`,
`check-conformance-inventory-callsite.py`, `test-conformance-inventory-callsite.py` and
`test-ci-hardening-b1.sh` all exit 0 — and only the added command exits 1.

**It cannot be dropped silently.** The hardening step is a closed set pinned in three
deliberately independent places, so the list carries the invocation rather than merely
permitting it:

| mutation | `check-conformance-…` | `test-conformance-…` | `test-ci-hardening-b1.sh` |
|---|---|---|---|
| line in `ci.yml`, absent from the three declarations | red | red | red |
| all four in agreement | green | green | green |
| line deleted from `ci.yml` again | red | red | red |
| line neutered with `\|\| true` | red | — | red |

## Verification

`test-ci-gate-expectations.sh`, `test-ci-job-timeouts-contract.sh --self-test`,
`check-ci-gate-coverage.py` (and `--self-test`),
`check-conformance-inventory-callsite.py`, `test-conformance-inventory-callsite.py`,
`test-ci-hardening-b1.sh`, `conformance/tests/test_completion_scope.py`, and
`shellcheck` on the changed shell files — all green. `ci.yml` was restored after every
mutation and checked with `git hash-object` against
`git rev-parse HEAD:.github/workflows/ci.yml`.

## Note for sequencing

`scripts/ci/test-ci-job-timeouts-contract.sh` is in the same position and is being wired
separately. Because the hardening step is an exact closed set, whichever of the two
lands second needs `gh pr update-branch` before merge or its required CI reports the
list as differing from the canonical one.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)



**Exact head**: `9973af46187b680f33b79a098500b491aa9c519f`
