### PR TITLE
ci: run the job-timeouts contract from required CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1170,6 +1170,7 @@ jobs:
           bash scripts/ci/check-assay-action-pin.sh
           bash scripts/ci/check-assay-action-pin.sh --published
           bash scripts/ci/test-ci-hardening-b1.sh
+          bash scripts/ci/test-ci-job-timeouts-contract.sh --self-test
           bash scripts/ci/test-structurizr-export-docker.sh
           python3 scripts/ci/check-conformance-inventory-callsite.py
           python3 scripts/ci/test-conformance-inventory-callsite.py

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -67,6 +67,7 @@ HARDENING_RUN_SCRIPT = (
     "bash scripts/ci/check-assay-action-pin.sh",
     "bash scripts/ci/check-assay-action-pin.sh --published",
     "bash scripts/ci/test-ci-hardening-b1.sh",
+    "bash scripts/ci/test-ci-job-timeouts-contract.sh --self-test",
     "bash scripts/ci/test-structurizr-export-docker.sh",
     "python3 scripts/ci/check-conformance-inventory-callsite.py",
     "python3 scripts/ci/test-conformance-inventory-callsite.py",

--- a/scripts/ci/test-ci-hardening-b1.sh
+++ b/scripts/ci/test-ci-hardening-b1.sh
@@ -605,6 +605,7 @@ required = (
     "bash scripts/ci/check-assay-action-pin.sh",
     "bash scripts/ci/check-assay-action-pin.sh --published",
     "bash scripts/ci/test-ci-hardening-b1.sh",
+    "bash scripts/ci/test-ci-job-timeouts-contract.sh --self-test",
     "bash scripts/ci/test-structurizr-export-docker.sh",
     "python3 scripts/ci/check-conformance-inventory-callsite.py",
     "python3 scripts/ci/test-conformance-inventory-callsite.py",

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -100,6 +100,7 @@ HARDENING_STEP_COMMANDS = (
     "bash scripts/ci/check-assay-action-pin.sh",
     "bash scripts/ci/check-assay-action-pin.sh --published",
     "bash scripts/ci/test-ci-hardening-b1.sh",
+    "bash scripts/ci/test-ci-job-timeouts-contract.sh --self-test",
     "bash scripts/ci/test-structurizr-export-docker.sh",
     "python3 scripts/ci/check-conformance-inventory-callsite.py",
     "python3 scripts/ci/test-conformance-inventory-callsite.py",


### PR DESCRIPTION
## Description

`scripts/ci/test-ci-job-timeouts-contract.sh` (added by #2334 for CI-5B / #2244) was invoked from **no workflow file at all**. Its only path to CI was `pre-commit run --all-files` in the `Lint (pre-commit)` job of `kernel-matrix.yml`, which is not among the required contexts in `.github/rulesets/main-required-ci-contexts.json` (`CI`, `lane-check/proof`, `host-capability-check`, `review-record-check`). The contract it states about every `ci.yml` job therefore could not fail a merge — the ceilings #2244 restored were unguarded against a second regression.

This adds it to the "Verify CI hardening contracts" step of the required `ci` job, and updates the three deliberately independent pins of that step's closed command set.

## Type of Change
- [x] Bug fix (an unenforced gate)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Verification

Measured on `df7a54ff2`, macOS, worktree `dazzling-kirch-46a793`. The RED was written first.

**Removal / neuter proofs** — each turns all three pins red, so the line cannot be dropped or defanged silently:

| `ci.yml` state | `test-ci-hardening-b1` | `test-conformance-inventory-callsite` | `check-conformance-inventory-callsite` |
|---|---|---|---|
| line added, pins untouched | 1 | 1 | 1 |
| line deleted again | 1 | 1 | 1 |
| line + `\|\| true` | 1 | 1 | 1 |
| all three pins updated | 0 | 0 | 0 |

**Discriminator proofs** — mutate `ci.yml`, then run every guard already in the `ci` job:

| mutation | pre-existing guards | added command |
|---|---|---|
| `scope` 10 → 45 | all green | **1** (`class mismatch: expected 10, got 45`) |
| `perf` 20 → 360 | all green | **1** |
| `scope` `timeout-minutes` key deleted | checker + inv-test + completion red | 1 |

The third row is the coverage boundary, stated rather than glossed: the pre-existing guards pin the *direct key set* of the two contract-pinned jobs, so they do catch a deleted ceiling on `scope`. What none of them catch is a **wrong value anywhere**, or the 360-minute inherit on the fifteen jobs they do not pin. That inherit is the regression this script exists to prevent.

`ci.yml` was restored via `git checkout --` and hash-confirmed equal to `HEAD:.github/workflows/ci.yml` before the single intended insertion was re-applied; `git diff` on that file is one added line, zero deletions.

- [x] `bash scripts/ci/test-ci-job-timeouts-contract.sh --self-test`
- [x] `bash scripts/ci/test-ci-gate-expectations.sh`
- [x] `python3 scripts/ci/check-ci-gate-coverage.py`
- [x] `python3 scripts/ci/check-conformance-inventory-callsite.py`
- [x] `python3 scripts/ci/test-conformance-inventory-callsite.py`
- [x] `bash scripts/ci/test-ci-hardening-b1.sh`
- [x] `python3 conformance/tests/test_completion_scope.py`
- [x] `python3 conformance/tests/test_registry.py` (shares the `assert_hard_run_command` import — checked for collateral)
- [x] `shellcheck` clean on both changed//invoked shell scripts
- [ ] `cargo check` / `cargo test` — not applicable, no Rust changed (workspace clippy and the cross-target Linux gate both passed in pre-push regardless)

## Note on where the third pin actually bites

`HARDENING_RUN_SCRIPT` in `conformance/tests/test_completion_scope.py` is a **declaration, not a self-enforcing test**: adding the line to `ci.yml` alone leaves that file's own suite green, because no test in it applies the `("ci", "Verify CI hardening contracts")` contract to the live workflow. Its enforcement point is `check-conformance-inventory-callsite.py:67`, which imports `assert_hard_run_command` and applies it to the real `ci.yml`. Verifying only `test_completion_scope.py` would read as "this pin does not cover the line", which is false.

## Conflicts with #2878

#2878 inserts into the *same* closed command set, in the same three pins, plus `ci.yml`. Whichever merges second will conflict textually and must re-run all three pins after rebase rather than resolving by hand — the point of the three independent literals is that they are reconciled, not synced.

## Checklist
- [x] Code follows project style
- [x] Documentation updated accordingly (n/a — no documented surface changed)
- [x] Tests added to cover the change (the change *is* a gate wiring; its coverage is the RED/discriminator matrix above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



**Exact head**: `08f07ce5d958e702a852b01f63a3df9c95cb9a26`



**Exact head**: `7140560029e885259020e683a0e67fb693d55a50`
