### PR TITLE
ci(nextest): report a retried pass as a failure in every lane nextest governs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,3 +3,9 @@ failure-output = "immediate-final"
 success-output = "never"
 slow-timeout = { period = "60s", terminate-after = 2 }
 retries = { backoff = "fixed", count = 1, delay = "1s" }
+# A retried pass is a flake, and a flake is reported as a failure (#2871). The retry stays so the
+# FLAKY diagnostic names the test; the run no longer reads as clean. This governs every
+# `cargo nextest run`: local runs and the Split Wave 0 lane. The required CI job uses `cargo test`,
+# which never retries. A per-test retry for an owned flake belongs in [[profile.default.overrides]]
+# with its tracking issue, never here. Pinned by scripts/ci/test-nextest-flaky-result.sh.
+flaky-result = "fail"

--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -72,7 +72,7 @@ jobs:
 
           if [[ "${run_all}" == "true" ]]; then
             global_changed=true
-          elif grep -Eq '^(Cargo\.toml|Cargo\.lock|rust-toolchain|rust-toolchain\.toml|deny\.toml|clippy\.toml|\.cargo/)' "$changed_file"; then
+          elif grep -Eq '^(Cargo\.toml|Cargo\.lock|rust-toolchain|rust-toolchain\.toml|deny\.toml|clippy\.toml|\.cargo/|\.config/)' "$changed_file"; then
             global_changed=true
           else
             global_changed=false
@@ -218,6 +218,15 @@ jobs:
           echo "installing cargo-hack ${CARGO_HACK_VERSION}"
           cargo install --locked --version "${CARGO_HACK_VERSION}" cargo-hack
           assert_cargo_plugin_version cargo-hack "${CARGO_HACK_VERSION}"
+
+      # This lane is where nextest runs, so it is where the profile's flaky-result contract is
+      # pinned (#2871): a test that fails once and passes on retry must fail the run. The
+      # required CI job uses `cargo test` and never retries; the profile does not reach it.
+      - name: Self-test nextest reports a retried pass as a failure
+        shell: bash
+        env:
+          RUSTUP_TOOLCHAIN: stable
+        run: bash scripts/ci/test-nextest-flaky-result.sh
 
       - name: Run curated feature sets
         shell: bash

--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -34,6 +34,10 @@ Repository state observed on 2026-06-11:
   - `.github/workflows/assay-runner-lane-check.yml`
     (`Assay-Runner Lane Check`)
   - `.github/workflows/split-wave0-gates.yml` (`Split Wave 0 Gates`)
+    This is the only hosted lane that runs `cargo nextest`; the required `CI` test job
+    runs `cargo test`. `.config/nextest.toml` sets `flaky-result = "fail"`, so a test that
+    fails once and passes on retry is reported as a failure wherever nextest runs, here and
+    locally. `scripts/ci/test-nextest-flaky-result.sh` pins that in this lane (#2871).
 - Experiment, docs, perf, and nightly workflows exist separately and should not
   be promoted into required PR cost by default.
 - Release workflow: `.github/workflows/release.yml`, with binary builds,

--- a/crates/assay-xtask/src/main.rs
+++ b/crates/assay-xtask/src/main.rs
@@ -502,3 +502,28 @@ mod tests {
         );
     }
 }
+
+/// A test that is flaky by construction, driven only by
+/// `scripts/ci/test-nextest-flaky-result.sh` (#2871).
+///
+/// Nextest runs each attempt in a fresh process, so a marker file is the channel between
+/// attempts: the first attempt finds no marker, writes one and fails; the retry finds it and
+/// passes. That is the exact shape `retries = 1` used to report as a pass. It is ignored so no
+/// ordinary suite selects it; the script runs it with `--run-ignored ignored-only` and a fresh
+/// marker per arm. Without the marker environment it fails every attempt, which is a broken
+/// fixture rather than a flaky one, and the script's sanity arm distinguishes the two.
+#[cfg(test)]
+mod flaky_fixture {
+    #[test]
+    #[ignore = "flaky by construction; run only through scripts/ci/test-nextest-flaky-result.sh"]
+    fn flaky_by_construction_fails_once_then_passes() {
+        let marker = std::env::var_os("ASSAY_FLAKY_FIXTURE_MARKER")
+            .expect("ASSAY_FLAKY_FIXTURE_MARKER must name the marker file for this fixture");
+        let marker = std::path::Path::new(&marker);
+        if marker.exists() {
+            return;
+        }
+        std::fs::write(marker, b"first attempt\n").expect("write the attempt marker");
+        panic!("first attempt fails by construction; the retry must find the marker");
+    }
+}

--- a/crates/assay-xtask/src/main.rs
+++ b/crates/assay-xtask/src/main.rs
@@ -502,28 +502,3 @@ mod tests {
         );
     }
 }
-
-/// A test that is flaky by construction, driven only by
-/// `scripts/ci/test-nextest-flaky-result.sh` (#2871).
-///
-/// Nextest runs each attempt in a fresh process, so a marker file is the channel between
-/// attempts: the first attempt finds no marker, writes one and fails; the retry finds it and
-/// passes. That is the exact shape `retries = 1` used to report as a pass. It is ignored so no
-/// ordinary suite selects it; the script runs it with `--run-ignored ignored-only` and a fresh
-/// marker per arm. Without the marker environment it fails every attempt, which is a broken
-/// fixture rather than a flaky one, and the script's sanity arm distinguishes the two.
-#[cfg(test)]
-mod flaky_fixture {
-    #[test]
-    #[ignore = "flaky by construction; run only through scripts/ci/test-nextest-flaky-result.sh"]
-    fn flaky_by_construction_fails_once_then_passes() {
-        let marker = std::env::var_os("ASSAY_FLAKY_FIXTURE_MARKER")
-            .expect("ASSAY_FLAKY_FIXTURE_MARKER must name the marker file for this fixture");
-        let marker = std::path::Path::new(&marker);
-        if marker.exists() {
-            return;
-        }
-        std::fs::write(marker, b"first attempt\n").expect("write the attempt marker");
-        panic!("first attempt fails by construction; the retry must find the marker");
-    }
-}

--- a/crates/gateway-evidence-replay/tests/nextest_flaky_result_fixture.rs
+++ b/crates/gateway-evidence-replay/tests/nextest_flaky_result_fixture.rs
@@ -1,0 +1,54 @@
+//! Fixtures for `scripts/ci/test-nextest-flaky-result.sh` (#2871).
+//!
+//! `.config/nextest.toml` sets `flaky-result = "fail"`, so a test that fails once and passes on
+//! retry is reported as a failure rather than silently as a pass. Proving that needs a test which
+//! is flaky by construction, and a clean test beside it to show the run does not label everything.
+//!
+//! Nextest runs each attempt in a fresh process and sets `NEXTEST_ATTEMPT` in it, so the attempt
+//! number is the whole mechanism: no marker file, no scratch directory, no path built from the
+//! environment. An earlier version used a marker file whose path came from an environment
+//! variable; CodeQL correctly flagged that as path injection (`rust/path-injection`, high), and
+//! this shape has no path to inject into.
+//!
+//! Both tests are `#[ignore]`, so no ordinary suite runs them: `cargo test --workspace` in the
+//! required CI job lists them as ignored and never executes them. The script selects them by name
+//! with `--run-ignored ignored-only`.
+//!
+//! They live in this crate because the fixture has to sit somewhere nextest runs, and this is a
+//! `publish = false` workspace leaf outside the delegated-runner gated paths. `assay-xtask` is
+//! where build tooling belongs semantically, but `crates/assay-xtask/` is in `all_gate_prefixes`,
+//! so a fixture there would make every change to it require a delegated runner proof.
+
+/// Fails on the first attempt and passes on the retry, which is exactly the shape
+/// `retries = 1` used to report as a clean pass.
+#[test]
+#[ignore = "flaky by construction; run only through scripts/ci/test-nextest-flaky-result.sh"]
+fn flaky_by_construction_fails_once_then_passes() {
+    let attempt = nextest_attempt();
+    assert!(
+        attempt > 1,
+        "attempt {attempt} fails by construction; the retry must pass"
+    );
+}
+
+/// Passes on its first attempt. The script asserts this one carries no flake label, so a profile
+/// that labelled every test a flake would not satisfy the contract either.
+#[test]
+#[ignore = "control for scripts/ci/test-nextest-flaky-result.sh"]
+fn clean_by_construction_passes_first_attempt() {
+    assert_eq!(
+        nextest_attempt(),
+        1,
+        "the clean control must not be retried; it passes on its first attempt"
+    );
+}
+
+/// The attempt number nextest set for this process, 1-based.
+fn nextest_attempt() -> u32 {
+    let raw = std::env::var("NEXTEST_ATTEMPT").expect(
+        "NEXTEST_ATTEMPT is unset: these fixtures are driven by cargo nextest, \
+         through scripts/ci/test-nextest-flaky-result.sh",
+    );
+    raw.parse()
+        .unwrap_or_else(|_| panic!("NEXTEST_ATTEMPT must be an integer, got {raw:?}"))
+}

--- a/scripts/ci/test-nextest-flaky-result.sh
+++ b/scripts/ci/test-nextest-flaky-result.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Pin that a test which fails once and passes on retry is reported as a failure by nextest (#2871).
+#
+# `.config/nextest.toml` retries every test once. Nextest's default treats a fail-then-pass as a
+# pass, so a flaky test was green in every lane that runs `cargo nextest run` (local runs, and the
+# Split Wave 0 workflow). `flaky-result = "fail"` keeps the retry and its FLAKY diagnostic but
+# reports the run as failed. This script proves that property with a fixture test that is flaky by
+# construction, under three arms:
+#
+#   control   the old behaviour, forced with NEXTEST_FLAKY_RESULT=pass: fresh marker, exit 0, FLAKY
+#   target    the repository configuration: fresh marker, non-zero exit, FLKY-FL still reported
+#   sanity    marker pre-created so the fixture passes first time: exit 0, neither label
+#
+# Nextest spells the two outcomes differently: a flake treated as a pass is `FLAKY`, a flake
+# treated as a failure is `FLKY-FL` with the line `test configured to fail if flaky`. Both carry
+# the retry; the target arm asserts the second so a profile that merely drops the retry (one
+# plain FAIL, no diagnostic) is rejected as well.
+#
+# Deleting `flaky-result` from the profile turns the target arm green with exit 0 and this script red.
+# Exit codes are captured without a pipe so the runner's status is what is asserted.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+FIXTURE_FILTER='test(flaky_by_construction_fails_once_then_passes)'
+FIXTURE_ENV="ASSAY_FLAKY_FIXTURE_MARKER"
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+command -v cargo >/dev/null || fail "cargo not on PATH"
+cargo nextest --version >/dev/null 2>&1 || fail "cargo-nextest is not installed; this contract needs it"
+
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/assay-nextest-flaky.XXXXXX")"
+trap 'rm -rf "$scratch"' EXIT
+
+# One invocation of the fixture. $1 = marker path, $2 = output file, remaining args = extra env.
+run_fixture() {
+  local marker="$1" out="$2"; shift 2
+  set +e
+  env "$@" "${FIXTURE_ENV}=${marker}" \
+    cargo nextest run -p assay-xtask --run-ignored ignored-only -E "${FIXTURE_FILTER}" \
+    >"$out" 2>&1
+  local rc=$?
+  set -e
+  return "$rc"
+}
+
+# Build once so the three arms measure the runner, not compilation.
+cargo nextest run -p assay-xtask --run-ignored ignored-only -E "${FIXTURE_FILTER}" --no-run \
+  >"$scratch/build.out" 2>&1 || { cat "$scratch/build.out" >&2; fail "fixture did not build"; }
+
+# The fixture must exist and be selected, or every arm below passes vacuously.
+listed="$(cargo nextest list -p assay-xtask --run-ignored ignored-only -E "${FIXTURE_FILTER}" 2>/dev/null | grep -c 'flaky_by_construction_fails_once_then_passes' || true)"
+[ "$listed" -eq 1 ] || fail "expected exactly one fixture test selected by ${FIXTURE_FILTER}, got ${listed}"
+
+# control: old behaviour, fresh marker -> flaky is a pass
+rc=0; run_fixture "$scratch/marker-control" "$scratch/control.out" NEXTEST_FLAKY_RESULT=pass || rc=$?
+[ "$rc" -eq 0 ] || { cat "$scratch/control.out" >&2; fail "control arm: expected exit 0 under NEXTEST_FLAKY_RESULT=pass, got ${rc}"; }
+grep -q 'FLAKY' "$scratch/control.out" || { cat "$scratch/control.out" >&2; fail "control arm: fixture did not register as FLAKY; it is not flaky by construction"; }
+echo "ok    control: a retried pass is reported FLAKY and the run exits 0 when flaky-result=pass is forced"
+
+# target: repository configuration, fresh marker -> flaky is a failure
+rc=0; run_fixture "$scratch/marker-target" "$scratch/target.out" || rc=$?
+[ "$rc" -ne 0 ] || { cat "$scratch/target.out" >&2; fail "target arm: the repository profile let a retried pass exit 0; flaky-result is not \"fail\""; }
+grep -q 'FLKY-FL' "$scratch/target.out" || { cat "$scratch/target.out" >&2; fail "target arm: run failed but without the FLKY-FL diagnostic; the retry itself is gone"; }
+echo "ok    target: under the repository profile a retried pass exits ${rc} and is reported FLKY-FL"
+
+# sanity: marker present, first attempt passes -> ordinary pass, no FLAKY
+: >"$scratch/marker-sanity"
+rc=0; run_fixture "$scratch/marker-sanity" "$scratch/sanity.out" || rc=$?
+[ "$rc" -eq 0 ] || { cat "$scratch/sanity.out" >&2; fail "sanity arm: fixture failed with the marker present; the fixture is broken, not flaky"; }
+if grep -qE 'FLAKY|FLKY-FL' "$scratch/sanity.out"; then cat "$scratch/sanity.out" >&2; fail "sanity arm: a first-attempt pass was reported as a flake"; fi
+echo "ok    sanity: with the marker present the fixture passes first time and carries no flake label"
+
+echo "PASS: nextest flaky-result contract"

--- a/scripts/ci/test-nextest-flaky-result.sh
+++ b/scripts/ci/test-nextest-flaky-result.sh
@@ -3,27 +3,28 @@
 #
 # `.config/nextest.toml` retries every test once. Nextest's default treats a fail-then-pass as a
 # pass, so a flaky test was green in every lane that runs `cargo nextest run` (local runs, and the
-# Split Wave 0 workflow). `flaky-result = "fail"` keeps the retry and its FLAKY diagnostic but
-# reports the run as failed. This script proves that property with a fixture test that is flaky by
-# construction, under three arms:
+# Split Wave 0 lane). `flaky-result = "fail"` keeps the retry and its diagnostic but reports the
+# run as failed. The fixtures live in crates/gateway-evidence-replay/tests/ and are driven by
+# NEXTEST_ATTEMPT, which nextest sets per attempt process.
 #
-#   control   the old behaviour, forced with NEXTEST_FLAKY_RESULT=pass: fresh marker, exit 0, FLAKY
-#   target    the repository configuration: fresh marker, non-zero exit, FLKY-FL still reported
-#   sanity    marker pre-created so the fixture passes first time: exit 0, neither label
+# Three arms, each a separate nextest run:
+#
+#   control   flaky fixture with NEXTEST_FLAKY_RESULT=pass forced: exit 0, labelled FLAKY
+#   target    flaky fixture under the repository profile: non-zero, labelled FLKY-FL
+#   clean     the non-flaky fixture: exit 0, no flake label of either spelling
 #
 # Nextest spells the two outcomes differently: a flake treated as a pass is `FLAKY`, a flake
-# treated as a failure is `FLKY-FL` with the line `test configured to fail if flaky`. Both carry
-# the retry; the target arm asserts the second so a profile that merely drops the retry (one
-# plain FAIL, no diagnostic) is rejected as well.
-#
-# Deleting `flaky-result` from the profile turns the target arm green with exit 0 and this script red.
-# Exit codes are captured without a pipe so the runner's status is what is asserted.
+# treated as a failure is `FLKY-FL` with the line `test configured to fail if flaky`. The target
+# arm asserts the second, so a profile that merely dropped the retry (one plain FAIL, no
+# diagnostic) is rejected as well. Exit codes are captured without a pipe.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
-FIXTURE_FILTER='test(flaky_by_construction_fails_once_then_passes)'
-FIXTURE_ENV="ASSAY_FLAKY_FIXTURE_MARKER"
+
+FIXTURE_CRATE="gateway-evidence-replay"
+FLAKY_TEST="flaky_by_construction_fails_once_then_passes"
+CLEAN_TEST="clean_by_construction_passes_first_attempt"
 
 fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 
@@ -33,43 +34,52 @@ cargo nextest --version >/dev/null 2>&1 || fail "cargo-nextest is not installed;
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/assay-nextest-flaky.XXXXXX")"
 trap 'rm -rf "$scratch"' EXIT
 
-# One invocation of the fixture. $1 = marker path, $2 = output file, remaining args = extra env.
+# One nextest run over a single named fixture. $1 = test name, $2 = output file, rest = extra env.
 run_fixture() {
-  local marker="$1" out="$2"; shift 2
+  local test_name="$1" out="$2"; shift 2
   set +e
-  env "$@" "${FIXTURE_ENV}=${marker}" \
-    cargo nextest run -p assay-xtask --run-ignored ignored-only -E "${FIXTURE_FILTER}" \
-    >"$out" 2>&1
+  env "$@" cargo nextest run -p "$FIXTURE_CRATE" --run-ignored ignored-only \
+    -E "test(=${test_name})" >"$out" 2>&1
   local rc=$?
   set -e
   return "$rc"
 }
 
-# Build once so the three arms measure the runner, not compilation.
-cargo nextest run -p assay-xtask --run-ignored ignored-only -E "${FIXTURE_FILTER}" --no-run \
-  >"$scratch/build.out" 2>&1 || { cat "$scratch/build.out" >&2; fail "fixture did not build"; }
+# Each arm must select exactly one test. A filter that matched nothing would make every
+# assertion below pass vacuously, and nextest exits 0 on an empty selection by default.
+assert_selects_one() {
+  local test_name="$1" listed rc=0
+  listed="$(cargo nextest list -p "$FIXTURE_CRATE" --run-ignored ignored-only \
+    -E "test(=${test_name})" 2>"$scratch/list.err")" || rc=$?
+  [ "$rc" -eq 0 ] || { cat "$scratch/list.err" >&2; fail "nextest list failed for ${test_name}"; }
+  local count
+  count="$(grep -c -- "$test_name" <<<"$listed" || true)"
+  [ "$count" -eq 1 ] || fail "expected exactly one test named ${test_name}, nextest listed ${count}"
+}
 
-# The fixture must exist and be selected, or every arm below passes vacuously.
-listed="$(cargo nextest list -p assay-xtask --run-ignored ignored-only -E "${FIXTURE_FILTER}" 2>/dev/null | grep -c 'flaky_by_construction_fails_once_then_passes' || true)"
-[ "$listed" -eq 1 ] || fail "expected exactly one fixture test selected by ${FIXTURE_FILTER}, got ${listed}"
+# Build once so the arms measure the runner rather than compilation.
+cargo nextest run -p "$FIXTURE_CRATE" --run-ignored ignored-only --no-run \
+  >"$scratch/build.out" 2>&1 || { cat "$scratch/build.out" >&2; fail "fixtures did not build"; }
 
-# control: old behaviour, fresh marker -> flaky is a pass
-rc=0; run_fixture "$scratch/marker-control" "$scratch/control.out" NEXTEST_FLAKY_RESULT=pass || rc=$?
+assert_selects_one "$FLAKY_TEST"
+assert_selects_one "$CLEAN_TEST"
+
+# control: old behaviour forced -> a retried pass is a pass
+rc=0; run_fixture "$FLAKY_TEST" "$scratch/control.out" NEXTEST_FLAKY_RESULT=pass || rc=$?
 [ "$rc" -eq 0 ] || { cat "$scratch/control.out" >&2; fail "control arm: expected exit 0 under NEXTEST_FLAKY_RESULT=pass, got ${rc}"; }
 grep -q 'FLAKY' "$scratch/control.out" || { cat "$scratch/control.out" >&2; fail "control arm: fixture did not register as FLAKY; it is not flaky by construction"; }
-echo "ok    control: a retried pass is reported FLAKY and the run exits 0 when flaky-result=pass is forced"
+echo "ok    control: a retried pass is FLAKY and exits 0 when flaky-result=pass is forced"
 
-# target: repository configuration, fresh marker -> flaky is a failure
-rc=0; run_fixture "$scratch/marker-target" "$scratch/target.out" || rc=$?
+# target: repository profile -> a retried pass is a failure, and still diagnosed
+rc=0; run_fixture "$FLAKY_TEST" "$scratch/target.out" || rc=$?
 [ "$rc" -ne 0 ] || { cat "$scratch/target.out" >&2; fail "target arm: the repository profile let a retried pass exit 0; flaky-result is not \"fail\""; }
 grep -q 'FLKY-FL' "$scratch/target.out" || { cat "$scratch/target.out" >&2; fail "target arm: run failed but without the FLKY-FL diagnostic; the retry itself is gone"; }
 echo "ok    target: under the repository profile a retried pass exits ${rc} and is reported FLKY-FL"
 
-# sanity: marker present, first attempt passes -> ordinary pass, no FLAKY
-: >"$scratch/marker-sanity"
-rc=0; run_fixture "$scratch/marker-sanity" "$scratch/sanity.out" || rc=$?
-[ "$rc" -eq 0 ] || { cat "$scratch/sanity.out" >&2; fail "sanity arm: fixture failed with the marker present; the fixture is broken, not flaky"; }
-if grep -qE 'FLAKY|FLKY-FL' "$scratch/sanity.out"; then cat "$scratch/sanity.out" >&2; fail "sanity arm: a first-attempt pass was reported as a flake"; fi
-echo "ok    sanity: with the marker present the fixture passes first time and carries no flake label"
+# clean: a test that passes first time carries no flake label under the same profile
+rc=0; run_fixture "$CLEAN_TEST" "$scratch/clean.out" || rc=$?
+[ "$rc" -eq 0 ] || { cat "$scratch/clean.out" >&2; fail "clean arm: the non-flaky fixture failed under the repository profile"; }
+if grep -qE 'FLAKY|FLKY-FL' "$scratch/clean.out"; then cat "$scratch/clean.out" >&2; fail "clean arm: a first-attempt pass was labelled a flake"; fi
+echo "ok    clean: a first-attempt pass exits 0 and carries no flake label"
 
 echo "PASS: nextest flaky-result contract"


### PR DESCRIPTION
**Candidate, not a landing.** Head SHA `7616130d982ffd3c1c0dc58beb46f6b6df4a6f8d`. Sole author; needs an independent exact-head review record before merge, and I will not write one.

Supersedes the review of `fd9d6507129b7b77e90087529dc31fdb989ad4fa`, which returned BLOCKED with two findings. Both are addressed below, along with a third the review did not report.

## Problem

`.config/nextest.toml` retried every test once and nextest's default reported a fail-then-pass as a pass. That governed every `cargo nextest run`: local and agent runs, including the runs PR bodies cite as verification evidence, and the Split Wave 0 lane (`split-wave0-gates.yml:256`, `:289`, `:307`).

It does **not** govern the required `CI` context. The `test` job runs `cargo test` (`ci.yml:745`, `:838`), which never retries; a flaky test there fails outright. Earlier descriptions on #2174 and #2871 said "repository-wide", and that was corrected on those issues.

## Change

`flaky-result = "fail"` in `[profile.default]`. Per the nextest docs (0.9.131+; Wave 0 pins 0.9.143), the test is still retried and then treated as failing even if the rerun passes. Nextest prints `TRY 1 FAIL`, `TRY 2 PASS`, `test configured to fail if flaky`, labels the result `FLKY-FL`, and exits non-zero. Under the old behaviour the same run is labelled `FLAKY` and exits 0.

## Review findings from `fd9d65071`, and what changed

**Finding 1, gated path — fixed by relocation.** The fixture was in `crates/assay-xtask/src/main.rs`. That prefix is in `all_gate_prefixes`, so `classify_file` returns `Gate.ALL` ("shared runner/eBPF/monitor/xtask code requires gates=all") and required `lane-check/proof` demanded a delegated runner proof for a shell contract test. The failing run said so: *"No attested delegated proof pack matched this PR's gated content."* Confirmed at source before acting. `assay-xtask` is where build tooling belongs semantically, which is the tension; the gating rule wins.

**Finding 2, missing head SHA — fixed.** This body cites `7616130d982ffd3c1c0dc58beb46f6b6df4a6f8d`, the 40-hex form `pr_landing_readiness.py` matches on (`SHA_RE`, `:20`).

**Not reported by the review: two high-severity CodeQL alerts.** `rust/path-injection` at `main.rs:523` and `:526`, on the fixture's own `marker.exists()` and `fs::write(marker, …)`. The marker path came from an environment variable, so it was a path built from a user-provided value. The check was failing on the reviewed head.

**One change closes all three.** Nextest sets `NEXTEST_ATTEMPT` in each attempt process, so the attempt number is the whole mechanism: the flaky fixture fails when it is 1 and passes after. No marker file, no scratch directory, no path to inject into. The fixtures moved to `crates/gateway-evidence-replay/tests/nextest_flaky_result_fixture.rs`, a `publish = false` workspace leaf whose `tests/` classifies `Gate.NONE`.

## A hole in my own test, closed in the same change

The previous three arms would have been satisfied by a profile that labelled **every** test a flake: nothing asserted that a clean test stays clean. There is now a second fixture that passes on its first attempt, and the script asserts it carries no flake label of either spelling.

## Proof

`scripts/ci/test-nextest-flaky-result.sh`, three arms, exit codes captured without a pipe. Each arm also asserts its filter selects exactly one test, since nextest exits 0 on an empty selection.

| arm | configuration | expected | observed |
|---|---|---|---|
| control | `NEXTEST_FLAKY_RESULT=pass` forced | exit 0, `FLAKY` | exit 0, `FLAKY` |
| target | repository profile | non-zero, `FLKY-FL` | exit 100, `FLKY-FL` |
| clean | non-flaky fixture | exit 0, no label | exit 0, no label |

Mutations, each red for a distinct reason:

- **`flaky-result` deleted** → target arm red: the masking returns.
- **`retries = 0`** → control arm red: without a retry the fixture is not flaky, it simply fails. A profile that merely stops retrying does not pass.
- **flaky fixture made always-pass** → control arm red: the contract would otherwise be vacuous.

Also verified on this head: every changed path classifies `Gate.NONE`; both fixtures are `#[ignore]`, so `cargo test --workspace` in the required job lists them and runs neither (2 ignored, 0 run); `test-ci-gate-expectations.sh`, `test-ci-job-timeouts-contract.sh` and `check-ci-gate-coverage.py` all pass; `shellcheck`, `cargo fmt --check` and `cargo clippy -p gateway-evidence-replay --all-targets -D warnings` clean.

## Wiring

- The self-test runs as a step in the Split Wave 0 `feature-matrix` job, right after nextest is installed. No job is added to `ci.yml`, so neither CI contract changes.
- `.config/` joins that lane's global-relevance regex, so a change to the profile runs the lane that pins it.
- `CI-CONTRACT.md` states which lanes nextest governs.

## Non-claims

No claim that any current test is flaky. No change to the required `CI` context or to which tests run there. The Windows job-level flake in #2246 is a `cargo test` job and is not addressed here. Not a release blocker.

## Review asks

Whether `NEXTEST_ATTEMPT` is a stable contract across the local 0.9.137 and the pinned 0.9.143, and whether it is set under every execution mode this repository could select. Whether `FLKY-FL` and `FLAKY` are stable labels across those versions. Whether `-E "test(=NAME)"` exact-match selection behaves as assumed on 0.9.143. Whether `gateway-evidence-replay` is a defensible host, or whether the fixture should live somewhere else outside gated paths.

Refs #2871. Does not close it: the per-test override convention and the `CI-CONTRACT.md` sentence are here; the issue's remaining box (an owned-flake override actually declared) has no candidate today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
