### PR TITLE
review: refuse to land text that would close an issue the PR does not declare

### DIFF
--- a/scripts/review/README.md
+++ b/scripts/review/README.md
@@ -59,11 +59,12 @@ immutable attestation or protection against subsequent evidence edits.
 GitHub closes an issue when a closing keyword (`close`, `closes`, `closed`, `fix`, `fixes`,
 `fixed`, `resolve`, `resolves`, `resolved`, any case, optional colon) is followed by an issue
 reference, in a PR description or in a commit message that lands on the default branch. It has
-no notion of negation, and it reads commit messages the author can no longer edit. Between
-2026-08-19 and 2026-09-05 that closed five issues their authors meant to keep open: a sentence
-saying a change leaves an issue open, written with the keyword directly before the number,
-closes that issue; and a keyword retracted from a PR body still closes the issue from the
-commit that carried it.
+no notion of negation, and it reads commit messages the author can no longer edit. Measured with
+GitHub's own `ClosedEvent.closer`, that closed issues their authors meant to keep open nine times
+across six issues between 2026-08-19 and 2026-09-05, and two of those closes went unnoticed for
+days, one of them on a P1 security bug. A sentence saying a change leaves an issue open, written
+with the keyword directly before the number, closes that issue; and a keyword retracted from a PR
+body still closes the issue from the commit that carried it.
 
 `pr_landing_readiness.py` therefore reports a blocker, via `closing_keywords.py`, when:
 
@@ -78,9 +79,26 @@ the same: never put a closing keyword next to an issue number unless you mean to
 Write `Refs #N` for a relationship. There is no negated form that GitHub understands, so the
 words must not appear, in the body or in a commit message.
 
+A negation counts when it sits in the same clause as the keyword. A clause runs back across soft
+line breaks, because this repository hard-wraps prose, and ends at sentence punctuation, a blank
+line, a list item, heading, table row or blockquote. A capitalised keyword that opens its own line
+(`Closes #N`, the trailer shape) starts a new clause. Typographic apostrophes are read as ASCII,
+so `doesn’t` is a negation. The negators are listed in `closing_keywords.py`; bare "no" is
+left out on purpose, since "a no-op that closes #N" is a real close.
+
 The rule is deliberately conservative: it prefers a false block, which costs one rewording, to
-a silent close. It cannot see a keyword that was edited out of the body before merge but left
-in place when the issue closed, and it does not undo a close that already happened.
+a silent close. Known limits, each a false block rather than a silent close unless stated:
+
+- The title is scanned for every merge method. It lands in the merge or squash commit subject,
+  but not under `--rebase`, where a title keyword is therefore a spurious block.
+- The base branch is not consulted. A PR into a non-default branch closes nothing by its body,
+  but its commit messages still close issues when those commits later reach the default branch,
+  so the commit rule stays relevant there.
+- An issue linked through the sidebar's Development panel also closes on merge and carries no
+  keyword text. That is a deliberate act and is out of scope; it is a silent close this guard
+  cannot see.
+- A keyword edited out of the body before merge is invisible afterwards, and a close that already
+  happened is not undone.
 
 The broader readiness queries accept only the fixed `gh pr` and `gh api` command
 families used by the reporter, validate repository and branch path components, and

--- a/scripts/review/README.md
+++ b/scripts/review/README.md
@@ -54,6 +54,34 @@ Subprocess output goes to temporary files; this is not a disk-quota guarantee.
 No evidence contents are executed. GitHub comments remain editable; this is not an
 immutable attestation or protection against subsequent evidence edits.
 
+## Closing keywords
+
+GitHub closes an issue when a closing keyword (`close`, `closes`, `closed`, `fix`, `fixes`,
+`fixed`, `resolve`, `resolves`, `resolved`, any case, optional colon) is followed by an issue
+reference, in a PR description or in a commit message that lands on the default branch. It has
+no notion of negation, and it reads commit messages the author can no longer edit. Between
+2026-08-19 and 2026-09-05 that closed five issues their authors meant to keep open: a sentence
+saying a change leaves an issue open, written with the keyword directly before the number,
+closes that issue; and a keyword retracted from a PR body still closes the issue from the
+commit that carried it.
+
+`pr_landing_readiness.py` therefore reports a blocker, via `closing_keywords.py`, when:
+
+- a closing keyword and issue reference sit in a negated clause, in the body, the title or any
+  commit message; or
+- a commit message or the title closes an issue that the PR body does not also close with a
+  non-negated keyword. The title is not parsed on the PR, but it becomes the subject of the
+  merge or squash commit, which is.
+
+The PR body is the live declaration of what a merge closes. The remedy for either blocker is
+the same: never put a closing keyword next to an issue number unless you mean to close it.
+Write `Refs #N` for a relationship. There is no negated form that GitHub understands, so the
+words must not appear, in the body or in a commit message.
+
+The rule is deliberately conservative: it prefers a false block, which costs one rewording, to
+a silent close. It cannot see a keyword that was edited out of the body before merge but left
+in place when the issue closed, and it does not undo a close that already happened.
+
 The broader readiness queries accept only the fixed `gh pr` and `gh api` command
 families used by the reporter, validate repository and branch path components, and
 apply a 30-second timeout plus an 8-MiB JSON ceiling before parsing. Human-readable
@@ -66,6 +94,7 @@ Run synthetic tests (fake gh, no live merges):
 python3 scripts/review/test_review_relay.py
 python3 scripts/review/test_safe_merge_protocol.py
 python3 scripts/review/test_pr_landing_readiness.py
+python3 scripts/review/test_closing_keywords.py
 ```
 
 The `review-relay-protocol-tests` pre-commit hook runs the complete set on the PR

--- a/scripts/review/README.md
+++ b/scripts/review/README.md
@@ -79,24 +79,37 @@ the same: never put a closing keyword next to an issue number unless you mean to
 Write `Refs #N` for a relationship. There is no negated form that GitHub understands, so the
 words must not appear, in the body or in a commit message.
 
-A negation counts when it sits in the same clause as the keyword. A clause runs back across soft
+A negation counts when it sits in the clause that contains the reference, before the keyword or
+after the number: "Fixes #N, but does not finish it" closes #N too. A clause runs across soft
 line breaks, because this repository hard-wraps prose, and ends at sentence punctuation, a blank
-line, a list item, heading, table row or blockquote. A capitalised keyword that opens its own line
-(`Closes #N`, the trailer shape) starts a new clause. Typographic apostrophes are read as ASCII,
-so `doesn’t` is a negation. The negators are listed in `closing_keywords.py`; bare "no" is
-left out on purpose, since "a no-op that closes #N" is a real close.
+line, a list item, heading, table row or blockquote. A keyword that opens its own line gets no
+exemption, capitalised or not. "does not" at the end of one line and `Closes #N` on the next may
+be a wrapped sentence or a trailer; the text cannot tell them apart, and GitHub closes the issue
+either way. A trailer is therefore a declaration only after a finished sentence or a blank line.
+Typographic apostrophes are read as ASCII, so `doesn’t` is a negation. The negators are listed in
+`closing_keywords.py`; bare "no" is left out on purpose, since "a no-op that closes #N" is a real
+close.
 
 The rule is deliberately conservative: it prefers a false block, which costs one rewording, to
-a silent close. Known limits, each a false block rather than a silent close unless stated:
+a silent close. Known false blocks:
 
+- A line that mentions a negation, even inside inline code, followed with no punctuation or blank
+  line by a genuine closing line. End the sentence or leave a blank line.
+- A declaration under "not only ... but also", which reads as negated.
+- A genuine close followed in the same clause by a negation, as in "Fixes #N without changing the
+  API". End the sentence after the number.
 - The title is scanned for every merge method. It lands in the merge or squash commit subject,
   but not under `--rebase`, where a title keyword is therefore a spurious block.
 - The base branch is not consulted. A PR into a non-default branch closes nothing by its body,
   but its commit messages still close issues when those commits later reach the default branch,
   so the commit rule stays relevant there.
+
+Known silent closes, which this guard cannot see:
+
+- A negation word outside the list. The list covers every negator found in this repository's
+  history and in review, but it is finite, and an unlisted one reads as a declaration.
 - An issue linked through the sidebar's Development panel also closes on merge and carries no
-  keyword text. That is a deliberate act and is out of scope; it is a silent close this guard
-  cannot see.
+  keyword text. That is a deliberate act and is out of scope.
 - A keyword edited out of the body before merge is invisible afterwards, and a close that already
   happened is not undone.
 

--- a/scripts/review/closing_keywords.py
+++ b/scripts/review/closing_keywords.py
@@ -52,7 +52,8 @@ _CLAUSE_BOUNDARY = re.compile(
 # "no longer" is in, because it negates what follows it. Contractions are matched with and without
 # the apostrophe, since "wont" and "doesnt" are what fast typing produces.
 _NEGATORS = (
-    "not", "never", "nor", "neither", "without", "cannot", "unable", "hardly",
+    "not", "never", "nor", "neither", "without", "cannot", "unable",
+    "hardly", "barely", "scarcely", "rarely", "seldom", "aint",
     "dont", "doesnt", "didnt", "wont", "isnt", "arent", "cant", "shouldnt", "wouldnt", "couldnt",
 )
 _NEGATION = re.compile(
@@ -62,9 +63,6 @@ _NEGATION = re.compile(
 # Typographic apostrophes become ASCII before the negation scan: an editor or a phone turns
 # "doesn't" into "doesn\u2019t", and GitHub still reads the keyword that follows.
 _APOSTROPHES = str.maketrans({"\u2019": "'", "\u2018": "'", "\u02bc": "'", "\uff07": "'"})
-# A keyword that opens its own line with a capital letter ("Closes #5") is a trailer or a new
-# sentence, not the wrapped tail of the line above, so it starts a fresh clause.
-_LINE_OPENING_KEYWORD = re.compile(r"[ \t]*(?:[-*+][ \t]+|\d+[.)][ \t]+)?[A-Z]")
 
 _LINE_LIMIT = 200
 
@@ -86,26 +84,33 @@ def _line_of(text: str, start: int, end: int) -> str:
     return line if len(line) <= _LINE_LIMIT else line[:_LINE_LIMIT - 3] + "..."
 
 
-def _is_negated(text: str, start: int) -> bool:
-    """Whether the clause before a keyword carries a negation.
+def _is_negated(text: str, start: int, end: int) -> bool:
+    """Whether the clause containing a closing reference carries a negation, on either side.
 
-    The clause runs back to the nearest boundary, across soft line breaks. A capitalised keyword
-    at the start of its own line begins a new clause, so a trailer never inherits the line above.
+    The clause runs from the nearest boundary before the keyword to the nearest one after the
+    reference, across soft line breaks. Both sides count: "Fixes #5, but does not close it" closes
+    #5 as surely as "does not close #5" does. Over the last 100 merged PRs no genuine close had a
+    negation later in its own clause, so reading forward cost no false block there.
+
+    A capitalised keyword opening its own line gets no exemption: "does not" at the end of one
+    line and "Close #5" on the next may be a wrapped sentence, and GitHub closes #5 either way. An
+    earlier version exempted that shape as a trailer; over the same 100 PRs the exemption touched
+    40 references and prevented no false block, while it let a negated close through silently.
     """
-    line_start = text.rfind("\n", 0, start) + 1
-    if _LINE_OPENING_KEYWORD.fullmatch(text[line_start:start + 1]):
-        return False
     before = text[:start]
     boundaries = list(_CLAUSE_BOUNDARY.finditer(before))
-    clause = before[boundaries[-1].end():] if boundaries else before
-    return bool(_NEGATION.search(clause.translate(_APOSTROPHES)))
+    clause_before = before[boundaries[-1].end():] if boundaries else before
+    after = text[end:]
+    boundary = _CLAUSE_BOUNDARY.search(after)
+    clause_after = after[:boundary.start()] if boundary else after
+    return bool(_NEGATION.search((clause_before + " " + clause_after).translate(_APOSTROPHES)))
 
 
 def _references(repo: str, text: str):
     """Yield (key, display, negated, line) for every closing reference in text."""
     for match in _CLOSING.finditer(text or ""):
         key, display = _normalise(repo, match)
-        yield key, display, _is_negated(text, match.start()), _line_of(text, match.start(), match.end())
+        yield key, display, _is_negated(text, match.start(), match.end()), _line_of(text, match.start(), match.end())
 
 
 def closing_problems(repo: str, title: str, body: str, commit_messages) -> list[str]:

--- a/scripts/review/closing_keywords.py
+++ b/scripts/review/closing_keywords.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Closing-keyword landing guard (#2880).
+
+GitHub closes an issue when a closing keyword followed by an issue reference appears in a pull
+request description, or in a commit message that lands on the default branch. Two properties
+of that rule have closed issues on this repository that their authors meant to keep open:
+
+- GitHub has no notion of negation. A sentence that says a change does not close an issue,
+  with the issue number right after the keyword, closes that issue.
+- Commit messages are frozen. Editing the PR body to retract a keyword does not remove the
+  same keyword from a commit message, and the commit closes the issue when it lands.
+
+The guard treats the PR body as the live declaration of what a merge closes, and refuses to
+land when:
+
+1. a closing keyword and issue reference sit in a negated clause, in any text GitHub parses; or
+2. a commit message, or the title, closes an issue that the body does not also close with a
+   non-negated keyword. The title is not parsed while it sits on the PR, but it becomes the
+   subject of the merge or squash commit, which is.
+
+Comparing against GitHub's own `closingIssuesReferences` would be circular for the first rule:
+GitHub computes that set by the same parse, so a negated phrase is already in it.
+
+The rule is deliberately conservative. It prefers a false block, which costs one rewording,
+to a silent close. The remedy for a block is always the same: say what you mean without a
+closing keyword next to an issue number, for example "Refs #N".
+"""
+from __future__ import annotations
+
+import re
+
+_KEYWORD = r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)"
+_REF = (
+    r"(?:(?P<repo>[A-Za-z0-9][\w.-]*/[\w.-]+)?#(?P<num>\d+)"
+    r"|https://github\.com/(?P<urepo>[\w.-]+/[\w.-]+)/issues/(?P<unum>\d+))"
+)
+# The lookarounds give the keyword whole-word boundaries without treating a hyphen as one, so
+# "disclose", "prefix", "unresolved", "fixture" and "closet" never match.
+_CLOSING = re.compile(rf"(?<![\w-]){_KEYWORD}(?![\w-])\s*:?\s*{_REF}", re.IGNORECASE)
+
+# A clause ends at sentence punctuation followed by whitespace, so "ci.yml" is not a boundary.
+_CLAUSE_BOUNDARY = re.compile(r"[.!?;](?=\s)")
+# Bare "no" is left out on purpose: "a no-op that closes #5" is a real close, not a negation.
+_NEGATION = re.compile(r"(?<![\w-])(?:not|never|nor|without|cannot)(?![\w-])|n't(?![\w-])",
+                       re.IGNORECASE)
+
+_LINE_LIMIT = 200
+
+
+def _normalise(repo: str, match: re.Match) -> tuple[tuple[str, int], str]:
+    """(comparison key, display form) for one closing reference."""
+    ref_repo = match.group("repo") or match.group("urepo") or repo
+    num = int(match.group("num") or match.group("unum"))
+    key = (ref_repo.lower(), num)
+    display = f"#{num}" if ref_repo.lower() == repo.lower() else f"{ref_repo}#{num}"
+    return key, display
+
+
+def _line_of(text: str, start: int, end: int) -> str:
+    line_start = text.rfind("\n", 0, start) + 1
+    line_end = text.find("\n", end)
+    line = text[line_start:] if line_end == -1 else text[line_start:line_end]
+    line = " ".join(line.split())
+    return line if len(line) <= _LINE_LIMIT else line[:_LINE_LIMIT - 3] + "..."
+
+
+def _is_negated(text: str, start: int) -> bool:
+    """Whether the clause before a keyword, on the same line, carries a negation."""
+    line_start = text.rfind("\n", 0, start) + 1
+    before = text[line_start:start]
+    boundaries = list(_CLAUSE_BOUNDARY.finditer(before))
+    clause = before[boundaries[-1].end():] if boundaries else before
+    return bool(_NEGATION.search(clause))
+
+
+def _references(repo: str, text: str):
+    """Yield (key, display, negated, line) for every closing reference in text."""
+    for match in _CLOSING.finditer(text or ""):
+        key, display = _normalise(repo, match)
+        yield key, display, _is_negated(text, match.start()), _line_of(text, match.start(), match.end())
+
+
+def closing_problems(repo: str, title: str, body: str, commit_messages) -> list[str]:
+    """Landing blockers for closing keywords; an empty list means the text is safe to land.
+
+    `commit_messages` holds either plain message strings or `(label, message)` pairs.
+    """
+    problems: list[str] = []
+    declared: set[tuple[str, int]] = set()
+
+    for key, display, negated, line in _references(repo, body):
+        if negated:
+            problems.append(
+                f"negated closing keyword in PR body still closes {display}; "
+                f'GitHub ignores negation: "{line}"'
+            )
+        else:
+            declared.add(key)
+
+    sources = [("title", title or "")]
+    for index, item in enumerate(commit_messages, start=1):
+        label, message = item if isinstance(item, tuple) else (f"commit {index}", item)
+        sources.append((label, message or ""))
+
+    for label, text in sources:
+        for key, display, negated, line in _references(repo, text):
+            if negated:
+                problems.append(
+                    f"negated closing keyword in {label} still closes {display}; "
+                    f'GitHub ignores negation: "{line}"'
+                )
+            elif key not in declared:
+                problems.append(
+                    f"{label} closes {display}, which the PR body does not declare; "
+                    f'declare it in the body or drop the keyword: "{line}"'
+                )
+    return problems

--- a/scripts/review/closing_keywords.py
+++ b/scripts/review/closing_keywords.py
@@ -38,11 +38,33 @@ _REF = (
 # "disclose", "prefix", "unresolved", "fixture" and "closet" never match.
 _CLOSING = re.compile(rf"(?<![\w-]){_KEYWORD}(?![\w-])\s*:?\s*{_REF}", re.IGNORECASE)
 
-# A clause ends at sentence punctuation followed by whitespace, so "ci.yml" is not a boundary.
-_CLAUSE_BOUNDARY = re.compile(r"[.!?;](?=\s)")
+# A clause ends at sentence punctuation followed by whitespace, so "ci.yml" is not a boundary,
+# and at a paragraph break. It also ends where a line starts a new structural element: a list
+# item, heading, table row or blockquote. A plain soft line break does not end it, because this
+# repository hard-wraps PR bodies and commit messages, so "It does not" at the end of one line and
+# the keyword at the start of the next is an ordinary shape, not an edge case.
+_CLAUSE_BOUNDARY = re.compile(
+    r"[.!?;](?=\s)"
+    r"|\n[ \t]*\n"
+    r"|\n(?=[ \t]*(?:[-*+][ \t]|\d+[.)][ \t]|#{1,6}[ \t]|\||>))"
+)
 # Bare "no" is left out on purpose: "a no-op that closes #5" is a real close, not a negation.
-_NEGATION = re.compile(r"(?<![\w-])(?:not|never|nor|without|cannot)(?![\w-])|n't(?![\w-])",
-                       re.IGNORECASE)
+# "no longer" is in, because it negates what follows it. Contractions are matched with and without
+# the apostrophe, since "wont" and "doesnt" are what fast typing produces.
+_NEGATORS = (
+    "not", "never", "nor", "neither", "without", "cannot", "unable", "hardly",
+    "dont", "doesnt", "didnt", "wont", "isnt", "arent", "cant", "shouldnt", "wouldnt", "couldnt",
+)
+_NEGATION = re.compile(
+    r"(?<![\w-])(?:" + "|".join(_NEGATORS) + r"|no[ \t\n]+longer)(?![\w-])|n't(?![\w-])",
+    re.IGNORECASE,
+)
+# Typographic apostrophes become ASCII before the negation scan: an editor or a phone turns
+# "doesn't" into "doesn\u2019t", and GitHub still reads the keyword that follows.
+_APOSTROPHES = str.maketrans({"\u2019": "'", "\u2018": "'", "\u02bc": "'", "\uff07": "'"})
+# A keyword that opens its own line with a capital letter ("Closes #5") is a trailer or a new
+# sentence, not the wrapped tail of the line above, so it starts a fresh clause.
+_LINE_OPENING_KEYWORD = re.compile(r"[ \t]*(?:[-*+][ \t]+|\d+[.)][ \t]+)?[A-Z]")
 
 _LINE_LIMIT = 200
 
@@ -65,12 +87,18 @@ def _line_of(text: str, start: int, end: int) -> str:
 
 
 def _is_negated(text: str, start: int) -> bool:
-    """Whether the clause before a keyword, on the same line, carries a negation."""
+    """Whether the clause before a keyword carries a negation.
+
+    The clause runs back to the nearest boundary, across soft line breaks. A capitalised keyword
+    at the start of its own line begins a new clause, so a trailer never inherits the line above.
+    """
     line_start = text.rfind("\n", 0, start) + 1
-    before = text[line_start:start]
+    if _LINE_OPENING_KEYWORD.fullmatch(text[line_start:start + 1]):
+        return False
+    before = text[:start]
     boundaries = list(_CLAUSE_BOUNDARY.finditer(before))
     clause = before[boundaries[-1].end():] if boundaries else before
-    return bool(_NEGATION.search(clause))
+    return bool(_NEGATION.search(clause.translate(_APOSTROPHES)))
 
 
 def _references(repo: str, text: str):

--- a/scripts/review/pr_landing_readiness.py
+++ b/scripts/review/pr_landing_readiness.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from urllib.parse import quote, unquote
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from closing_keywords import closing_problems  # noqa: E402
 from assay_review_record_check import (  # noqa: E402
     GateError,
     MARKER as REVIEW_RECORD_MARKER,
@@ -21,7 +23,7 @@ SHA_RE = re.compile(r"(?<![0-9a-f])[0-9a-f]{40}(?![0-9a-f])", re.IGNORECASE)
 REPO_COMPONENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,99}")
 MAX_JSON_BYTES = 8 * 1024 * 1024
 COMMAND_TIMEOUT_SECONDS = 30
-PR_VIEW_FIELDS = "number,title,url,state,author,isDraft,mergeable,mergeStateStatus,headRefName,headRefOid,baseRefName,baseRefOid,body,reviews,comments"
+PR_VIEW_FIELDS = "number,title,url,state,author,isDraft,mergeable,mergeStateStatus,headRefName,headRefOid,baseRefName,baseRefOid,body,reviews,comments,commits"
 PR_CHECK_FIELDS = "name,state,bucket,link,workflow,event"
 REQUIRED_CONTEXT_QUERY = "query($owner:String!,$name:String!,$ref:String!){repository(owner:$owner,name:$name){ref(qualifiedName:$ref){branchProtectionRule{requiredStatusCheckContexts}}}}"
 
@@ -350,6 +352,17 @@ def main():
         blockers.append("current-head BLOCKED review exists")
     if not body_mentions_head:
         blockers.append("PR body does not mention current head SHA")
+    # Closing keywords in text that lands on the default branch (#2880). GitHub has no notion
+    # of negation and reads frozen commit messages, so both have closed issues their authors
+    # meant to keep open. See scripts/review/closing_keywords.py for the rule.
+    commit_messages = [
+        (f"commit {str(c.get('oid') or '')[:9]}",
+         f"{c.get('messageHeadline') or ''}\n\n{c.get('messageBody') or ''}")
+        for c in (pr.get("commits") or [])
+    ]
+    keyword_problems = closing_problems(
+        args.repo, pr.get("title") or "", pr.get("body") or "", commit_messages)
+    blockers.extend(keyword_problems)
 
     payload = {
         "pr": {key: pr.get(key) for key in ("number", "title", "url", "state", "author", "isDraft", "mergeable", "mergeStateStatus", "headRefName", "headRefOid", "baseRefName", "baseRefOid")},
@@ -360,6 +373,7 @@ def main():
         "check_policy": "explicit-unprotected" if explicit_checks else "classic-and-active-rulesets",
         "review_candidates": candidates,
         "body_mentions_head": body_mentions_head,
+        "closing_keyword_problems": keyword_problems,
         "blockers": blockers,
         "landing_candidate": not blockers,
         "non_claim": "Reviewer independence and actionable-finding disposition require human verification.",

--- a/scripts/review/test_closing_keywords.py
+++ b/scripts/review/test_closing_keywords.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Behavioural tests for the closing-keyword landing guard (#2880).
+
+The two incident fixtures reproduce what actually happened on this repository. GitHub parses
+closing keywords only in PR descriptions and commit messages, never in file contents, so this
+file is safe as it stands. The keyword is still assembled from parts and the issue numbers are
+fake, so the fixture text cannot be lifted verbatim into a PR body or commit message, where it
+would close whatever it names.
+"""
+import importlib.util
+import pathlib
+import unittest
+
+MODULE_PATH = pathlib.Path(__file__).with_name("closing_keywords.py")
+SPEC = importlib.util.spec_from_file_location("closing_keywords", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+REPO = "Rul1an/assay"
+KW = "clo" + "se"          # assembled so this file carries no live keyword phrase
+KWS = KW + "s"
+
+
+def problems(title="", body="", commits=()):
+    return MODULE.closing_problems(REPO, title, body, list(commits))
+
+
+class IncidentFixtures(unittest.TestCase):
+    def test_negated_keyword_in_body_is_refused(self):
+        # PR #2805: the body said it did not close the trace-v7 issue, and GitHub closed it,
+        # because GitHub has no notion of negation and reads the keyword and number alone.
+        body = f"Storage coherence only. Does not {KW} #9001; the carrier stays open."
+        found = problems(body=body)
+        self.assertTrue(found, "a negated keyword next to an issue number must block landing")
+        self.assertTrue(any("#9001" in p and "negat" in p for p in found), found)
+
+    def test_commit_keyword_the_body_retracted_is_refused(self):
+        # PR #2532: the author edited the body to say the issue stays open, but the squash
+        # commit still carried the keyword from the original commit body, and the issue closed.
+        body = "Addresses the inventory half of #9002. The M18 residual is untouched, so it stays open."
+        commit = f"test(cli): compare parsed publisher sets\n\n{KWS.capitalize()} #9002"
+        found = problems(body=body, commits=[commit])
+        self.assertTrue(found, "a commit that closes what the body does not declare must block")
+        self.assertTrue(any("#9002" in p and "commit" in p for p in found), found)
+
+
+class Controls(unittest.TestCase):
+    def test_no_keywords_is_clean(self):
+        self.assertEqual(problems(title="ci: tidy", body="Refs #10. Nothing closes.",
+                                  commits=["ci: tidy\n\nRefs #10"]), [])
+
+    def test_declared_close_is_clean(self):
+        self.assertEqual(problems(body=f"{KWS.capitalize()} #11"), [])
+
+    def test_commit_close_echoed_by_body_is_clean(self):
+        self.assertEqual(problems(body=f"{KWS.capitalize()} #12",
+                                  commits=[f"fix: thing\n\n{KWS.capitalize()} #12"]), [])
+
+    def test_negation_in_a_previous_sentence_does_not_leak(self):
+        body = f"This does not change behaviour. {KWS.capitalize()} #13."
+        self.assertEqual(problems(body=body), [])
+
+    def test_refs_is_not_a_closing_keyword(self):
+        self.assertEqual(problems(body="Does not close anything; refs #14 only."), [])
+
+
+class Grammar(unittest.TestCase):
+    """Every form GitHub documents must be recognised, or the guard has a blind spot."""
+
+    def test_every_documented_keyword_is_recognised(self):
+        for word in ("close", "closes", "closed", "fix", "fixes", "fixed",
+                     "resolve", "resolves", "resolved"):
+            with self.subTest(word=word):
+                found = problems(commits=[f"x\n\n{word} #20"])
+                self.assertTrue(found, f"{word!r} closes an issue and was not seen")
+
+    def test_colon_and_uppercase_forms(self):
+        self.assertTrue(problems(commits=["x\n\nCLOSES: #21"]))
+        self.assertTrue(problems(commits=["x\n\nFixes:#22"]))
+
+    def test_same_repo_long_form_and_url_normalise_to_one_issue(self):
+        body = f"{KWS.capitalize()} #23"
+        for ref in ("Rul1an/assay#23", "https://github.com/Rul1an/assay/issues/23"):
+            with self.subTest(ref=ref):
+                self.assertEqual(problems(body=body, commits=[f"x\n\nfixes {ref}"]), [])
+
+    def test_cross_repo_close_must_also_be_declared(self):
+        found = problems(commits=["x\n\nfixes octo/other#24"])
+        self.assertTrue(any("octo/other#24" in p for p in found), found)
+
+    def test_title_lands_in_the_merge_commit(self):
+        found = problems(title="Fix #25 flake in the runner")
+        self.assertTrue(any("#25" in p and "title" in p for p in found), found)
+
+    def test_word_boundary_prevents_false_matches(self):
+        # "disclose", "prefix", "unresolved" contain keywords as substrings, not as words.
+        # This must sit in a commit message: a false match in the body only adds to the
+        # declared set and reports nothing, so a body-only test cannot see the boundary go.
+        for text in ("disclose #26", "prefix #27", "unresolved #28"):
+            with self.subTest(text=text):
+                self.assertEqual(problems(commits=[f"docs: x\n\n{text}"]), [])
+
+    def test_offending_line_is_reported(self):
+        body = f"Line one.\nIt does not {KW} #29 at all.\nLine three."
+        found = problems(body=body)
+        self.assertTrue(any(f"does not {KW} #29" in p for p in found), found)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/review/test_closing_keywords.py
+++ b/scripts/review/test_closing_keywords.py
@@ -44,6 +44,49 @@ class IncidentFixtures(unittest.TestCase):
         self.assertTrue(any("#9002" in p and "commit" in p for p in found), found)
 
 
+class NegationShapes(unittest.TestCase):
+    """Found by the independent reviews of 9dd968c4c (Muse F1-F3, Ruley 1): each was a silent
+    close before the fix. Every boundary and every negator is pinned on its own, so dropping any
+    one of them turns exactly the matching test red."""
+
+    # A literal list, deliberately not read from the module. An earlier version iterated
+    # MODULE._NEGATORS, so deleting a word from the module also deleted it from the test, and
+    # seventeen of eighteen negators could be dropped with the suite still green.
+    NEGATORS = ("not", "never", "nor", "neither", "without", "cannot", "unable", "hardly",
+                "dont", "doesnt", "didnt", "wont", "isnt", "arent", "cant", "shouldnt",
+                "wouldnt", "couldnt", "no longer", "does n't")
+
+    def test_every_negator_is_recognised(self):
+        for word in self.NEGATORS:
+            with self.subTest(word=word):
+                found = problems(body=f"This change {word} {KW} #9010.")
+                self.assertTrue(found, f"{word!r} before a keyword was read as a declaration")
+
+    def test_typographic_apostrophe_is_a_negation(self):
+        for apostrophe in ("’", "‘", "ʼ", "＇"):
+            with self.subTest(apostrophe=hex(ord(apostrophe))):
+                found = problems(body=f"It doesn{apostrophe}t {KW} #9011.")
+                self.assertTrue(found, "an editor's curly apostrophe hid the negation")
+
+    def test_negation_on_the_line_above_a_wrapped_keyword(self):
+        # This repository hard-wraps prose, so the negation often ends the previous line.
+        self.assertTrue(problems(body=f"It does not\n{KW} #9012."))
+        self.assertTrue(problems(body=f"- This does not\n  {KW} #9013, a wrapped list item."))
+
+    def test_capitalised_keyword_on_its_own_line_starts_a_new_clause(self):
+        # A trailer after an unrelated negation must stay a declaration, not become a block.
+        self.assertEqual(problems(body=f"This does not change behaviour\n{KWS.capitalize()} #9014"), [])
+
+    def test_new_list_item_does_not_inherit_the_previous_negation(self):
+        self.assertEqual(problems(body=f"- this does not change x\n- {KWS} #9015"), [])
+
+    def test_paragraph_break_resets_the_clause(self):
+        self.assertEqual(problems(body=f"It does not\n\n{KWS} #9016"), [])
+
+    def test_table_row_does_not_inherit_the_previous_row(self):
+        self.assertEqual(problems(body=f"| a | does not change |\n| b | {KWS} #9017 |"), [])
+
+
 class Controls(unittest.TestCase):
     def test_no_keywords_is_clean(self):
         self.assertEqual(problems(title="ci: tidy", body="Refs #10. Nothing closes.",

--- a/scripts/review/test_closing_keywords.py
+++ b/scripts/review/test_closing_keywords.py
@@ -53,7 +53,7 @@ class NegationShapes(unittest.TestCase):
     # MODULE._NEGATORS, so deleting a word from the module also deleted it from the test, and
     # seventeen of eighteen negators could be dropped with the suite still green.
     NEGATORS = ("not", "never", "nor", "neither", "without", "cannot", "unable", "hardly",
-                "dont", "doesnt", "didnt", "wont", "isnt", "arent", "cant", "shouldnt",
+                "barely", "scarcely", "rarely", "seldom", "aint", "dont", "doesnt", "didnt", "wont", "isnt", "arent", "cant", "shouldnt",
                 "wouldnt", "couldnt", "no longer", "does n't")
 
     def test_every_negator_is_recognised(self):
@@ -73,9 +73,30 @@ class NegationShapes(unittest.TestCase):
         self.assertTrue(problems(body=f"It does not\n{KW} #9012."))
         self.assertTrue(problems(body=f"- This does not\n  {KW} #9013, a wrapped list item."))
 
-    def test_capitalised_keyword_on_its_own_line_starts_a_new_clause(self):
-        # A trailer after an unrelated negation must stay a declaration, not become a block.
-        self.assertEqual(problems(body=f"This does not change behaviour\n{KWS.capitalize()} #9014"), [])
+    def test_capitalised_keyword_on_its_own_line_is_still_negated(self):
+        # Found by the review of da4f917 (Muse R1). A capitalised keyword opening its own line was
+        # exempted as a trailer, so each of these read clean while GitHub closed the issue.
+        cap, upper = KW.capitalize(), KWS.upper()
+        for body in (f"This PR does not\n{cap} #9014",
+                     f"This PR does not\n{upper} #9014",
+                     f"This PR does not\n  {cap} #9014 and more words",
+                     f"It does not\nchange that and\n{cap} #9014"):
+            with self.subTest(body=body):
+                self.assertTrue(problems(body=body), "a capitalised keyword line escaped the negation")
+
+    def test_trailer_after_a_boundary_is_a_declaration(self):
+        # The shapes a real trailer takes: after a blank line, or after a finished sentence.
+        self.assertEqual(problems(body=f"This does not change behaviour.\n{KWS.capitalize()} #9018"), [])
+        self.assertEqual(problems(body=f"This does not change behaviour\n\n{KWS.capitalize()} #9019"), [])
+
+    def test_negation_after_the_reference_in_the_same_clause(self):
+        # CodeRabbit on 9dd968c4c: the clause after the reference counts too.
+        self.assertTrue(problems(body=f"{KWS.capitalize()} #9020, but does not finish it"))
+        self.assertTrue(problems(body=f"{KWS.capitalize()} #9021 without\nthe second half"))
+
+    def test_negation_in_the_next_sentence_does_not_leak_back(self):
+        self.assertEqual(problems(body=f"{KWS.capitalize()} #9022. This does not change behaviour."), [])
+        self.assertEqual(problems(body=f"{KWS.capitalize()} #9023\n\nIt does not change behaviour."), [])
 
     def test_new_list_item_does_not_inherit_the_previous_negation(self):
         self.assertEqual(problems(body=f"- this does not change x\n- {KWS} #9015"), [])

--- a/scripts/review/test_pr_landing_readiness.py
+++ b/scripts/review/test_pr_landing_readiness.py
@@ -312,13 +312,13 @@ class UnprotectedPolicyTests(unittest.TestCase):
     def run_report(self, *, explicit=True, protected=False, rules=None, checks=None,
                    review=True, blocked=False, state="OPEN", draft=False,
                    mergeable="MERGEABLE", body_current=True, number=30,
-                   output_format="json"):
+                   output_format="json", title="test", body_extra="", commits=None):
         head = "b" * 40
-        pr = dict(number=number, title="test", state=state, isDraft=draft,
+        pr = dict(number=number, title=title, state=state, isDraft=draft,
                   mergeable=mergeable, headRefOid=head, baseRefOid="a" * 40,
                   baseRefName="main", headRefName="codex/review-fix",
-                  body=head if body_current else "no pinned head",
-                  reviews=[], comments=[])
+                  body=(head if body_current else "no pinned head") + body_extra,
+                  reviews=[], comments=[], commits=commits or [])
         if review:
             pr["comments"] = [{"author": {"login": "reviewer"}, "body": f"READY\n{head}"}]
         if blocked:
@@ -404,6 +404,44 @@ class UnprotectedPolicyTests(unittest.TestCase):
         for protected, rules in [(True, []), (None, []), (False, [{}]), (False, {})]:
             with self.subTest(protected=protected, rules=rules), self.assertRaises(SystemExit):
                 self.run_report(protected=protected, rules=rules)
+
+    # The closing-keyword guard (#2880) is only worth anything on the landing path, so these
+    # drive it through main() rather than through the helper. Each case is otherwise a clean
+    # landing candidate, so the keyword blocker is the only thing that can flip the verdict.
+    KW = "clo" + "ses"
+
+    def test_clean_candidate_is_the_control_for_the_keyword_cases(self):
+        report, _ = self.run_report(body_extra=f"\n\n{self.KW.capitalize()} #7",
+                                    commits=[{"oid": "c" * 40, "messageHeadline": "fix: x",
+                                              "messageBody": f"{self.KW.capitalize()} #7"}])
+        self.assertTrue(report["landing_candidate"], report["blockers"])
+        self.assertEqual(report["closing_keyword_problems"], [])
+
+    def test_negated_keyword_in_body_blocks_landing(self):
+        report, _ = self.run_report(body_extra=f"\n\nDoes not {self.KW[:-1]} #7.")
+        self.assertFalse(report["landing_candidate"])
+        self.assertTrue(any("#7" in b and "negat" in b for b in report["blockers"]),
+                        report["blockers"])
+
+    def test_commit_keyword_the_body_does_not_declare_blocks_landing(self):
+        report, _ = self.run_report(
+            body_extra="\n\nRefs #7; it stays open.",
+            commits=[{"oid": "d" * 40, "messageHeadline": "fix: x",
+                      "messageBody": f"{self.KW.capitalize()} #7"}])
+        self.assertFalse(report["landing_candidate"])
+        self.assertTrue(any("dddddddd" in b and "#7" in b for b in report["blockers"]),
+                        report["blockers"])
+
+    def test_title_keyword_the_body_does_not_declare_blocks_landing(self):
+        report, _ = self.run_report(title="Fix #7 in the runner")
+        self.assertFalse(report["landing_candidate"])
+        self.assertTrue(any("title" in b and "#7" in b for b in report["blockers"]),
+                        report["blockers"])
+
+    def test_commits_are_requested_from_github(self):
+        _, calls = self.run_report()
+        view = next(c for c in calls if c[1:3] == ["pr", "view"])
+        self.assertIn("commits", view[-1].split(","))
 
     def test_missing_or_non_success_checks_refused(self):
         for state, bucket in [("FAILURE", "fail"), ("PENDING", "pending"), ("SKIPPED", "pass"), ("NEUTRAL", "pass"), ("SUCCESS", "unknown")]:

--- a/scripts/review/test_safe_merge_protocol.py
+++ b/scripts/review/test_safe_merge_protocol.py
@@ -6,7 +6,7 @@ with tempfile.TemporaryDirectory(prefix='safe-merge-protocol-') as d:
     ci = root / 'scripts' / 'ci'
     review.mkdir(parents=True)
     ci.mkdir(parents=True)
-    for name in ('safe_merge.sh', 'pr_landing_readiness.py', 'verify_review_identity.py'):
+    for name in ('safe_merge.sh', 'pr_landing_readiness.py', 'verify_review_identity.py', 'closing_keywords.py'):
         shutil.copy2(source / name, review / name)
     shutil.copy2(source.parent / 'ci' / 'assay_review_record_check.py',
                  ci / 'assay_review_record_check.py')
@@ -19,7 +19,7 @@ case=os.environ['CASE']
 if args[:2]==['pr','view']:
  record=dict(schema='assay.review-record.v0',head_sha='a'*40 if case=='stale' else head,review_completed=True,verdict='BLOCKED' if case=='blocked' else 'READY',builder=dict(agent='codex',instance='writer'),reviewer=dict(agent='claude',instance='other' if case=='identity-mismatch' else 'reviewer',github_login='reviewer'),independence=dict(did_not_build=True,did_not_author_governing_spec=True),findings=[],no_findings=True)
  body='<!-- assay-review-record -->\\n```json\\n'+json.dumps(record)+'\\n```'
- print(json.dumps(dict(number=30,author=dict(login='owner'),state='OPEN',isDraft=False,mergeable='MERGEABLE',headRefOid=head,headRefName='codex/review-fix',baseRefOid='a'*40,baseRefName='main',body=head,comments=[] if case=='no-review' else [dict(author=dict(login='reviewer'),body=body)])))
+ print(json.dumps(dict(number=30,author=dict(login='owner'),state='OPEN',isDraft=False,mergeable='MERGEABLE',headRefOid=head,headRefName='codex/review-fix',baseRefOid='a'*40,baseRefName='main',body=head+('\\n\\nDoes not '+'clo'+'se #7.' if case=='negated-keyword' else ''),comments=[] if case=='no-review' else [dict(author=dict(login='reviewer'),body=body)])))
 elif args[:2]==['pr','checks']:
  print(json.dumps([dict(name='reproduce',state='SKIPPED' if case=='skipped' else 'SUCCESS',bucket='pass')]))
 elif args[:2]==['pr','merge']:
@@ -38,7 +38,7 @@ elif args[-1].endswith('/branches/main'): print('{"protected":false}')
 else: raise SystemExit('unexpected gh arguments: '+repr(args))
 ''')
     gh.chmod(0o755)
-    for case, explicit in [('protected',False),('ruleset',False),('unprotected',True),('no-review',True),('skipped',True),('blocked',True),('stale',True),('identity-mismatch',True)]:
+    for case, explicit in [('protected',False),('ruleset',False),('unprotected',True),('no-review',True),('skipped',True),('blocked',True),('stale',True),('identity-mismatch',True),('negated-keyword',True)]:
         log=root/'merge.json'
         log.unlink(missing_ok=True)
         env=dict(os.environ, PATH=str(root)+':'+os.environ['PATH'], CASE=case, MERGE_LOG=str(log))
@@ -48,6 +48,8 @@ else: raise SystemExit('unexpected gh arguments: '+repr(args))
         expected=case in ('protected','ruleset','unprotected')
         assert (p.returncode==0)==expected,(case,p.stderr)
         assert log.exists()==expected,case
+        if case=='negated-keyword':
+            assert 'negated closing keyword' in p.stderr and '#7' in p.stderr,(case,p.stderr)
         if expected:
             command=json.loads(log.read_text())
             assert command[-2:]==['--match-head-commit','b'*40],command


### PR DESCRIPTION
**Candidate, not a landing.** Current head `041e89d39d345acbe753bd3397c0b4b54005e5a9` is `gh pr update-branch` over the reviewed head `60334aaea3bfa02932321ee3a514ccd907fa1c44`, bringing in main's #2884 (`.cursor/environment.json`, `.gitignore`, no reviewed file); Muse's carry record with both AGENTS.md equivalence checks: [5617134905](https://github.com/Rul1an/assay/pull/2883#issuecomment-5617134905). Reviewed head SHA `60334aaea3bfa02932321ee3a514ccd907fa1c44`. Supersedes `da4f917824210ccfd375514df1de153d4c1466e5` (Muse: READY, [record](https://github.com/Rul1an/assay/pull/2883#issuecomment-5616469573), with findings R1-R3) and `9dd968c4c990d13c465c0fa35c259e018263c6bb` (Muse READY, Ruley BLOCKED advisory). Every finding and its disposition is below. Sole author; needs an independent exact-head review record before merge, and I will not write one.

Closes #2880

## Problem

GitHub closes an issue when a closing keyword sits directly before an issue number, in a PR description or in a commit message that lands on the default branch. It has no notion of negation, and it reads commit messages the author can no longer edit.

Measured with GitHub's own `closer` field (GraphQL `ClosedEvent.closer`), that shut issues their authors meant to keep open **nine times across six issues** between 2026-08-19 and 2026-09-05. Two of those closes went unnoticed for days:

| issue | shut by | shape | outcome |
|---|---|---|---|
| #2383 | a commit in #2532 | keyword retracted from the body, still in the commit | reopened |
| #2194 | #2633 body and commit | sentence saying the PR left it open | reopened after 5 min |
| #2684 | #2738 body | same | reopened after 16 min |
| #2194 | #2734 body | same | reopened after 58 min |
| #2776 | #2779 body | `Does **not** ...` before the number | reopened after 90 s |
| #2776 | #2780 body | same | **still shut; P1 security bug** |
| #2782 | #2795 body | same | shut for six days; reopened 2026-09-10 |
| #2787 | #2805 body | same | reopened after 90 s |
| #2684 | commit `be0c2b4a8` in #2822 | same | reopened after 29 s |

#2880 was filed after two of these. The rest surfaced while measuring this guard: five on the first sweep, and #2194's two and #2776's two on a wider one. #2776 needs an owner decision; nothing in this PR changes its state.

## Rule

The PR body is the live declaration of what a merge closes. `pr_landing_readiness.py` reports a blocker, via a new `closing_keywords.py`, when:

1. a closing keyword and issue reference sit in a negated clause, in the body, the title or any commit message; or
2. a commit message or the title closes an issue the body does not also close with a non-negated keyword. The title is included because it becomes the merge or squash commit subject.

`safe_merge.sh` already refuses on any readiness blocker, so there is no second check path. `commits` joins `PR_VIEW_FIELDS`; the command boundary still pins the exact `gh pr view` shape.

**One deliberate change from the issue as filed.** It asked to compare against GitHub's `closingIssuesReferences`. That set is computed by the same parse, so a negated phrase is already in it: the comparison cannot see the case that matters most. The body is the non-circular declaration.

## Proof (first round, at `9dd968c4c`)

Tests written first and red (module absent, then readiness unwired):

- 14 on the rule: both filed incidents as fixtures; clean, declared, echoed and previous-sentence controls; every documented keyword; colon and uppercase; same-repo long form and URL normalise to one issue; cross-repo; title; word boundaries; the offending line is reported.
- 5 through `main()`, each an otherwise clean landing candidate so the keyword blocker is the only thing that can flip it, plus one asserting `commits` is requested from GitHub.
- 1 end to end in `test_safe_merge_protocol.py`: the fake `gh` returns a negated body; `safe_merge.sh` exits 1, names the reason, and **`gh pr merge` is never invoked**.

Six mutations, each red: negation detection off; undeclared-close check off; `commits` dropped from the fields; problems computed but not blocking; title unscanned; word boundary removed.

The last one survived at first. The word-boundary test had its text in the body, where a false match only adds to the declared set and reports nothing. It now sits in a commit message, where removing the boundary fails all three cases.

**On real data.** The rule run over the current text of the last 60 merged PRs (#2784 to #2882): three flagged, all three genuine negated phrases GitHub acted on, none spurious. #2532 flags on its real commit. #2805 reads clean today because its body was edited after the close; a guard can only judge the text present at merge time.

Whole review suite 53/53. Every changed path classifies `Gate.NONE`. This PR's own body and commit message were run through the guard before pushing: clean.

## Review findings on `9dd968c4c` and their disposition

Two independent reviewers, run in parallel with separate scopes: Muse (full adversarial review, mutations, record) and Ruley (the negation heuristic, and the real-data claims). Both reproduced the nine-`closer` record and the sweep, and both confirmed `gh pr merge` is never invoked.

| finding | raised by | disposition |
|---|---|---|
| negation on the line above a wrapped keyword was missed | Muse F2, Ruley | **fixed**: a clause runs back across soft line breaks and ends at sentence punctuation, a blank line, a list item, heading, table row or blockquote |
| a typographic apostrophe hid the negation in `doesn’t` | Muse F1, Ruley | **fixed**: apostrophes normalised before the negation scan |
| out-of-list negators (`unable`, `wont`, `hardly`) | Ruley | **fixed**: added with `neither`, `no longer` and the apostrophe-less contractions; `far from` left out, since `close`/`closes`/`closed` never follow it in a real sentence |
| negator list unpinned | Muse F3 | **fixed, and worse than reported**: the test iterated the module's own list, so 17 of 18 negators could be dropped with the suite green. It now carries a literal list; each negator drop is red |
| title scanned under `--rebase`, where it never lands | Muse F4, Ruley | **documented** in the README as a known false block |
| base branch not consulted | Muse F5 | **documented**: a non-default base closes nothing by its body, but its commits still close issues when they reach the default branch |
| body said #2782 "still closed today"; closer attribution vs #2788 | Muse F6 | **corrected** in this body: #2782 was reopened 2026-09-10; GitHub's `closer` names #2795, and #2788 carried the same sentence |
| sidebar Development links close with no keyword text | Muse F7 | **documented** as a silent close this guard cannot see |

Each boundary and the apostrophe step has its own test and its own mutation; all red.

**Rerun on real data.** Over the current text of the last 100 merged PRs (#2715 to #2882): seven flagged, each confirmed against GitHub's `closer` field as a close its author wrote they did not intend. None spurious.

**The guard caught its author.** The first draft of the fix commit message described two of the new incidents as "#2734 <past-tense keyword> #2194". Run through the guard before commit, it was refused: merged, it would have shut #2194, an open P1.

Whole review suite 60/60 at `da4f917`. Every changed path classifies `Gate.NONE`.

## Review findings on `da4f917` and their disposition

Muse reviewed the delta at the exact head: 60/60, every listed mutation red including all 20 single-negator drops, the 100-PR sweep reproduced at exactly seven hits, and this PR's own text clean.

| finding | severity | disposition |
|---|---|---|
| R1: the trailer rule was a silent-clean path. `does not` at the end of one line and a capitalised keyword opening the next read clean in seven shapes, while GitHub closes the issue. The README called every limit but one a false block, which this made untrue | medium | **fixed by removal.** Measured first: over the last 100 merged PRs the exemption touched 40 references and prevented no false block; the sweep gives the same seven hits with and without it. A trailer is now a declaration only after a finished sentence or a blank line. The rule's own test is inverted to four blocking shapes plus two clean trailer controls; re-adding the exemption turns it red |
| R2: a line mentioning a negation, even in inline code, directly before a genuine closing line is blocked; so is a `not only ... but also` declaration | low | **documented** in the README as known false blocks, with the remedy |
| R3: `barely`, `scarcely`, `rarely`, `seldom`, `aint` read clean | low | **fixed**: added and pinned in the literal list; each drop is red |
| CodeRabbit on `9dd968c4c`, second half: a negation after the number (`<keyword> #N, but does not finish it`) read as a declaration. The `no longer` half was already fixed in `da4f917`; this half had not been disposed | major (bot) | **fixed**: the negation scan covers the clause on both sides of the reference. Over the 48 real references in the 100-PR sweep no genuine close had a negation later in its clause. `<keyword> #N without changing X` is a new known false block, documented. Forward scan off, forward scan unbounded, and backward scan off are each red |

The README now splits known false blocks from known silent closes, and names the finite negator list among the silent closes: an unlisted negation word still reads as a declaration.

Whole review suite 63/63 at this head; the 100-PR sweep still gives exactly the same seven hits.

## Non-claims

- A close that already happened is not undone. #2776 needs a separate decision.
- An issue linked through the sidebar's Development panel also closes on merge and is invisible to a text scan. That is a deliberate act, not a surprise, and is out of scope.
- The negation heuristic is conservative. It prefers a false block, which costs one rewording, to a silent close.
- The review tests run through the `review-relay-protocol-tests` pre-commit hook and Kernel Matrix Lint, not required CI.

## Review asks

Review the delta `da4f917..60334aaea`: is the removal complete, is the README's split between false blocks and silent closes accurate, and does any shape now block that should not? Rerun the mutations and the 100-PR sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


