### PR TITLE
Add repo-managed Cloud Agent environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Assay",
+  "install": "cargo install --path crates/assay-cli --locked && cargo install --path crates/assay-mcp-server --locked"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ docs/DISTRIBUTION-CHANNELS.md
 .cursor/*
 !.cursor/BUGBOT.md
 !.cursor/mcp.json
+!.cursor/environment.json
 .mcpregistry_*
 _v.txt
 ai-agent-eval-plugin/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a repo-managed Cloud Agent development environment so agents (and contributors using Cursor Cloud) get a working Assay toolchain on startup.

- New `.cursor/environment.json` with an `install` step that builds and installs the `assay` and `assay-mcp-server` binaries from source, placing them on `PATH` for the golden-path workflow, `make demo`, and `examples/`.
- `.gitignore` gains a `!.cursor/environment.json` exception (alongside the existing `BUGBOT.md` / `mcp.json` exceptions) so the repo-managed config is tracked.

The default Cursor base image already provides `rustup`, which auto-provisions the pinned Rust `1.96.0` toolchain (`rust-toolchain.toml`), plus `cargo`, `python3`, `make`, and C/C++ compilers, so no Dockerfile is required. This mirrors the existing `.devcontainer` approach (`cargo install --path crates/assay-cli --locked`) and extends it to also install `assay-mcp-server` (needed for the MCP proxy / SARIF golden-path steps).

This change touches only environment configuration — no evidence-ingestion, evidence-verification, or MCP-authorization code — so it is outside ADR-042/043 scope.

## Type of Change
- [x] New feature (development environment configuration)

## Verification

Local VM, branch head `038a36bf16228eb501ef24b4bf12163e7ff5f7d1`, `rustc 1.96.0`:

- [x] `cargo install --path crates/assay-cli --locked` and `cargo install --path crates/assay-mcp-server --locked` succeed; `assay version` and `assay-mcp-server --version` both report `6.1.0`.
- [x] `cargo build --workspace --locked` succeeds (all crates) — dev/test builds work.
- [x] `cargo test -p assay-common --locked` passes (unit + integration + doc-tests).
- [x] Golden path steps 1–9 exercised (`version`, `doctor` `config_check: checked`, `init`, `policy validate`, `run` all pass, `proxy-enforce`, `evidence show`, `evidence verify-privileged-mcp-action`, `enforcement-sarif`).
- [x] `make demo` — unsafe trace FAILS (policy enforced), safe trace PASSES.
- [x] `examples/privileged-action-gate/run.sh` — three DENY axes, one ALLOW, one ALLOW+conformance-mismatch, plus evidence import/verify claim matrix (`verdict=valid`).

### Prebuilt environment build (fresh checkout of this branch)

- [x] Draft build `bld-20260910-b88e32c4-4de3-4625-8da8-f101a68159f0` **SUCCEEDED**. Install log: rustup synced channel `1.96.0` from `rust-toolchain.toml`; `Installed package assay-cli ... (executable assay)` and `assay-mcp-server`; `[INSTALL] Exit code: 0`; snapshot ready.
- [x] **Fresh cloud agent booted from that build**: `assay` and `assay-mcp-server` (`6.1.0`) already on `PATH` under `/usr/local/cargo/bin` (not rebuilt), `rustc 1.96.0`; `make demo`, `privileged-action-gate/run.sh`, and the golden-path smoke all PASS.

### Independent review (quorum)

- [x] Non-building reviewer on head `038a36bf16228eb501ef24b4bf12163e7ff5f7d1`: **approve-with-nits**, no blockers. Confirmed diff is config-only (outside ADR-042/043), staging discipline satisfied, single-source tool-version pin, correct binary names, `--locked` safe, install idempotent. Full verdict posted as a PR comment bound to this SHA.

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

Note: no application code changed, so no new automated tests are added; verification is the environment build + fresh-agent + golden-path/demo runs above.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83a4991f-61db-4ec3-951e-ab5cdfd584e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83a4991f-61db-4ec3-951e-ab5cdfd584e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

