### PR TITLE
release(guard): check the README attestation row against the statement the source emits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -517,7 +517,16 @@ repos:
         pass_filenames: false
         # The ordinary release-surface guard owns installability and the last-published pin. This
         # hook owns only candidate/source identity and the release workflow that consumes it.
-        files: ^(Cargo\.toml|CHANGELOG\.md|docs/(generated/agent-golden-path\.json|guides/agent-golden-path\.md|reference/release\.md)|scripts/(docs/generate-agent-golden-path\.py|ci/((check|test-check)-tag-tree-outward-truth\.sh|lib/(workspace_version\.py|clear-git-repository-env\.sh)))|\.github/workflows/release\.yml|\.pre-commit-config\.yaml)$
+        files: ^(Cargo\.toml|CHANGELOG\.md|README\.md|crates/assay-evidence/src/attestation\.rs|docs/(generated/agent-golden-path\.json|guides/agent-golden-path\.md|reference/release\.md)|scripts/(docs/generate-agent-golden-path\.py|ci/((check|test-check)-tag-tree-outward-truth\.sh|check-readme-attestation-truth\.py|lib/(workspace_version\.py|clear-git-repository-env\.sh)))|\.github/workflows/release\.yml|\.pre-commit-config\.yaml)$
+
+      - id: readme-attestation-truth
+        name: README attestation row names the statement the source emits
+        entry: bash -c 'bash scripts/ci/test-check-readme-attestation-truth.sh && python3 scripts/ci/check-readme-attestation-truth.py'
+        language: system
+        pass_filenames: false
+        # The release path runs the check through check-tag-tree-outward-truth.sh; this hook holds
+        # its mutations and catches a README or emitter change at commit time (#2875).
+        files: ^(README\.md|crates/assay-evidence/src/attestation\.rs|scripts/ci/(check|test-check)-readme-attestation-truth\.(py|sh)|\.pre-commit-config\.yaml)$
 
       - id: editor-mcp-recipe-truth
         name: Editor MCP recipe describes only the shipped transport

--- a/crates/assay-evidence/src/attestation.rs
+++ b/crates/assay-evidence/src/attestation.rs
@@ -746,6 +746,45 @@ mod tests {
             .expect("the emitted predicate URI must bind its repository page");
     }
 
+    /// Run the README attestation-row check on what the CLI's constructor returns (#2875).
+    ///
+    /// `scripts/ci/check-readme-attestation-truth.py` holds the row rule. On the release path it
+    /// reads the names from this file's source text, because that job has no Rust toolchain. Here
+    /// it gets the URIs a running `statement_for_bundle_with_extent_and_limits` emits instead, so
+    /// a change the source reading cannot see, such as a type reassigned after
+    /// `statement_from_parts` returns, still fails under required CI. The second call is the
+    /// control: a URI the README does not name must be refused, or the first proves nothing.
+    #[cfg(unix)]
+    #[test]
+    fn readme_attestation_row_names_what_the_shipped_constructor_emits() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let check = |statement_type: &str, predicate_type: &str| {
+            std::process::Command::new("python3")
+                .arg(root.join("scripts/ci/check-readme-attestation-truth.py"))
+                .arg("--root")
+                .arg(&root)
+                .args(["--statement-type", statement_type])
+                .args(["--predicate-type", predicate_type])
+                .output()
+                .expect("python3 runs the README attestation check")
+        };
+        let statement =
+            statement_for_bundle_with_extent_and_limits(&bundle(), VerifyLimits::default())
+                .expect("the constructor `assay evidence attest` calls");
+
+        let shipped = check(&statement.type_, &statement.predicate_type);
+        assert!(
+            shipped.status.success(),
+            "README attestation row disagrees with the shipped statement: {}",
+            String::from_utf8_lossy(&shipped.stderr)
+        );
+        let other = format!("{}-changed", statement.predicate_type);
+        assert!(
+            !check(&statement.type_, &other).status.success(),
+            "the check accepted a predicate the README does not name"
+        );
+    }
+
     #[test]
     fn v1_predicate_uri_binding_refuses_a_missing_page() {
         let docs = tempfile::tempdir().expect("isolated docs directory");

--- a/crates/assay-evidence/src/attestation.rs
+++ b/crates/assay-evidence/src/attestation.rs
@@ -768,20 +768,49 @@ mod tests {
                 .output()
                 .expect("python3 runs the README attestation check")
         };
-        let statement =
-            statement_for_bundle_with_extent_and_limits(&bundle(), VerifyLimits::default())
-                .expect("the constructor `assay evidence attest` calls");
+        let bytes = bundle();
+        // Every public constructor, the CLI's first. A library caller gets the others.
+        let statements = [
+            (
+                "statement_for_bundle_with_extent_and_limits (the CLI's)",
+                statement_for_bundle_with_extent_and_limits(&bytes, VerifyLimits::default()),
+            ),
+            (
+                "statement_for_bundle_with_extent",
+                statement_for_bundle_with_extent(&bytes),
+            ),
+            (
+                "statement_for_bundle_with_limits",
+                statement_for_bundle_with_limits(&bytes, VerifyLimits::default()),
+            ),
+            ("statement_for_bundle", statement_for_bundle(&bytes)),
+        ];
+        for (name, statement) in statements {
+            let statement = statement.expect(name);
+            let shipped = check(&statement.type_, &statement.predicate_type);
+            assert!(
+                shipped.status.success(),
+                "README attestation row disagrees with {name}: {}",
+                String::from_utf8_lossy(&shipped.stderr)
+            );
+        }
 
-        let shipped = check(&statement.type_, &statement.predicate_type);
+        // The control must reach the README comparison, so it is a well-formed predicate URI that
+        // differs only in its version. A malformed one would be refused by the URI shape check
+        // alone, and a checker that compared nothing would still pass it (Grok, review of the
+        // second head).
+        let (base, _) = EVIDENCE_BUNDLE_PREDICATE_TYPE_V1
+            .rsplit_once('/')
+            .expect("a versioned predicate URI");
+        let refused = check(STATEMENT_TYPE, &format!("{base}/v999"));
         assert!(
-            shipped.status.success(),
-            "README attestation row disagrees with the shipped statement: {}",
-            String::from_utf8_lossy(&shipped.stderr)
+            !refused.status.success(),
+            "the check accepted a predicate version the README does not name"
         );
-        let other = format!("{}-changed", statement.predicate_type);
         assert!(
-            !check(&statement.type_, &other).status.success(),
-            "the check accepted a predicate the README does not name"
+            String::from_utf8_lossy(&refused.stderr).contains("does not state"),
+            "the control was refused before the README comparison: {}",
+            String::from_utf8_lossy(&refused.stderr)
         );
     }
 

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -33,7 +33,9 @@ This document outlines the canonical checklist for releasing new versions of Ass
     bash scripts/ci/check-tag-tree-outward-truth.sh
   ```
   This binds the workspace, changelog, and generated golden-path source identity
-  to the candidate tag, and verifies the caller-provided checkout SHA. It does not
+  to the candidate tag, and verifies the caller-provided checkout SHA. It also
+  checks that the README attestation row names the in-toto Statement and
+  predicate versions the source emits. It does not
   prove that a not-yet-created tag already points at that commit. The published install pin may still name the
   previous release until the candidate assets exist; installability and source
   identity are separate checks.

--- a/scripts/ci/check-readme-attestation-truth.py
+++ b/scripts/ci/check-readme-attestation-truth.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Refuse a README attestation row that names a statement or predicate the source does not emit.
+
+The README's "What ships" table described attestation as an "in-toto / DSSE statement (v0)" on
+v6.0.0 and v6.1.0 while `crates/assay-evidence/src/attestation.rs` emitted an in-toto v1
+Statement with the evidence-bundle/v1 predicate (#2859). Every release gate passed it, because
+none of them read the README (#2875).
+
+The source is the only vocabulary. The names are read from what `statement_from_parts` puts in
+`type_` and `predicate_type`, resolved through the constants it names: that function is the only
+place a statement is assembled, so switching it to another constant is a change of what ships,
+and a check that read a fixed constant name would miss it. The README row is the projection and
+must state both names, and no other version.
+
+Anything this cannot read is a failure, never a pass: a renamed emitter, a constant that is not a
+plain string, a URI outside the expected shape, or not exactly one attestation row.
+
+Usage: check-readme-attestation-truth.py [--root DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+README = "README.md"
+SOURCE = "crates/assay-evidence/src/attestation.rs"
+EMITTER = "statement_from_parts"
+ROW_PREFIX = "| **Attestation** | "
+
+STATEMENT_URI = re.compile(r"https://in-toto\.io/Statement/(v\d+(?:\.\d+)?)")
+PREDICATE_URI = re.compile(r"https://[^\s\"]+/attestation/([a-z0-9-]+/(v\d+(?:\.\d+)?))")
+VERSION_TOKEN = re.compile(r"(?<![\w.])v\d+(?:\.\d+)*(?![\w])")
+
+
+class CheckError(Exception):
+    pass
+
+
+def emitter_body(source: str) -> str:
+    starts = [m.start() for m in re.finditer(rf"^fn {EMITTER}\(", source, re.MULTILINE)]
+    if len(starts) != 1:
+        raise CheckError(f"{SOURCE}: expected exactly one `fn {EMITTER}(`, found {len(starts)}")
+    end = re.compile(r"^\}", re.MULTILINE).search(source, starts[0])
+    if end is None:
+        raise CheckError(f"{SOURCE}: `fn {EMITTER}` has no closing brace at column 0")
+    return source[starts[0]:end.end()]
+
+
+def emitted_constant(body: str, field: str) -> str:
+    names = re.findall(rf"^\s*{field}: ([A-Z][A-Z0-9_]*)\.to_string\(\),$", body, re.MULTILINE)
+    if len(names) != 1:
+        raise CheckError(
+            f"{SOURCE}: `{EMITTER}` must set `{field}` from exactly one named constant, "
+            f"found {len(names)}"
+        )
+    return names[0]
+
+
+def constant_value(source: str, name: str) -> str:
+    values = re.findall(rf"^(?:pub )?const {name}: &str =\s*\"([^\"\\]+)\";", source, re.MULTILINE)
+    if len(values) != 1:
+        raise CheckError(f"{SOURCE}: expected one plain string constant `{name}`, found {len(values)}")
+    return values[0]
+
+
+def emitted_names(source: str) -> tuple[str, str, str]:
+    """Return (statement version, predicate name, predicate version) as the source emits them."""
+    body = emitter_body(source)
+    statement = constant_value(source, emitted_constant(body, "type_"))
+    predicate = constant_value(source, emitted_constant(body, "predicate_type"))
+    statement_match = STATEMENT_URI.fullmatch(statement)
+    if statement_match is None:
+        raise CheckError(f"{SOURCE}: statement type {statement!r} is not an in-toto Statement URI")
+    predicate_match = PREDICATE_URI.fullmatch(predicate)
+    if predicate_match is None:
+        raise CheckError(f"{SOURCE}: predicate type {predicate!r} is not an attestation URI")
+    return statement_match.group(1), predicate_match.group(1), predicate_match.group(2)
+
+
+def readme_row(readme: str) -> str:
+    rows = [line for line in readme.splitlines() if line.startswith(ROW_PREFIX)]
+    if len(rows) != 1:
+        raise CheckError(f"{README}: expected exactly one README attestation row, found {len(rows)}")
+    return rows[0]
+
+
+def problems(root: Path) -> list[str]:
+    try:
+        source = (root / SOURCE).read_text(encoding="utf-8")
+        readme = (root / README).read_text(encoding="utf-8")
+        statement_version, predicate_name, predicate_version = emitted_names(source)
+        row = readme_row(readme)
+    except (OSError, CheckError) as exc:
+        return [str(exc)]
+
+    found = []
+    for phrase in (f"in-toto {statement_version} Statement", f"{predicate_name} predicate"):
+        if phrase not in row:
+            found.append(f"{README}: attestation row does not state \"{phrase}\", which "
+                         f"{SOURCE} emits: {row}")
+    allowed = {statement_version, predicate_version}
+    for token in sorted(set(VERSION_TOKEN.findall(row)) - allowed):
+        found.append(f"{README}: attestation row names {token}, which the emitted statement "
+                     f"does not carry: {row}")
+    return found
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
+    args = parser.parse_args()
+    found = problems(args.root)
+    for problem in found:
+        print(f"FAIL: {problem}", file=sys.stderr)
+    if found:
+        return 1
+    print("README attestation row: agrees with the statement and predicate the source emits")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check-readme-attestation-truth.py
+++ b/scripts/ci/check-readme-attestation-truth.py
@@ -6,16 +6,24 @@ v6.0.0 and v6.1.0 while `crates/assay-evidence/src/attestation.rs` emitted an in
 Statement with the evidence-bundle/v1 predicate (#2859). Every release gate passed it, because
 none of them read the README (#2875).
 
-The source is the only vocabulary. The names are read from what `statement_from_parts` puts in
-`type_` and `predicate_type`, resolved through the constants it names: that function is the only
-place a statement is assembled, so switching it to another constant is a change of what ships,
-and a check that read a fixed constant name would miss it. The README row is the projection and
-must state both names, and no other version.
+The source is the only vocabulary, read from two sides with this one rule:
 
-Anything this cannot read is a failure, never a pass: a renamed emitter, a constant that is not a
-plain string, a URI outside the expected shape, or not exactly one attestation row.
+- On the release path, where no Rust toolchain exists, the names come from the source text: what
+  `statement_from_parts` puts in `type_` and `predicate_type`, resolved through the constants it
+  names. Every public constructor goes through that function; reading it rather than a fixed
+  constant name means switching it to another constant is caught. The deprecated
+  `statement_from_manifest` also assembles a statement, with the v0 predicate the verifier refuses,
+  and is deliberately not read.
+- Under required CI, `readme_attestation_row_names_what_the_shipped_constructor_emits` in
+  `attestation.rs` runs the constructor the CLI calls and passes the URIs it returns through
+  `--statement-type` and `--predicate-type`. That covers a change on the ship path the source
+  reading cannot see, such as a type reassigned after `statement_from_parts` returns.
 
-Usage: check-readme-attestation-truth.py [--root DIR]
+The README row is the projection and must state both names, and no other version. Anything this
+cannot read is a failure, never a pass: a renamed emitter, a constant that is not a plain string,
+an assignment in an unfamiliar form, a URI outside the expected shape, or not exactly one row.
+
+Usage: check-readme-attestation-truth.py [--root DIR] [--statement-type URI --predicate-type URI]
 """
 
 from __future__ import annotations
@@ -66,11 +74,15 @@ def constant_value(source: str, name: str) -> str:
     return values[0]
 
 
-def emitted_names(source: str) -> tuple[str, str, str]:
-    """Return (statement version, predicate name, predicate version) as the source emits them."""
+def source_uris(source: str) -> tuple[str, str]:
+    """Return (statement type, predicate type) as the source text says `statement_from_parts` emits."""
     body = emitter_body(source)
-    statement = constant_value(source, emitted_constant(body, "type_"))
-    predicate = constant_value(source, emitted_constant(body, "predicate_type"))
+    return (constant_value(source, emitted_constant(body, "type_")),
+            constant_value(source, emitted_constant(body, "predicate_type")))
+
+
+def names(statement: str, predicate: str) -> tuple[str, str, str]:
+    """Return (statement version, predicate name, predicate version) from the two type URIs."""
     statement_match = STATEMENT_URI.fullmatch(statement)
     if statement_match is None:
         raise CheckError(f"{SOURCE}: statement type {statement!r} is not an in-toto Statement URI")
@@ -87,11 +99,12 @@ def readme_row(readme: str) -> str:
     return rows[0]
 
 
-def problems(root: Path) -> list[str]:
+def problems(root: Path, emitted: tuple[str, str] | None = None) -> list[str]:
     try:
-        source = (root / SOURCE).read_text(encoding="utf-8")
         readme = (root / README).read_text(encoding="utf-8")
-        statement_version, predicate_name, predicate_version = emitted_names(source)
+        if emitted is None:
+            emitted = source_uris((root / SOURCE).read_text(encoding="utf-8"))
+        statement_version, predicate_name, predicate_version = names(*emitted)
         row = readme_row(readme)
     except (OSError, CheckError) as exc:
         return [str(exc)]
@@ -100,7 +113,7 @@ def problems(root: Path) -> list[str]:
     for phrase in (f"in-toto {statement_version} Statement", f"{predicate_name} predicate"):
         if phrase not in row:
             found.append(f"{README}: attestation row does not state \"{phrase}\", which "
-                         f"{SOURCE} emits: {row}")
+                         f"the statement emits: {row}")
     allowed = {statement_version, predicate_version}
     for token in sorted(set(VERSION_TOKEN.findall(row)) - allowed):
         found.append(f"{README}: attestation row names {token}, which the emitted statement "
@@ -111,8 +124,13 @@ def problems(root: Path) -> list[str]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument("--statement-type", help="statement type URI a running constructor emitted")
+    parser.add_argument("--predicate-type", help="predicate type URI a running constructor emitted")
     args = parser.parse_args()
-    found = problems(args.root)
+    if (args.statement_type is None) != (args.predicate_type is None):
+        parser.error("--statement-type and --predicate-type go together")
+    emitted = None if args.statement_type is None else (args.statement_type, args.predicate_type)
+    found = problems(args.root, emitted)
     for problem in found:
         print(f"FAIL: {problem}", file=sys.stderr)
     if found:

--- a/scripts/ci/check-tag-tree-outward-truth.sh
+++ b/scripts/ci/check-tag-tree-outward-truth.sh
@@ -69,5 +69,10 @@ changelog_pattern="^## \\[${changelog_version}\\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$"
 [ "$(grep -Ec "$changelog_pattern" "$ROOT/CHANGELOG.md" || true)" -eq 1 ] ||
   fail "CHANGELOG.md must contain exactly one dated release heading for $source_version"
 
+# A format claim is outward truth too: v6.0.0 and v6.1.0 shipped a README naming a v0 statement
+# over a source that emitted v1 (#2859, #2875).
+python3 "$ROOT/scripts/ci/check-readme-attestation-truth.py" --root "$ROOT" ||
+  fail "README attestation row does not match the statement the source emits"
+
 printf 'tag-tree outward truth: source %s, candidate %s, checkout %s\n' \
   "$source_version" "$CANDIDATE_TAG" "$actual_sha"

--- a/scripts/ci/test-check-readme-attestation-truth.sh
+++ b/scripts/ci/test-check-readme-attestation-truth.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Prove the README attestation row is checked against the statement the source emits (#2875).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+CHECK="$ROOT/scripts/ci/check-readme-attestation-truth.py"
+README=README.md
+SOURCE=crates/assay-evidence/src/attestation.rs
+
+# The real files, not a hand-written fixture: the positive control has to be the tree that ships.
+reset_tree() {
+  rm -rf "$TMP/tree"
+  mkdir -p "$TMP/tree/$(dirname "$SOURCE")"
+  cp "$ROOT/$README" "$TMP/tree/$README"
+  cp "$ROOT/$SOURCE" "$TMP/tree/$SOURCE"
+}
+
+run_check() {
+  python3 "$CHECK" --root "$TMP/tree"
+}
+
+# Replace exactly one occurrence, so a mutation that silently matches nothing cannot pass as red.
+replace_once() {
+  python3 - "$TMP/tree/$1" "$2" "$3" <<'PY'
+from pathlib import Path
+import sys
+
+path, old, new = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+text = path.read_text(encoding="utf-8")
+if text.count(old) != 1:
+    raise SystemExit(f"mutation anchor must occur exactly once in {path}: {old!r}")
+path.write_text(text.replace(old, new), encoding="utf-8")
+PY
+}
+
+reset_tree
+run_check >"$TMP/control.out" 2>&1 || {
+  cat "$TMP/control.out" >&2
+  echo "FAIL: the shipped README and source must agree" >&2
+  exit 1
+}
+printf 'PASS: shipped README row agrees with the emitted statement\n'
+
+mutations=0
+expect_red() {
+  local name="$1" diagnostic="$2"
+  if run_check >"$TMP/$name.out" 2>&1; then
+    echo "FAIL: mutation $name was not observed" >&2
+    exit 1
+  fi
+  grep -Fq "$diagnostic" "$TMP/$name.out" || {
+    cat "$TMP/$name.out" >&2
+    echo "FAIL: mutation $name missed diagnostic: $diagnostic" >&2
+    exit 1
+  }
+  mutations=$((mutations + 1))
+  printf 'PASS: %s\n' "$name"
+  reset_tree
+}
+
+row_prefix='| **Attestation** | '
+
+# The row as it shipped on v6.0.0 and v6.1.0 (#2859): the historical defect must be red.
+python3 - "$TMP/tree/$README" "$row_prefix" <<'PY'
+from pathlib import Path
+import sys
+
+path, prefix = Path(sys.argv[1]), sys.argv[2]
+lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+hits = [i for i, line in enumerate(lines) if line.startswith(prefix)]
+if len(hits) != 1:
+    raise SystemExit("fixture needs exactly one attestation row")
+lines[hits[0]] = prefix + "Export a bundle as an in-toto / DSSE statement (v0), anchor-pluggable. |\n"
+path.write_text("".join(lines), encoding="utf-8")
+PY
+expect_red historical-v6.1.0-row 'does not state "in-toto v1 Statement"'
+
+# README side, one name at a time.
+replace_once "$README" 'in-toto v1 Statement' 'in-toto v2 Statement'
+expect_red readme-statement-version 'does not state "in-toto v1 Statement"'
+replace_once "$README" 'evidence-bundle/v1 predicate' 'evidence-bundle/v0 predicate'
+expect_red readme-predicate-version 'does not state "evidence-bundle/v1 predicate"'
+replace_once "$README" 'evidence-bundle/v1 predicate.' 'evidence-bundle/v1 predicate (v0).'
+expect_red readme-stray-version 'names v0'
+
+# Source side, one constant at a time, with the README left as it ships.
+replace_once "$SOURCE" '"https://in-toto.io/Statement/v1"' '"https://in-toto.io/Statement/v2"'
+expect_red source-statement-constant 'does not state "in-toto v2 Statement"'
+# Anchored on the declaration; a unit test further down repeats the URI as its expected value.
+replace_once "$SOURCE" '"https://docs.getassay.dev/attestation/evidence-bundle/v1";' \
+  '"https://docs.getassay.dev/attestation/evidence-bundle/v2";'
+expect_red source-predicate-constant 'does not state "evidence-bundle/v2 predicate"'
+
+# The emitter, not the constant's name, decides what ships: switching it is a change too.
+replace_once "$SOURCE" '        predicate_type: EVIDENCE_BUNDLE_PREDICATE_TYPE_V1.to_string(),' \
+  '        predicate_type: EVIDENCE_BUNDLE_PREDICATE_TYPE_V0.to_string(),'
+expect_red source-emitter-switch 'does not state "evidence-bundle/v0 predicate"'
+# Same for the statement type. Only one statement constant exists today, so the mutation adds a
+# second and points the emitter at it; a check that read `STATEMENT_TYPE` by name stays green.
+python3 - "$TMP/tree/$SOURCE" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+declaration = 'const STATEMENT_TYPE: &str = "https://in-toto.io/Statement/v1";\n'
+emitter = text.index("fn statement_from_parts(")
+field = "        type_: STATEMENT_TYPE.to_string(),\n"
+at = text.index(field, emitter)
+if text.count(declaration) != 1:
+    raise SystemExit("statement constant declaration must occur exactly once")
+text = text[:at] + "        type_: STATEMENT_TYPE_V2.to_string(),\n" + text[at + len(field):]
+text = text.replace(declaration, declaration
+                    + 'const STATEMENT_TYPE_V2: &str = "https://in-toto.io/Statement/v2";\n')
+path.write_text(text, encoding="utf-8")
+PY
+expect_red source-statement-emitter-switch 'does not state "in-toto v2 Statement"'
+
+# Anything the check cannot read is a failure, never a pass.
+replace_once "$SOURCE" 'fn statement_from_parts(' 'fn statement_assembled_from_parts('
+expect_red emitter-not-found 'statement_from_parts'
+python3 - "$TMP/tree/$README" "$row_prefix" <<'PY'
+from pathlib import Path
+import sys
+
+path, prefix = Path(sys.argv[1]), sys.argv[2]
+path.write_text("".join(
+    line for line in path.read_text(encoding="utf-8").splitlines(keepends=True)
+    if not line.startswith(prefix)
+), encoding="utf-8")
+PY
+expect_red row-missing 'exactly one README attestation row'
+python3 - "$TMP/tree/$README" "$row_prefix" <<'PY'
+from pathlib import Path
+import sys
+
+path, prefix = Path(sys.argv[1]), sys.argv[2]
+lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+row = next(line for line in lines if line.startswith(prefix))
+path.write_text("".join(lines) + row, encoding="utf-8")
+PY
+expect_red row-duplicated 'exactly one README attestation row'
+
+if [ "$mutations" -ne 11 ]; then
+  echo "FAIL: expected 11 observed mutations, got $mutations" >&2
+  exit 1
+fi
+
+# The check pins names, not prose: a reworded row that keeps both names stays green.
+python3 - "$TMP/tree/$README" "$row_prefix" <<'PY'
+from pathlib import Path
+import sys
+
+path, prefix = Path(sys.argv[1]), sys.argv[2]
+lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+hits = [i for i, line in enumerate(lines) if line.startswith(prefix)]
+lines[hits[0]] = (prefix + "Signed evidence: an in-toto v1 Statement, DSSE-wrapped, "
+                  "carrying the evidence-bundle/v1 predicate. |\n")
+path.write_text("".join(lines), encoding="utf-8")
+PY
+run_check >"$TMP/reworded.out" 2>&1 || {
+  cat "$TMP/reworded.out" >&2
+  echo "FAIL: a reworded row naming the same statement and predicate was refused" >&2
+  exit 1
+}
+printf 'PASS: reworded row with the same names stays green\n'
+printf 'README attestation truth mutations: %s observed\n' "$mutations"

--- a/scripts/ci/test-check-readme-attestation-truth.sh
+++ b/scripts/ci/test-check-readme-attestation-truth.sh
@@ -119,6 +119,53 @@ path.write_text(text, encoding="utf-8")
 PY
 expect_red source-statement-emitter-switch 'does not state "in-toto v2 Statement"'
 
+# Found by the review of 55b42551c (Grok F4): each of these mutants of the checker survived.
+# Two assignments of one field in the emitter: neither may win silently.
+python3 - "$TMP/tree/$SOURCE" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+field = "        predicate_type: EVIDENCE_BUNDLE_PREDICATE_TYPE_V1.to_string(),\n"
+at = text.index(field, text.index("fn statement_from_parts("))
+second = "        predicate_type: EVIDENCE_BUNDLE_PREDICATE_TYPE_V0.to_string(),\n"
+path.write_text(text[:at] + field + second + text[at + len(field):], encoding="utf-8")
+PY
+expect_red emitter-two-assignments 'from exactly one named constant'
+# An assignment in a form the check does not parse fails closed instead of being guessed at.
+replace_once "$SOURCE" '        predicate_type: EVIDENCE_BUNDLE_PREDICATE_TYPE_V1.to_string(),' \
+  '        predicate_type: EVIDENCE_BUNDLE_PREDICATE_TYPE_V1.to_owned(),'
+expect_red emitter-unfamiliar-form 'from exactly one named constant'
+# The names must be in the attestation row, not merely somewhere in the README.
+python3 - "$TMP/tree/$README" "$row_prefix" <<'PY'
+from pathlib import Path
+import sys
+
+path, prefix = Path(sys.argv[1]), sys.argv[2]
+lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+hits = [i for i, line in enumerate(lines) if line.startswith(prefix)]
+lines[hits[0]] = prefix + "Export a bundle as a signed statement. |\n"
+lines.append("\nElsewhere: an in-toto v1 Statement with the evidence-bundle/v1 predicate.\n")
+path.write_text("".join(lines), encoding="utf-8")
+PY
+expect_red names-elsewhere-only 'does not state "in-toto v1 Statement"'
+
+# The runtime leg: attestation.rs's unit test passes the URIs a running constructor returned.
+run_check() {
+  python3 "$CHECK" --root "$TMP/tree" --statement-type https://in-toto.io/Statement/v1 \
+    --predicate-type https://docs.getassay.dev/attestation/evidence-bundle/v2
+}
+expect_red runtime-predicate-differs 'does not state "evidence-bundle/v2 predicate"'
+run_check() {
+  python3 "$CHECK" --root "$TMP/tree" \
+    --predicate-type https://docs.getassay.dev/attestation/evidence-bundle/v1
+}
+expect_red runtime-half-given 'go together'
+run_check() {
+  python3 "$CHECK" --root "$TMP/tree"
+}
+
 # Anything the check cannot read is a failure, never a pass.
 replace_once "$SOURCE" 'fn statement_from_parts(' 'fn statement_assembled_from_parts('
 expect_red emitter-not-found 'statement_from_parts'
@@ -144,8 +191,8 @@ path.write_text("".join(lines) + row, encoding="utf-8")
 PY
 expect_red row-duplicated 'exactly one README attestation row'
 
-if [ "$mutations" -ne 11 ]; then
-  echo "FAIL: expected 11 observed mutations, got $mutations" >&2
+if [ "$mutations" -ne 16 ]; then
+  echo "FAIL: expected 16 observed mutations, got $mutations" >&2
   exit 1
 fi
 

--- a/scripts/ci/test-check-tag-tree-outward-truth.sh
+++ b/scripts/ci/test-check-tag-tree-outward-truth.sh
@@ -9,9 +9,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-mkdir -p "$TMP/scripts/ci/lib" "$TMP/docs/generated" "$TMP/docs/guides" "$TMP/.github"
+mkdir -p "$TMP/scripts/ci/lib" "$TMP/docs/generated" "$TMP/docs/guides" "$TMP/.github" \
+  "$TMP/crates/assay-evidence/src"
 cp "$ROOT/scripts/ci/check-tag-tree-outward-truth.sh" "$TMP/scripts/ci/"
+cp "$ROOT/scripts/ci/check-readme-attestation-truth.py" "$TMP/scripts/ci/"
 cp "$ROOT/scripts/ci/lib/workspace_version.py" "$TMP/scripts/ci/lib/"
+# The attestation row is read from the real files; its own mutations live in
+# test-check-readme-attestation-truth.sh. Here one mutation proves the release path calls it.
+cp "$ROOT/README.md" "$TMP/README.md"
+cp "$ROOT/crates/assay-evidence/src/attestation.rs" "$TMP/crates/assay-evidence/src/"
 cat > "$TMP/Cargo.toml" <<'EOF'
 [workspace.package]
 version = "5.3.0"
@@ -40,7 +46,7 @@ printf '%s\n' 'v5.2.0' > "$TMP/.github/assay-release-tag"
   git init -q
   git config user.email test@example.invalid
   git config user.name test
-  git add -- Cargo.toml CHANGELOG.md .github docs scripts
+  git add -- Cargo.toml CHANGELOG.md README.md .github crates docs scripts
   git commit -qm fixture
 )
 
@@ -81,6 +87,8 @@ mutate_and_fail stale-guide-source docs/guides/agent-golden-path.md \
   'source tree declares Assay `5.2.0` (`v5.2.0`)' 'source-tree declaration'
 mutate_and_fail stale-changelog CHANGELOG.md \
   '\[5.3.0\]' '[5.2.0]' 'release heading'
+mutate_and_fail stale-readme-attestation README.md \
+  'in-toto v1 Statement' 'in-toto v0 Statement' 'README attestation row'
 
 if (cd "$TMP" && CANDIDATE_TAG=v5.2.0 EXPECTED_SHA="$head_sha" \
   bash scripts/ci/check-tag-tree-outward-truth.sh) >"$TMP/tag-mismatch.out" 2>&1; then
@@ -106,8 +114,8 @@ printf '%s\n' 'v4.9.0' > "$TMP/.github/assay-release-tag"
 run_check >/dev/null
 printf 'PASS: install-pin-does-not-govern-candidate-identity\n'
 
-if [ "$mutations" -ne 6 ]; then
-  echo "FAIL: expected 6 observed mutations, got $mutations" >&2
+if [ "$mutations" -ne 7 ]; then
+  echo "FAIL: expected 7 observed mutations, got $mutations" >&2
   exit 1
 fi
 printf 'tag-tree outward-truth mutations: %s observed\n' "$mutations"
@@ -193,11 +201,14 @@ pattern = re.compile(selectors[0])
 for required in (
     "Cargo.toml",
     "CHANGELOG.md",
+    "README.md",
+    "crates/assay-evidence/src/attestation.rs",
     "docs/generated/agent-golden-path.json",
     "docs/guides/agent-golden-path.md",
     "docs/reference/release.md",
     ".github/workflows/release.yml",
     "scripts/ci/check-tag-tree-outward-truth.sh",
+    "scripts/ci/check-readme-attestation-truth.py",
     "scripts/ci/test-check-tag-tree-outward-truth.sh",
     "scripts/ci/lib/clear-git-repository-env.sh",
 ):


### PR DESCRIPTION
**Candidate, not a landing.** Current head `a73cd0be744b2da5e9f30aee3d94f288677f3c44` is `gh pr update-branch` over the reviewed head `2e4d85578efb16cb37b0323fca573c07d5663217` (Grok READY, [record](https://github.com/Rul1an/assay/pull/2885#issuecomment-5617646787)); it brings in #2883, #2884 and #2887, none of which touches a reviewed file. Muse's carry record with both AGENTS.md equivalence checks: [5617701388](https://github.com/Rul1an/assay/pull/2885#issuecomment-5617701388). Earlier heads: `1de9273157fe812d1e64fd1fa435f7af5f8fce39` (Grok READY, two residuals), `55b42551c577ed885c6533d3c7ffe61969155f9c` (Grok BLOCKED).

Closes #2875

## Problem

`v6.0.0` and `v6.1.0` shipped a README whose "What ships" table described attestation as an "in-toto / DSSE statement (v0)", while `crates/assay-evidence/src/attestation.rs` emitted an in-toto v1 Statement with the `evidence-bundle/v1` predicate (Refs #2859; the row itself is already corrected on main). Every release gate passed it, because none of them read the README.

## Rule

`scripts/ci/check-readme-attestation-truth.py` takes the names from the source and requires the README row to state them:

- The rule lives in one place and takes its names from two sides. On the release path it reads what `statement_from_parts` puts in `type_` and `predicate_type` and resolves those constants; every public constructor goes through that function. Under required CI, a unit test runs `statement_for_bundle_with_extent_and_limits`, the constructor `assay evidence attest` calls, and passes the URIs it returns to the same script. The deprecated `statement_from_manifest` also assembles a statement (the refused v0 predicate) and is deliberately not read. (An earlier version of this body said `statement_from_parts` was the only assembler; that was false.)
- The README must have exactly one `| **Attestation** |` row, stating `in-toto <v> Statement` and `<predicate>/<v> predicate`, and no other version token. The wording around the names is free.
- Anything it cannot read fails: a renamed emitter, a non-literal constant, a URI outside the expected shape, zero or two rows.

No second vocabulary: the constants are the source, the row is the projection.

**Where it runs.** On the release path, inside `check-tag-tree-outward-truth.sh`, which `release.yml` runs in `release-contract` before anything is built (`Verify candidate source-tree identity`). That job installs no Rust toolchain and the release workflow runs no `cargo test`, which is why this is a script and not a unit test beside the existing `v1_predicate_uri_names_its_documented_page`. At commit time a new `readme-attestation-truth` pre-commit hook runs its mutations and the check; Kernel Matrix Lint already triggers on `README.md`, `crates/assay-evidence/**` and `scripts/**`.

## Proof

- **RED first.** The test was written before the check and failed on its absence. The real `v6.1.0` tree (README and `attestation.rs` from the tag) fails with three diagnostics: the statement name missing, the predicate name missing, and a stray `v0`. Main passes.
- **11 mutations (16 after review, see below), each red with its own diagnostic**, on copies of the real files: the historical v6.1.0 row; README statement version only; README predicate version only; a stray version appended; the statement constant only; the predicate constant only; the emitter switched to the V0 predicate; the emitter switched to a second statement constant; the emitter renamed; the row removed; the row duplicated. A reworded row that keeps both names stays green, so the check pins names, not prose.
- **The checker itself mutated nine ways**, each turning the test red: stray-version scan off, predicate or statement read from a fixed constant name, fail-open on unreadable input, either phrase check dropped, first row wins, exit 0 on problems. The fixed statement-constant mutant survived at first, because no test switched the emitter's `type_`; the eleventh mutation above was added for it.
- **Wiring.** `test-check-tag-tree-outward-truth.sh` copies the real README and source into its sandbox and gains one mutation (`stale-readme-attestation`), 6 to 7 observed. Deleting the call from `check-tag-tree-outward-truth.sh` turns that test red. Its pinned hook-selector list now includes the three new inputs.
- All 66 pre-commit hooks passed on the commit.

## Review findings on `55b42551c` and their disposition

| finding | severity | disposition |
|---|---|---|
| F1: the check read only `statement_from_parts`. A type reassigned on the CLI's path after that function returns, or a public constructor that stops calling it, left it green | high | **fixed by a second leg, not a smarter regex.** `readme_attestation_row_names_what_the_shipped_constructor_emits` (attestation.rs, `cfg(unix)`, required CI) runs the constructor the CLI calls and hands the emitted URIs to the same Python rule via `--statement-type`/`--predicate-type`, with a control that a URI the README does not name is refused. Grok's exact mutant (predicate reassigned to V0 after `statement_from_parts`) leaves the release-path script green and turns this test red |
| F2: the predicate URI's authority is not pinned by this check | medium | **covered elsewhere**: `v1_predicate_uri_names_its_documented_page` requires the `https://docs.getassay.dev/` prefix and fails under required CI on any other host. The README row does not state a host, so it is not this check's claim |
| F3: "the only place a statement is assembled" was false (`statement_from_manifest`) | medium | **corrected** in the script docstring and in this body |
| F4: three checker mutants survived (first assignment wins; phrases searched in the whole README; `.to_owned()` accepted) | medium | **fixed**: `emitter-two-assignments`, `names-elsewhere-only`, `emitter-unfamiliar-form` pin them, plus two cases for the new override. 16 mutations, each red |
| F5: names, not meaning | low | accepted; already a stated non-claim |

The release path still cannot see a ship-path change that the source text hides; that leg exists for README drift at release time, and the Rust leg covers the ship path on every code PR. A README-only PR is checked by the pre-commit leg (Kernel Matrix Lint, not required) and at release.

## Residuals from the READY review of `1de927315` and their disposition

| residual | disposition |
|---|---|
| the ship-path test ran only the CLI's constructor; `statement_for_bundle_with_limits` reassigning its type after `statement_from_parts` stayed green on both legs | **fixed**: the test runs all four public constructors; that mutant is red (`disagrees with statement_for_bundle_with_limits`) |
| the control URI (`<predicate>-changed`) was refused by the URI shape check before any README comparison, so a checker that validated shape and compared nothing still passed it | **fixed**: the control is a well-formed predicate URI differing only in version, and the test asserts it was refused by the README comparison; that shape-only checker mutant is red |
| neither leg runs the `assay evidence attest` binary; a CLI that stopped calling the constructor stays green | **accepted, stated**: the Rust leg covers every library constructor; the CLI call site is one line (`attest.rs:106`) and a binary-level test is out of this PR's scope |
| a `.into()` widening of the checker's assignment regex survives | **accepted**: the same open class as `.to_owned()`; the checker fails closed on any form it does not parse, which the `emitter-unfamiliar-form` case pins |

## Non-claims

- Covers the attestation row only, as scoped. Widening to other README rows is a separate decision.
- The PR-time leg is pre-commit via Kernel Matrix Lint, which is not a required context, like its tag-tree sibling. The binding leg is the release path.
- Checks names, not meaning: a row stating the right names over a wrong description of what signing does would pass.
- `docs/reference/release.md` gains one sentence saying the tag-tree check now covers this row.

## Review asks

Find a README row that states the right names and would still mislead, or a source change that alters what ships and leaves the check green. Challenge the choice of `statement_from_parts` as the anchor, and whether a script on the release path is the right home versus a Rust test plus a required-CI leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



