### PR TITLE
fix(evidence): bind pull --verify to the requested bundle id, and refuse a colliding push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+- `evidence pull --verify` now requires the verified bundle to identify as the requested
+  `bundle_id`, and verifies before writing: previously any internally valid bundle stored under the
+  requested key was reported as `Verified: OK` and written under the requested name.
+- `evidence push` no longer treats an existing object under the same `bundle_id` as an idempotent
+  re-upload unless it is byte-identical. `bundle_id` is the `run_root`, shared by different
+  archives with the same events; previously the second archive was silently not stored, the command
+  exited 0, and `--run-id` linked the run to the other archive. It now fails and links nothing.
+
 ## [6.1.0] - 2026-09-09
 
 ### Added

--- a/crates/assay-cli/src/cli/commands/evidence/pull.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/pull.rs
@@ -147,6 +147,24 @@ async fn pull_single(
         Err(e) => return Err(e).context("failed to download bundle"),
     };
 
+    // With --verify, the bytes are verified and bound to the requested id before anything is
+    // written. Integrity alone says the store returned *a* valid bundle; the store is keyed by a
+    // name anyone with write access can put any object under, so the verified manifest must also
+    // name the bundle that was asked for. Writing first, as this used to, left an unverified file
+    // under the requested name even when verification then failed.
+    if verify {
+        let verified = assay_evidence::verify_bundle(std::io::Cursor::new(bytes.as_ref()))
+            .context("bundle verification failed")?;
+        if verified.manifest.bundle_id != bundle_id {
+            anyhow::bail!(
+                "bundle identity mismatch: requested {}, but the store returned a bundle that \
+                 identifies as {}; nothing was written",
+                shown(bundle_id),
+                shown(&verified.manifest.bundle_id)
+            );
+        }
+    }
+
     // Determine output path
     let out_path = if out.is_dir() {
         out.join(bundle_filename(bundle_id))
@@ -163,10 +181,7 @@ async fn pull_single(
 
     eprintln!("✅ Downloaded to: {}", out_path.display());
 
-    // Verify if requested
     if verify {
-        let cursor = std::io::Cursor::new(bytes.as_ref());
-        assay_evidence::verify_bundle(cursor).context("bundle verification failed")?;
         eprintln!("✅ Verified: OK");
     }
 

--- a/crates/assay-cli/src/cli/commands/evidence/push.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/push.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 use assay_common::limits::{LimitKind, LimitReader};
 use assay_evidence::bundle::writer::VerifyLimits;
-use assay_evidence::store::BundleStore;
+use assay_evidence::store::{BundleStore, StreamCeiling};
 use assay_evidence::{resolve_store_url, Bytes, ObjectStoreBundleStore, StoreError, StoreSpec};
 use clap::Args;
 use std::fs::File;
@@ -92,17 +92,36 @@ pub async fn cmd_push(args: PushArgs) -> Result<i32> {
         .with_context(|| "failed to connect to store")?;
 
     // 4. Upload bundle
-    match store.put_bundle(&bundle_id, bytes).await {
+    match store.put_bundle(&bundle_id, bytes.clone()).await {
         Ok(()) => {
             eprintln!("✅ Uploaded: {}", bundle_id);
         }
         Err(StoreError::AlreadyExists { .. }) => {
+            // The key is `bundle_id`, which is the bundle's `run_root`: a digest over event
+            // semantics, not over the archive. A different archive with the same events shares it.
+            // So an existing object is an idempotent re-upload only if it is these bytes; anything
+            // else would keep the other archive and, below, link this run to it. `--allow-exists`
+            // quiets the identical case and does not waive this.
+            let stored = store
+                .get_bundle_bounded(&bundle_id, StreamCeiling::new(limits.max_bundle_bytes))
+                .await
+                .with_context(|| {
+                    format!(
+                        "bundle {bundle_id} already exists and could not be read back to compare"
+                    )
+                })?;
+            if stored != bytes {
+                anyhow::bail!(
+                    "a different archive is already stored as {bundle_id}; it was not replaced, \
+                     and no run was linked"
+                );
+            }
             if args.allow_exists {
                 eprintln!("ℹ️  Bundle already exists: {}", bundle_id);
             } else {
                 eprintln!("⚠️  Bundle already exists: {}", bundle_id);
                 eprintln!("   Use --allow-exists to suppress this warning");
-                // Not an error - idempotent
+                // Not an error: the stored object is these exact bytes.
             }
         }
         Err(e) => {

--- a/crates/assay-cli/tests/evidence_store_test.rs
+++ b/crates/assay-cli/tests/evidence_store_test.rs
@@ -240,3 +240,247 @@ fn test_no_store_configured_exits_2() {
         .code(2)
         .stderr(predicate::str::contains("Config error"));
 }
+
+// ── Identity across push and pull ─────────────────────────────────────────────────────────────
+//
+// The store is keyed by `bundle_id`, which is the bundle's `run_root`: a digest over event
+// semantics, not over the archive bytes. Two findings followed from that. `pull --verify` checked
+// that the bytes were *a* valid bundle, never that they were the bundle that was asked for; and
+// `push` treated any existing object under the key as an idempotent re-upload without looking at
+// it, then linked the run to whatever was there.
+
+/// Export a bundle whose single observed file is `observed`, so each call can differ in content.
+fn create_bundle_observing(
+    dir: &std::path::Path,
+    name: &str,
+    observed: &str,
+) -> std::path::PathBuf {
+    let profile_path = dir.join(format!("{name}.yaml"));
+    let bundle_path = dir.join(format!("{name}.tar.gz"));
+    let profile = format!(
+        r#"
+version: "1.0"
+name: {name}
+created_at: "2026-03-15T12:00:00Z"
+updated_at: "2026-03-15T12:00:00Z"
+total_runs: 1
+run_ids: ["{name}_run"]
+entries:
+  files:
+    "{observed}":
+      first_seen: 100
+      last_seen: 200
+      runs_seen: 1
+      hits_total: 1
+"#
+    );
+    fs::write(&profile_path, profile).unwrap();
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args(["evidence", "export", "--profile"])
+        .arg(&profile_path)
+        .arg("--out")
+        .arg(&bundle_path)
+        .assert()
+        .success();
+    bundle_path
+}
+
+/// Push and return the bundle id the command reports.
+fn push_and_read_id(bundle: &std::path::Path, store_url: &str) -> String {
+    let out = Command::cargo_bin("assay")
+        .unwrap()
+        .args(["evidence", "push"])
+        .arg(bundle)
+        .args(["--store", store_url])
+        .assert()
+        .success();
+    let stderr = String::from_utf8(out.get_output().stderr.clone()).unwrap();
+    stderr
+        .lines()
+        .find_map(|line| line.split("Uploaded: ").nth(1))
+        .map(|id| id.trim().to_string())
+        .expect("push reports the uploaded bundle id")
+}
+
+/// The store object whose bytes equal `bytes`, wherever the file backend nested it.
+fn stored_object_with(store_dir: &std::path::Path, bytes: &[u8]) -> std::path::PathBuf {
+    fn walk(dir: &std::path::Path, bytes: &[u8]) -> Option<std::path::PathBuf> {
+        for entry in fs::read_dir(dir).ok()? {
+            let path = entry.ok()?.path();
+            if path.is_dir() {
+                if let Some(found) = walk(&path, bytes) {
+                    return Some(found);
+                }
+            } else if fs::read(&path).ok()? == bytes {
+                return Some(path);
+            }
+        }
+        None
+    }
+    walk(store_dir, bytes).expect("the pushed archive is stored byte for byte")
+}
+
+#[test]
+fn pull_verify_refuses_a_valid_bundle_stored_under_another_id() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("store");
+    fs::create_dir_all(&store_dir).unwrap();
+    let store_url = format!("file://{}", store_dir.display());
+
+    let requested = create_bundle_observing(dir.path(), "requested", "/tmp/requested.txt");
+    let other = create_bundle_observing(dir.path(), "other", "/tmp/other.txt");
+    let requested_id = push_and_read_id(&requested, &store_url);
+    let other_id = push_and_read_id(&other, &store_url);
+    assert_ne!(
+        requested_id, other_id,
+        "the fixture needs two distinct bundles"
+    );
+
+    // Anyone who can write to the store puts a different, internally valid bundle under the
+    // requested key.
+    let requested_object = stored_object_with(&store_dir, &fs::read(&requested).unwrap());
+    fs::copy(&other, &requested_object).unwrap();
+
+    let pull_dir = dir.path().join("pulled");
+    fs::create_dir_all(&pull_dir).unwrap();
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "pull",
+            "--bundle-id",
+            &requested_id,
+            "--store",
+            &store_url,
+        ])
+        .arg("--verify")
+        .arg("-o")
+        .arg(&pull_dir)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Verified: OK").not())
+        .stderr(predicate::str::contains(&other_id));
+
+    assert_eq!(
+        fs::read_dir(&pull_dir).unwrap().count(),
+        0,
+        "a bundle that is not the one requested must not be written under its name"
+    );
+}
+
+#[test]
+fn pull_verify_still_accepts_the_bundle_that_was_requested() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("store");
+    fs::create_dir_all(&store_dir).unwrap();
+    let store_url = format!("file://{}", store_dir.display());
+
+    let bundle = create_bundle_observing(dir.path(), "requested", "/tmp/requested.txt");
+    let id = push_and_read_id(&bundle, &store_url);
+
+    let pull_dir = dir.path().join("pulled");
+    fs::create_dir_all(&pull_dir).unwrap();
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "pull",
+            "--bundle-id",
+            &id,
+            "--store",
+            &store_url,
+            "--verify",
+            "-o",
+        ])
+        .arg(&pull_dir)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Verified: OK"));
+    let written: Vec<_> = fs::read_dir(&pull_dir).unwrap().collect();
+    assert_eq!(written.len(), 1);
+    assert_eq!(
+        fs::read(written[0].as_ref().unwrap().path()).unwrap(),
+        fs::read(&bundle).unwrap()
+    );
+}
+
+/// The same archive content, gzip-compressed again with a different header: a different byte
+/// sequence that verifies and carries the same `bundle_id`.
+fn recompressed(bundle: &std::path::Path, out: &std::path::Path) {
+    use std::io::{Read, Write};
+    let mut tar = Vec::new();
+    flate2::read::GzDecoder::new(fs::File::open(bundle).unwrap())
+        .read_to_end(&mut tar)
+        .unwrap();
+    let mut encoder = flate2::GzBuilder::new()
+        .mtime(1_234_567)
+        .write(fs::File::create(out).unwrap(), flate2::Compression::best());
+    encoder.write_all(&tar).unwrap();
+    encoder.finish().unwrap();
+}
+
+#[test]
+fn push_refuses_a_different_archive_under_an_existing_id_and_links_nothing() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("store");
+    fs::create_dir_all(&store_dir).unwrap();
+    let store_url = format!("file://{}", store_dir.display());
+
+    let first = create_bundle_observing(dir.path(), "first", "/tmp/first.txt");
+    let id = push_and_read_id(&first, &store_url);
+    let second = dir.path().join("second.tar.gz");
+    recompressed(&first, &second);
+    assert_ne!(fs::read(&first).unwrap(), fs::read(&second).unwrap());
+
+    for extra in [&[][..], &["--allow-exists"][..]] {
+        Command::cargo_bin("assay")
+            .unwrap()
+            .args(["evidence", "push"])
+            .arg(&second)
+            .args(["--store", &store_url, "--run-id", "collision-run"])
+            .args(extra)
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(&id));
+    }
+
+    // Nothing was linked to the run, and the stored object is still the first archive.
+    let listed = Command::cargo_bin("assay")
+        .unwrap()
+        .args(["evidence", "list", "--store", &store_url])
+        .args(["--run-id", "collision-run", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        !String::from_utf8_lossy(&listed.stdout).contains(&id),
+        "a refused push must not link the run to the stored archive"
+    );
+    stored_object_with(&store_dir, &fs::read(&first).unwrap());
+}
+
+#[test]
+fn push_of_identical_bytes_stays_idempotent_and_links_the_run() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("store");
+    fs::create_dir_all(&store_dir).unwrap();
+    let store_url = format!("file://{}", store_dir.display());
+
+    let bundle = create_bundle_observing(dir.path(), "same", "/tmp/same.txt");
+    let id = push_and_read_id(&bundle, &store_url);
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args(["evidence", "push"])
+        .arg(&bundle)
+        .args(["--store", &store_url, "--run-id", "same-run"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("already exists"));
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args(["evidence", "list", "--store", &store_url])
+        .args(["--run-id", "same-run", "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&id));
+}

--- a/docs/architecture/ADR-015-BYOS-Storage-Strategy.md
+++ b/docs/architecture/ADR-015-BYOS-Storage-Strategy.md
@@ -306,6 +306,21 @@ Then:
 - Store `x-assay-bundle-id` metadata for verification
 - Support checksum validation on pull
 
+**Correction (2026-09-10).** The push sketch above treats `AlreadyExists` as "same bundle_id =
+same bytes". That premise is false: `bundle_id` is the bundle's `run_root`, a digest over event
+semantics, so two different archives carrying the same events share it. And "support checksum
+validation on pull" was implemented as integrity only: `pull --verify` never compared the verified
+manifest with the id that was requested. Both now hold as properties of the CLI:
+
+- `evidence push` treats an existing object as idempotent only when it is byte-identical to the
+  local archive; a different archive under the same id fails, is not stored, and links no run.
+  `--allow-exists` quiets the identical case only.
+- `evidence pull --verify` verifies before writing and requires the verified manifest's
+  `bundle_id` to equal the requested id; on a mismatch nothing is written.
+
+Keying the store by a digest of the archive bytes, rather than by `run_root`, would remove the
+collision itself; that is a storage-layout change and is not part of this correction.
+
 ### WORM Responsibility
 
 User is responsible for configuring Object Lock on their bucket:


### PR DESCRIPTION
**Security fix for GHSA-959f-h4x8-m24q, publication approved by the owner.** Current head `b3c314837a29ff41c4e374041025d5d6b0f04827` is `gh pr update-branch` over the reviewed head `33dd6aaca1a46bd47e4d1b87fd780e7dcc67726a`. Muse's review record for the reviewed head (made in the advisory's private fork, where GitHub refuses comments): [5618392410](https://github.com/Rul1an/assay/pull/2891#issuecomment-5618392410); Muse's carry record with both AGENTS.md checks: [5618407121](https://github.com/Rul1an/assay/pull/2891#issuecomment-5618407121). Lands through required CI, then ships in v6.1.1.

## Problem

The evidence store is keyed by `bundle_id`, which is the bundle's `run_root`: a digest over event semantics, not the archive bytes.

- `evidence pull --verify` verified the downloaded bytes and printed `Verified: OK` without comparing the verified manifest's `bundle_id` with the requested one, so any internally valid bundle under the requested key was accepted and written under the requested name. It wrote the file before verifying.
- `evidence push` treated `StoreError::AlreadyExists` as idempotent without reading the stored object: a different archive with the same events was silently not stored, exit 0, and `--run-id` linked the run to the other archive.

## Change

- pull: with `--verify`, verify first, then require `verified.manifest.bundle_id == requested`; on a mismatch bail with both ids and write nothing. The `Verified: OK` line is unchanged for consumers.
- push: on `AlreadyExists`, read the stored object back under the same `max_bundle_bytes` ceiling; continue only if byte-identical, otherwise fail before any run link. `--allow-exists` quiets only the identical case.
- ADR-015: dated correction of its "same bundle_id = same bytes" premise. CHANGELOG: Security entry under Unreleased.

## Proof

Tests first, in `crates/assay-cli/tests/evidence_store_test.rs` (file:// backend):

| test | before the fix | after |
|---|---|---|
| `pull_verify_refuses_a_valid_bundle_stored_under_another_id` | **RED**: "Unexpected success", exit 0 | green; nothing written |
| `push_refuses_a_different_archive_under_an_existing_id_and_links_nothing` (re-gzipped same content, with and without `--allow-exists`) | **RED**: "Unexpected success" | green; run not linked; stored object still the first archive |
| `pull_verify_still_accepts_the_bundle_that_was_requested` | green | green (control) |
| `push_of_identical_bytes_stays_idempotent_and_links_the_run` | green | green (control) |

Mutations, each red in exactly its own test: identity comparison removed; verification moved back after the write; byte comparison removed; `--allow-exists` allowed to waive the comparison.

`cargo test -p assay-cli --no-fail-fast` (86 test binaries) and `cargo clippy -p assay-cli --all-targets -- -D warnings`: green. Hosted CI did not run in the private fork; it runs here.

## Non-claims

- The store stays keyed by `run_root`; keying by an archive digest would remove the collision and is a layout change, not in this fix.
- `pull` without `--verify` still writes what the store returns, as documented; the identity binding is part of verification.
- The run-to-bundle index (`runs/{run_id}/bundles/*.ref`) is store-written; a writer who can alter it can still point a run at a different, correctly identified bundle. Out of scope.
- Observed, not fixed: the file:// backend nests the absolute store path under the store root (`store/<abs path>/store/bundles/...`). Unrelated to identity; noted for a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

