### PR TITLE
fix(release): pin crates.io Trusted Publisher identity to the crates environment

### DIFF
--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -50,7 +50,14 @@ This document outlines the canonical checklist for releasing new versions of Ass
   `python3 scripts/ci/check-release-runbook-truth.py`, compare its expected identity with every
   owner-visible PyPI publisher row, and retain a redacted receipt containing only the project,
   repository, workflow, environment, publisher count, observation time, and result.
-- [ ] **Trusted Publishing**: Ensure GitHub Actions OIDC is enabled for the release tag on every current crates.io crate:
+- [ ] **Trusted Publishing**: Require, per crate, a GitHub Trusted Publisher:
+  repository `Rul1an/assay`, workflow `release.yml`, environment `crates`.
+  Remove every other publisher, including any publisher whose environment is unset.
+  An unset environment is broader authority and does not match this contract. Before creating a tag, run
+  `python3 scripts/ci/check-release-runbook-truth.py`, compare its expected identity with every
+  owner-visible crates.io publisher row, and retain a redacted receipt containing only the crate,
+  repository, workflow, environment, publisher count, observation time, and result.
+  No credentials.
   - `assay-common`
   - `assay-registry`
   - `assay-canonical`

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -58,6 +58,7 @@ This document outlines the canonical checklist for releasing new versions of Ass
   owner-visible crates.io publisher row, and retain a redacted receipt containing only the crate,
   repository, workflow, environment, publisher count, observation time, and result.
   No credentials.
+  on every current crates.io crate:
   - `assay-common`
   - `assay-registry`
   - `assay-canonical`

--- a/scripts/ci/check-release-runbook-truth.py
+++ b/scripts/ci/check-release-runbook-truth.py
@@ -37,6 +37,9 @@ _CRATES_ITEM_TITLE = "Trusted Publishing"
 _CRATES_REPOSITORY = _PYPI_REPOSITORY
 _CRATES_WORKFLOW = _PYPI_WORKFLOW
 _CRATES_ENVIRONMENT = "crates"
+_CRATES_PUBLISH_ACTION = (
+    "rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18"
+)
 _CRATES_IDENTITY_SENTENCE = (
     "Require, per crate, a GitHub Trusted Publisher: "
     "repository `Rul1an/assay`, "
@@ -256,6 +259,16 @@ def _id_token_write_problems(job: str, *, job_id: str) -> list[str]:
     return []
 
 
+def _pinned_publish_action_problems(
+    job: str, *, job_id: str, action: str, label: str
+) -> list[str]:
+    if _active_step_uses(job).count(action) != 1:
+        return [
+            f"{job_id} does not invoke the pinned {label} trusted-publishing action exactly once"
+        ]
+    return []
+
+
 def _pypi_workflow_problems(workflow: str) -> list[str]:
     job, entries, problems = _publisher_job(workflow, "publish-pypi", "PyPI")
     if job is None or entries is None:
@@ -266,10 +279,14 @@ def _pypi_workflow_problems(workflow: str) -> list[str]:
         )
     )
     problems.extend(_id_token_write_problems(job, job_id="publish-pypi"))
-    if _active_step_uses(job).count(_PYPI_PUBLISH_ACTION) != 1:
-        problems.append(
-            "publish-pypi does not invoke the pinned PyPI trusted-publishing action exactly once"
+    problems.extend(
+        _pinned_publish_action_problems(
+            job,
+            job_id="publish-pypi",
+            action=_PYPI_PUBLISH_ACTION,
+            label="PyPI",
         )
+    )
     return problems
 
 
@@ -283,6 +300,14 @@ def _crates_workflow_problems(workflow: str) -> list[str]:
         )
     )
     problems.extend(_id_token_write_problems(job, job_id="publish-crates"))
+    problems.extend(
+        _pinned_publish_action_problems(
+            job,
+            job_id="publish-crates",
+            action=_CRATES_PUBLISH_ACTION,
+            label="crates.io",
+        )
+    )
     return problems
 
 
@@ -381,7 +406,7 @@ def _crates_docs_problems(docs: str) -> list[str]:
     return _trusted_publisher_docs_problems(
         docs,
         title=_CRATES_ITEM_TITLE,
-        label="Trusted Publishing",
+        label="crates.io Trusted Publishing",
         required_literals=(
             f"`{_CRATES_REPOSITORY}`",
             f"`{_CRATES_WORKFLOW}`",
@@ -390,19 +415,19 @@ def _crates_docs_problems(docs: str) -> list[str]:
         required_sentences=(
             (
                 _CRATES_IDENTITY_SENTENCE,
-                "Trusted Publishing item does not require the crates.io publisher identity per crate",
+                "crates.io Trusted Publishing item does not require the crates.io publisher identity per crate",
             ),
             (
                 _CRATES_LEGACY_REMOVAL_SENTENCE,
-                "Trusted Publishing item does not require removal of publishers whose environment is unset",
+                "crates.io Trusted Publishing item does not require removal of publishers whose environment is unset",
             ),
             (
                 _CRATES_UNSET_ENVIRONMENT_SENTENCE,
-                "Trusted Publishing item does not reject an unset environment",
+                "crates.io Trusted Publishing item does not reject an unset environment",
             ),
             (
                 _CRATES_RECEIPT_SENTENCE,
-                "Trusted Publishing item omits the redacted crates.io receipt sentence",
+                "crates.io Trusted Publishing item omits the redacted crates.io receipt sentence",
             ),
         ),
     )
@@ -416,13 +441,15 @@ def _crates_publisher_problems(workflow: str, docs: str) -> list[str]:
     return _crates_workflow_problems(workflow) + _crates_docs_problems(docs)
 
 
-def _trusted_publisher_identity_json(*, environment: str) -> str:
+def _trusted_publisher_identity_json(
+    *, environment: str, repository: str, workflow: str
+) -> str:
     return json.dumps(
         {
             "environment": environment,
             "publisher_count": 1,
-            "repository": _PYPI_REPOSITORY,
-            "workflow": _PYPI_WORKFLOW,
+            "repository": repository,
+            "workflow": workflow,
         },
         sort_keys=True,
         separators=(",", ":"),
@@ -555,11 +582,19 @@ def main() -> int:
     print("ok   release runbook matches executable release.yml")
     print(
         "expected_pypi_trusted_publisher="
-        + _trusted_publisher_identity_json(environment=_PYPI_ENVIRONMENT)
+        + _trusted_publisher_identity_json(
+            environment=_PYPI_ENVIRONMENT,
+            repository=_PYPI_REPOSITORY,
+            workflow=_PYPI_WORKFLOW,
+        )
     )
     print(
         "expected_crates_trusted_publisher="
-        + _trusted_publisher_identity_json(environment=_CRATES_ENVIRONMENT)
+        + _trusted_publisher_identity_json(
+            environment=_CRATES_ENVIRONMENT,
+            repository=_CRATES_REPOSITORY,
+            workflow=_CRATES_WORKFLOW,
+        )
     )
     return 0
 

--- a/scripts/ci/check-release-runbook-truth.py
+++ b/scripts/ci/check-release-runbook-truth.py
@@ -33,6 +33,26 @@ _PYPI_SINGLE_PUBLISHER_SENTENCE = (
 _PYPI_EMPTY_ENVIRONMENT_SENTENCE = (
     "An empty environment is broader authority and does not match this contract."
 )
+_CRATES_ITEM_TITLE = "Trusted Publishing"
+_CRATES_REPOSITORY = _PYPI_REPOSITORY
+_CRATES_WORKFLOW = _PYPI_WORKFLOW
+_CRATES_ENVIRONMENT = "crates"
+_CRATES_IDENTITY_SENTENCE = (
+    "Require, per crate, a GitHub Trusted Publisher: "
+    "repository `Rul1an/assay`, "
+    "workflow `release.yml`, environment `crates`."
+)
+_CRATES_LEGACY_REMOVAL_SENTENCE = (
+    "Remove every other publisher, including any publisher whose environment is unset."
+)
+_CRATES_UNSET_ENVIRONMENT_SENTENCE = (
+    "An unset environment is broader authority and does not match this contract."
+)
+_CRATES_RECEIPT_SENTENCE = (
+    "retain a redacted receipt containing only the crate, "
+    "repository, workflow, environment, publisher count, observation time, and result. "
+    "No credentials."
+)
 _BEFORE_CLAIM = re.compile(
     r"GitHub Release is created before crates publication",
     re.IGNORECASE,
@@ -200,32 +220,69 @@ def _active_step_uses(job: str) -> list[str]:
     return uses
 
 
-def _pypi_workflow_problems(workflow: str) -> list[str]:
+def _publisher_job(
+    workflow: str, job_id: str, label: str
+) -> tuple[str | None, dict[str, str] | None, list[str]]:
     try:
         jobs = _mapping_block(workflow, "jobs", 0)
-        job = _mapping_block(jobs, "publish-pypi", 2)
+        job = _mapping_block(jobs, job_id, 2)
         entries = _child_entries(job)
     except AssertionError as exc:
-        return [f"release.yml PyPI publisher identity is unavailable ({exc})"]
+        return None, None, [f"release.yml {label} publisher identity is unavailable ({exc})"]
+    return job, entries, []
 
-    problems: list[str] = []
-    environment = entries.get("environment", "").split(" #", 1)[0].strip(" '\"")
-    if environment != _PYPI_ENVIRONMENT:
-        problems.append(
-            f"publish-pypi environment is {environment!r}, expected {_PYPI_ENVIRONMENT!r}"
-        )
+
+def _job_environment(entries: dict[str, str]) -> str:
+    return entries.get("environment", "").split(" #", 1)[0].strip(" '\"")
+
+
+def _environment_problems(
+    entries: dict[str, str], *, job_id: str, expected: str
+) -> list[str]:
+    environment = _job_environment(entries)
+    if environment != expected:
+        return [f"{job_id} environment is {environment!r}, expected {expected!r}"]
+    return []
+
+
+def _id_token_write_problems(job: str, *, job_id: str) -> list[str]:
     try:
         permissions = _child_entries(_mapping_block(job, "permissions", 4))
     except AssertionError as exc:
-        problems.append(f"publish-pypi permissions are unavailable ({exc})")
-    else:
-        id_token = permissions.get("id-token", "").split(" #", 1)[0].strip(" '\"")
-        if id_token != "write":
-            problems.append("publish-pypi does not grant id-token: write")
+        return [f"{job_id} permissions are unavailable ({exc})"]
+    id_token = permissions.get("id-token", "").split(" #", 1)[0].strip(" '\"")
+    if id_token != "write":
+        return [f"{job_id} does not grant id-token: write"]
+    return []
+
+
+def _pypi_workflow_problems(workflow: str) -> list[str]:
+    job, entries, problems = _publisher_job(workflow, "publish-pypi", "PyPI")
+    if job is None or entries is None:
+        return problems
+    problems.extend(
+        _environment_problems(
+            entries, job_id="publish-pypi", expected=_PYPI_ENVIRONMENT
+        )
+    )
+    problems.extend(_id_token_write_problems(job, job_id="publish-pypi"))
     if _active_step_uses(job).count(_PYPI_PUBLISH_ACTION) != 1:
         problems.append(
             "publish-pypi does not invoke the pinned PyPI trusted-publishing action exactly once"
         )
+    return problems
+
+
+def _crates_workflow_problems(workflow: str) -> list[str]:
+    job, entries, problems = _publisher_job(workflow, "publish-crates", "crates.io")
+    if job is None or entries is None:
+        return problems
+    problems.extend(
+        _environment_problems(
+            entries, job_id="publish-crates", expected=_CRATES_ENVIRONMENT
+        )
+    )
+    problems.extend(_id_token_write_problems(job, job_id="publish-crates"))
     return problems
 
 
@@ -261,40 +318,115 @@ def _optional_lsm_item(docs: str) -> str:
     return _checklist_item(docs, _LSM_ITEM_TITLE)
 
 
-def _pypi_docs_problems(docs: str) -> list[str]:
+def _visible_docs(docs: str) -> str:
+    return re.sub(r"<!--.*?-->", "", docs, flags=re.DOTALL)
+
+
+def _trusted_publisher_docs_problems(
+    docs: str,
+    *,
+    title: str,
+    label: str,
+    required_literals: tuple[str, ...],
+    required_sentences: tuple[tuple[str, str], ...],
+) -> list[str]:
     try:
-        visible_docs = re.sub(r"<!--.*?-->", "", docs, flags=re.DOTALL)
-        item = _checklist_item(visible_docs, _PYPI_ITEM_TITLE)
+        item = _checklist_item(_visible_docs(docs), title)
     except AssertionError as exc:
         return [str(exc)]
 
     problems: list[str] = []
-    required_literals = (
-        f"`{_PYPI_REPOSITORY}`",
-        f"`{_PYPI_WORKFLOW}`",
-        f"`{_PYPI_ENVIRONMENT}`",
-        f"`{_PYPI_LEGACY_WORKFLOW}`",
-    )
     for literal in required_literals:
         if literal not in item:
-            problems.append(f"PyPI Trusted Publisher item omits {literal}")
+            problems.append(f"{label} item omits {literal}")
     normalized = " ".join(item.split())
+    for sentence, message in required_sentences:
+        if sentence not in normalized:
+            problems.append(message)
     lowered = normalized.lower()
-    if _PYPI_SINGLE_PUBLISHER_SENTENCE not in normalized:
-        problems.append("PyPI Trusted Publisher item does not require exactly one publisher")
-    if _PYPI_LEGACY_REMOVAL_SENTENCE not in normalized:
-        problems.append(
-            "PyPI Trusted Publisher item does not require removal of the legacy publish.yml publisher"
-        )
-    if _PYPI_EMPTY_ENVIRONMENT_SENTENCE not in normalized:
-        problems.append("PyPI Trusted Publisher item does not reject an empty environment")
     if "owner-visible" not in lowered or "redacted receipt" not in lowered:
-        problems.append("PyPI Trusted Publisher item omits the redacted owner-visible receipt")
+        problems.append(f"{label} item omits the redacted owner-visible receipt")
     return problems
+
+
+def _pypi_docs_problems(docs: str) -> list[str]:
+    return _trusted_publisher_docs_problems(
+        docs,
+        title=_PYPI_ITEM_TITLE,
+        label="PyPI Trusted Publisher",
+        required_literals=(
+            f"`{_PYPI_REPOSITORY}`",
+            f"`{_PYPI_WORKFLOW}`",
+            f"`{_PYPI_ENVIRONMENT}`",
+            f"`{_PYPI_LEGACY_WORKFLOW}`",
+        ),
+        required_sentences=(
+            (
+                _PYPI_SINGLE_PUBLISHER_SENTENCE,
+                "PyPI Trusted Publisher item does not require exactly one publisher",
+            ),
+            (
+                _PYPI_LEGACY_REMOVAL_SENTENCE,
+                "PyPI Trusted Publisher item does not require removal of the legacy publish.yml publisher",
+            ),
+            (
+                _PYPI_EMPTY_ENVIRONMENT_SENTENCE,
+                "PyPI Trusted Publisher item does not reject an empty environment",
+            ),
+        ),
+    )
+
+
+def _crates_docs_problems(docs: str) -> list[str]:
+    return _trusted_publisher_docs_problems(
+        docs,
+        title=_CRATES_ITEM_TITLE,
+        label="Trusted Publishing",
+        required_literals=(
+            f"`{_CRATES_REPOSITORY}`",
+            f"`{_CRATES_WORKFLOW}`",
+            f"`{_CRATES_ENVIRONMENT}`",
+        ),
+        required_sentences=(
+            (
+                _CRATES_IDENTITY_SENTENCE,
+                "Trusted Publishing item does not require the crates.io publisher identity per crate",
+            ),
+            (
+                _CRATES_LEGACY_REMOVAL_SENTENCE,
+                "Trusted Publishing item does not require removal of publishers whose environment is unset",
+            ),
+            (
+                _CRATES_UNSET_ENVIRONMENT_SENTENCE,
+                "Trusted Publishing item does not reject an unset environment",
+            ),
+            (
+                _CRATES_RECEIPT_SENTENCE,
+                "Trusted Publishing item omits the redacted crates.io receipt sentence",
+            ),
+        ),
+    )
 
 
 def _pypi_publisher_problems(workflow: str, docs: str) -> list[str]:
     return _pypi_workflow_problems(workflow) + _pypi_docs_problems(docs)
+
+
+def _crates_publisher_problems(workflow: str, docs: str) -> list[str]:
+    return _crates_workflow_problems(workflow) + _crates_docs_problems(docs)
+
+
+def _trusted_publisher_identity_json(*, environment: str) -> str:
+    return json.dumps(
+        {
+            "environment": environment,
+            "publisher_count": 1,
+            "repository": _PYPI_REPOSITORY,
+            "workflow": _PYPI_WORKFLOW,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
 
 
 def _bullet_mentions_github_release(line: str) -> bool:
@@ -404,6 +536,7 @@ def contract_problems(workflow: str, docs: str) -> list[str]:
         _workflow_problems(workflow)
         + _docs_problems(docs)
         + _pypi_publisher_problems(workflow, docs)
+        + _crates_publisher_problems(workflow, docs)
     )
 
 
@@ -422,16 +555,11 @@ def main() -> int:
     print("ok   release runbook matches executable release.yml")
     print(
         "expected_pypi_trusted_publisher="
-        + json.dumps(
-            {
-                "environment": _PYPI_ENVIRONMENT,
-                "publisher_count": 1,
-                "repository": _PYPI_REPOSITORY,
-                "workflow": _PYPI_WORKFLOW,
-            },
-            sort_keys=True,
-            separators=(",", ":"),
-        )
+        + _trusted_publisher_identity_json(environment=_PYPI_ENVIRONMENT)
+    )
+    print(
+        "expected_crates_trusted_publisher="
+        + _trusted_publisher_identity_json(environment=_CRATES_ENVIRONMENT)
     )
     return 0
 

--- a/scripts/ci/test-release-runbook-truth.py
+++ b/scripts/ci/test-release-runbook-truth.py
@@ -302,6 +302,45 @@ class ReleaseRunbookTruthMutations(unittest.TestCase):
         )
         self.assert_mutation_bites(workflow=mutated)
 
+    def test_crates_auth_action_removed_bites(self) -> None:
+        mutated = replace_once(
+            self.workflow,
+            "        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5\n",
+            "        run: echo skipped\n",
+        )
+        self.assert_mutation_bites(workflow=mutated)
+
+    def test_crates_auth_action_disabled_step_bites(self) -> None:
+        mutated = replace_once(
+            self.workflow,
+            "      - name: Authenticate with crates.io\n"
+            "        id: auth\n"
+            "        uses: rust-lang/crates-io-auth-action@",
+            "      - name: Authenticate with crates.io\n"
+            "        if: ${{ false }}\n"
+            "        id: auth\n"
+            "        uses: rust-lang/crates-io-auth-action@",
+        )
+        self.assert_mutation_bites(workflow=mutated)
+
+    def test_crates_auth_action_mutable_ref_bites(self) -> None:
+        mutated = replace_once(
+            self.workflow,
+            "rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18",
+            "rust-lang/crates-io-auth-action@main",
+        )
+        self.assert_mutation_bites(workflow=mutated)
+
+    def test_crates_auth_action_duplicated_bites(self) -> None:
+        mutated = replace_once(
+            self.workflow,
+            "        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5\n",
+            "        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5\n"
+            "      - name: Authenticate with crates.io again\n"
+            "        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5\n",
+        )
+        self.assert_mutation_bites(workflow=mutated)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/ci/test-release-runbook-truth.py
+++ b/scripts/ci/test-release-runbook-truth.py
@@ -257,6 +257,51 @@ class ReleaseRunbookTruthMutations(unittest.TestCase):
         self.assertNotEqual(item, contract._checklist_item(mutated, "PyPI Trusted Publisher"))
         self.assert_mutation_bites(docs=mutated)
 
+    def test_crates_publisher_expectation_matches_release_job(self) -> None:
+        self.assertEqual(
+            contract._crates_publisher_problems(self.workflow, self.docs), []
+        )
+
+    def test_crates_empty_environment_bites(self) -> None:
+        mutated = replace_once(
+            self.docs,
+            "An unset environment is broader authority and does not match this contract.",
+            "An unset environment is broader authority and matches this contract.",
+        )
+        self.assert_mutation_bites(docs=mutated)
+
+    def test_crates_wrong_environment_bites(self) -> None:
+        mutated = replace_once(
+            self.docs,
+            "workflow `release.yml`, environment `crates`.",
+            "workflow `release.yml`, environment `pypi`.",
+        )
+        self.assert_mutation_bites(docs=mutated)
+
+    def test_crates_wrong_workflow_bites(self) -> None:
+        mutated = replace_once(
+            self.docs,
+            "repository `Rul1an/assay`, workflow `release.yml`, environment `crates`.",
+            "repository `Rul1an/assay`, workflow `publish.yml`, environment `crates`.",
+        )
+        self.assert_mutation_bites(docs=mutated)
+
+    def test_crates_legacy_row_bites(self) -> None:
+        mutated = replace_once(
+            self.docs,
+            "  Remove every other publisher, including any publisher whose environment is unset.\n",
+            "  Keep publishers whose environment is unset. Remove only unrelated publishers.\n",
+        )
+        self.assert_mutation_bites(docs=mutated)
+
+    def test_crates_workflow_environment_drift_bites(self) -> None:
+        mutated = replace_once(
+            self.workflow,
+            "    environment: crates\n",
+            "    environment: release\n",
+        )
+        self.assert_mutation_bites(workflow=mutated)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
**Merge head `cc1bb579b9b9a67644045e5d800ce45ae29d679b`** is `gh pr update-branch` over the reviewed/carried head `5d8eb305fef32b978ebb614bed79dd6ed375541b`; carry record with both AGENTS.md checks: https://github.com/Rul1an/assay/pull/2901#issuecomment-5626069743.

**Merge head `5d8eb305fef32b978ebb614bed79dd6ed375541b`** is `gh pr update-branch` over the builder head `c8e53aaf8aa4899237da7cd3e518e458bc9da2df`; the review is requested on this merge head.

Candidate, not a landing. Head SHA c8e53aaf8aa4899237da7cd3e518e458bc9da2df. Sole author; needs an independent exact-head review record before merge.

## What changed

Repository half only. Three files:

- `docs/reference/release.md`: the Trusted Publishing crates.io item now requires, per crate, repository `Rul1an/assay`, workflow `release.yml`, environment `crates`. An unset environment is broader authority. The crate list is unchanged. The receipt sentence mirrors PyPI (crate, repository, workflow, environment, publisher count, observation time, result; no credentials).
- `scripts/ci/check-release-runbook-truth.py`: derives the crates.io expected identity from the `publish-crates` job environment in `release.yml`, the same way PyPI is derived from `publish-pypi`. Shared helpers (`_publisher_job`, `_environment_problems`, `_id_token_write_problems`, `_pinned_publish_action_problems`, `_trusted_publisher_docs_problems`, `_trusted_publisher_identity_json`) take a parameter where PyPI and crates.io use the same logic.
- `scripts/ci/test-release-runbook-truth.py`: mutation coverage for empty environment, wrong environment, wrong workflow, a legacy unset-environment row, and workflow environment drift with the doc unchanged, plus a positive control on the real files.

Owner-side crates.io publisher settings are not in this PR.

## Review follow-ups

Independent review READY on ccd1a060d30a1d7bea9cdcc37e7b1c48614abea5: https://github.com/Rul1an/assay/pull/2901#issuecomment-5624252915

D1: `publish-crates` now requires `rust-lang/crates-io-auth-action` pinned to `c6f97d42243bad5fab37ca0427f495c86d5b1a18` exactly once, with no step-level `if:`. Same helper as PyPI (`_pinned_publish_action_problems` over `_active_step_uses`).

| Mutation | Checker |
| --- | --- |
| step removed | FAIL: publish-crates does not invoke the pinned crates.io trusted-publishing action exactly once |
| step with if: `${{ false }}` | FAIL: publish-crates does not invoke the pinned crates.io trusted-publishing action exactly once |
| step pinned to `@main` | FAIL: publish-crates does not invoke the pinned crates.io trusted-publishing action exactly once |
| step duplicated | FAIL: publish-crates does not invoke the pinned crates.io trusted-publishing action exactly once |

D3: restored the lead-in `on every current crates.io crate:` before the 15-crate list.

D2 left alone: appended contradicting sentences pass on both halves.

## RED (checker and tests, before the runbook rewrite)

Worktree `/Users/roelschuurkes/wt-cursor-2874`, after the checker learned the crates.io contract and before `release.md` named it.

`python3 scripts/ci/check-release-runbook-truth.py` exit 1:

```
FAIL: Trusted Publishing item omits `Rul1an/assay`
FAIL: Trusted Publishing item omits `release.yml`
FAIL: Trusted Publishing item omits `crates`
FAIL: Trusted Publishing item does not require the crates.io publisher identity per crate
FAIL: Trusted Publishing item does not require removal of publishers whose environment is unset
FAIL: Trusted Publishing item does not reject an unset environment
FAIL: Trusted Publishing item omits the redacted crates.io receipt sentence
FAIL: Trusted Publishing item omits the redacted owner-visible receipt
```

`python3 scripts/ci/test-release-runbook-truth.py` failed in `setUpClass` on those same problems (0 tests run).

## GREEN (measured on head c8e53aaf8aa4899237da7cd3e518e458bc9da2df)

`python3 scripts/ci/check-release-runbook-truth.py` exit 0:

```
ok   release runbook matches executable release.yml
expected_pypi_trusted_publisher={"environment":"pypi","publisher_count":1,"repository":"Rul1an/assay","workflow":"release.yml"}
expected_crates_trusted_publisher={"environment":"crates","publisher_count":1,"repository":"Rul1an/assay","workflow":"release.yml"}
```

`python3 scripts/ci/test-release-runbook-truth.py`: 37 tests, OK.

Repo does not run ruff on `scripts/ci`.

## Mutation table (same head)

| Mutation | Checker |
| --- | --- |
| empty environment (docs accept an unset environment) | FAIL: crates.io Trusted Publishing item does not reject an unset environment |
| wrong environment (docs name `pypi`) | FAIL: omits `` `crates` ``; does not require the crates.io publisher identity per crate |
| wrong workflow (docs name `publish.yml`) | FAIL: omits `` `release.yml` ``; does not require the crates.io publisher identity per crate |
| legacy row (keep publishers whose environment is unset) | FAIL: does not require removal of publishers whose environment is unset |
| workflow `publish-crates` environment changed to `release`, doc stays | FAIL: publish-crates environment is 'release', expected 'crates' |
| positive control (real files) | PASS |

Refs #2874

Made with [Cursor](https://cursor.com)


