### PR TITLE
fix(mcp): stay silent for every parsed notification on stdio

### DIFF
--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -177,12 +177,34 @@ fn initialize_result(protocol_version: LegacyProtocolVersion) -> Value {
     })
 }
 
+/// A present `id` member — including `"id": null` — reads as `Some(..)`;
+/// only an absent member (via `#[serde(default)]`) reads as `None`. A
+/// `serde_json::Value` pre-parse would keep the last of duplicate members,
+/// so the request is parsed in this one typed step to keep serde's
+/// duplicate-member rejection.
+fn deserialize_present_id<'de, D>(deserializer: D) -> Result<Option<Option<Value>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<Value>::deserialize(deserializer).map(Some)
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct JsonRpcRequest {
     jsonrpc: String,
     method: String,
     params: Option<Value>,
-    id: Option<Value>,
+    /// Absent `id` (a notification) is `None`; `"id": null` is `Some(None)`.
+    #[serde(default, deserialize_with = "deserialize_present_id")]
+    id: Option<Option<Value>>,
+}
+
+impl JsonRpcRequest {
+    /// The id to put on the wire: absent and `null` both serialize as null,
+    /// and the notification case never reaches a response site.
+    fn response_id(&self) -> Option<Value> {
+        self.id.clone().flatten()
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -307,8 +329,11 @@ impl Server {
                 continue;
             }
 
-            // Parse Request
-            let raw: Value = match serde_json::from_str(&line) {
+            // Parse the line directly into the typed request: one parse, not
+            // Value-then-from_value. The Value map keeps the last of
+            // duplicate members while the typed parser rejects them, so the
+            // two-step shape answered duplicate-member requests last-wins.
+            let req: JsonRpcRequest = match serde_json::from_str(&line) {
                 Ok(r) => r,
                 Err(e) => {
                     tracing::warn!(
@@ -316,37 +341,28 @@ impl Server {
                         rid=%rid,
                         error=%e
                     );
-                    continue; // Ignore invalid JSON lines (stdio transport robustness)
+                    // Not a request: invalid JSON, a scalar/array line, or an
+                    // object that is not a valid request (missing member,
+                    // wrong type, duplicate member). All stay silent.
+                    continue;
                 }
             };
 
             // JSON-RPC 2.0 / MCP: a notification (no `id` member) MUST NOT be
             // answered, for any method, known or unknown. Presence of the key
-            // decides, not its value: `"id": null` deserializes to `None` like
-            // a missing id but is a request and keeps its response.
-            if raw.get("id").is_none() {
+            // decides, not its value: `"id": null` is `Some(None)` — a
+            // request — and keeps its response.
+            if req.id.is_none() {
                 tracing::info!(event="notification_skipped", rid=%rid);
                 continue;
             }
-
-            let req: JsonRpcRequest = match serde_json::from_value(raw) {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::warn!(
-                        event="json_parse_error",
-                        rid=%rid,
-                        error=%e
-                    );
-                    continue; // Ignore non-object lines (stdio transport robustness)
-                }
-            };
 
             // Revision before dispatch. A revision this server does not implement is refused by name,
             // with the supported set in `data`, rather than served as whatever the method happens
             // to do -- which is the silent best-effort the 2026-07-28 spec replaced.
             if let Err(data) = check_request_version(req.params.as_ref()) {
                 let resp = JsonRpcResponse::error_with_data(
-                    req.id.clone(),
+                    req.response_id(),
                     ERROR_UNSUPPORTED_PROTOCOL_VERSION,
                     "unsupported protocol version".to_string(),
                     data,
@@ -360,22 +376,27 @@ impl Server {
             // Dispatch
             let resp = match req.method.as_str() {
                 "initialize" => match LegacyProtocolVersion::negotiate(req.params.as_ref()) {
-                    Ok(version) => JsonRpcResponse::ok(req.id.clone(), initialize_result(version)),
+                    Ok(version) => {
+                        JsonRpcResponse::ok(req.response_id(), initialize_result(version))
+                    }
                     Err(()) => JsonRpcResponse::error(
-                        req.id.clone(),
+                        req.response_id(),
                         -32602,
                         INVALID_INITIALIZE_PARAMS.to_string(),
                     ),
                 },
                 "notifications/initialized" => {
-                    // Notification, no response needed usually, but good to ack log
+                    // Reached only with an `id` present: id-less lines exit at
+                    // the notification skip above. Staying silent here is
+                    // pre-existing (Slice C keeps request handling unchanged);
+                    // a later slice may answer `-32600`/`-32601` instead.
                     tracing::info!(event="initialized", rid=%rid);
                     continue;
                 }
                 "tools/list" => {
                     let tool_list = tools::list_tools();
                     JsonRpcResponse::ok(
-                        req.id.clone(),
+                        req.response_id(),
                         serde_json::json!({
                             "tools": tool_list
                         }),
@@ -384,7 +405,7 @@ impl Server {
                 "tools/call" => {
                     match tools::classify_call_tool_params(req.params.as_ref()) {
                         Err(fault) => JsonRpcResponse::error_with_data(
-                            req.id.clone(),
+                            req.response_id(),
                             fault.code(),
                             fault.message().to_string(),
                             fault.data(),
@@ -401,7 +422,7 @@ impl Server {
                             tracing::info!(
                                event="tool_call_start",
                                rid=%rid,
-                               rpc_id=?req.id,
+                               rpc_id=?req.response_id(),
                                bytes_in=bytes_in,
                                args_bytes=args_bytes,
                             );
@@ -419,7 +440,7 @@ impl Server {
                                     tracing::error!(
                                         event = "tool_execution_error",
                                         rid = %rid,
-                                        rpc_id = ?req.id,
+                                        rpc_id = ?req.response_id(),
                                         duration_ms = start.elapsed().as_millis() as u64,
                                         code = "E_INTERNAL"
                                     );
@@ -430,7 +451,7 @@ impl Server {
                                     tracing::warn!(
                                        event="tool_call_timeout",
                                        rid=%rid,
-                                       rpc_id=?req.id,
+                                       rpc_id=?req.response_id(),
                                        duration_ms=dur,
                                        code="E_TIMEOUT"
                                     );
@@ -446,7 +467,7 @@ impl Server {
                                 tracing::info!(
                                   event="tool_call_done",
                                   rid=%rid,
-                                  rpc_id=?req.id,
+                                  rpc_id=?req.response_id(),
                                   duration_ms=dur,
                                   outcome="app_error",
                                   allowed=allowed,
@@ -456,7 +477,7 @@ impl Server {
                                 tracing::info!(
                                   event="tool_call_done",
                                   rid=%rid,
-                                  rpc_id=?req.id,
+                                  rpc_id=?req.response_id(),
                                   duration_ms=dur,
                                   outcome="ok",
                                   allowed=allowed
@@ -499,7 +520,7 @@ impl Server {
                                 tracing::info!(
                                     event = "tool_decision",
                                     rid = %rid,
-                                    rpc_id = ?req.id,
+                                    rpc_id = ?req.response_id(),
                                     decision = %serde_json::to_string(&decision).unwrap_or_default(),
                                 );
                             }
@@ -516,12 +537,12 @@ impl Server {
                             if has_error {
                                 mcp_result["structuredContent"] = result;
                             }
-                            JsonRpcResponse::ok(req.id.clone(), mcp_result)
+                            JsonRpcResponse::ok(req.response_id(), mcp_result)
                         }
                     }
                 }
                 _ => JsonRpcResponse::error(
-                    req.id.clone(),
+                    req.response_id(),
                     ERROR_METHOD_NOT_FOUND,
                     "Method not found".to_string(),
                 ),

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -308,7 +308,7 @@ impl Server {
             }
 
             // Parse Request
-            let req: JsonRpcRequest = match serde_json::from_str(&line) {
+            let raw: Value = match serde_json::from_str(&line) {
                 Ok(r) => r,
                 Err(e) => {
                     tracing::warn!(
@@ -317,6 +317,27 @@ impl Server {
                         error=%e
                     );
                     continue; // Ignore invalid JSON lines (stdio transport robustness)
+                }
+            };
+
+            // JSON-RPC 2.0 / MCP: a notification (no `id` member) MUST NOT be
+            // answered, for any method, known or unknown. Presence of the key
+            // decides, not its value: `"id": null` deserializes to `None` like
+            // a missing id but is a request and keeps its response.
+            if raw.get("id").is_none() {
+                tracing::info!(event="notification_skipped", rid=%rid);
+                continue;
+            }
+
+            let req: JsonRpcRequest = match serde_json::from_value(raw) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(
+                        event="json_parse_error",
+                        rid=%rid,
+                        error=%e
+                    );
+                    continue; // Ignore non-object lines (stdio transport robustness)
                 }
             };
 

--- a/crates/assay-mcp-server/tests/outer_fallback_contract.rs
+++ b/crates/assay-mcp-server/tests/outer_fallback_contract.rs
@@ -407,3 +407,114 @@ fn invalid_json_line_is_ignored_and_session_continues() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!stderr.contains(NOT_JSON), "stderr reflected {NOT_JSON}");
 }
+
+/// Slice C (#2776): a parsed notification — a message with no `id` member — must
+/// produce no stdout line at all, for every method and even when the version
+/// check would have rejected it. Requests with an id (including `"id": null`)
+/// behave exactly as before.
+///
+/// Silence is pinned by interleaving: the server answers sequentially, so any
+/// response to a notification would be consumed by the next `read_response`
+/// under the wrong id and fail the exact-id assertion that follows it.
+#[test]
+fn notifications_produce_no_output() {
+    let (mut conn, _root) = spawn_server(None);
+    initialize(&mut conn);
+
+    // Each notification is followed by a request whose exact-id response proves
+    // the notification emitted nothing.
+    let mut next_id: u64 = 100;
+    let mut ping = |conn: &mut Conn, notification: Value| {
+        assert!(
+            notification.get("id").is_none(),
+            "test bug: not a notification: {notification}"
+        );
+        conn.send(notification);
+        next_id += 1;
+        let id = next_id;
+        let response = conn.request("tools/list", serde_json::json!({}), id);
+        assert_eq!(response.get("id"), Some(&Value::from(id)), "{response}");
+        assert!(
+            response.get("result").is_some(),
+            "tools/list after notification: {response}"
+        );
+    };
+
+    // Unknown method notification: the method fallback must stay silent.
+    ping(
+        &mut conn,
+        serde_json::json!({"jsonrpc": "2.0", "method": "no/such/method"}),
+    );
+    // Known notification name.
+    ping(
+        &mut conn,
+        serde_json::json!({"jsonrpc": "2.0", "method": "notifications/cancelled", "params": {}}),
+    );
+    // The legacy handshake ack stays silent.
+    ping(
+        &mut conn,
+        serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}),
+    );
+    // A notification the version check would have rejected stays silent too.
+    ping(
+        &mut conn,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "tools/list",
+            "params": {"_meta": {"io.modelcontextprotocol/protocolVersion": "2099-01-01"}}
+        }),
+    );
+
+    // The same version-mismatched method WITH an id is still answered: the
+    // refusal path is unchanged for requests.
+    next_id += 1;
+    let refused_id = next_id;
+    conn.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "tools/list",
+        "params": {"_meta": {"io.modelcontextprotocol/protocolVersion": "2099-01-01"}},
+        "id": refused_id
+    }));
+    let refused = conn.read_response();
+    assert_eq!(
+        refused.get("id"),
+        Some(&Value::from(refused_id)),
+        "{refused}"
+    );
+    assert_eq!(
+        refused.pointer("/error/code"),
+        Some(&serde_json::json!(-32022)),
+        "{refused}"
+    );
+
+    // `"id": null` is a REQUEST (it gets a response); only an absent `id`
+    // member is a notification.
+    conn.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "tools/list",
+        "params": {},
+        "id": null
+    }));
+    let null_id = conn.read_response();
+    assert_eq!(null_id.get("id"), Some(&Value::Null), "{null_id}");
+    assert!(
+        null_id.get("result").is_some(),
+        "`id: null` request still answered: {null_id}"
+    );
+
+    // Normal request control.
+    next_id += 1;
+    let control_id = next_id;
+    let control = conn.request("tools/list", serde_json::json!({}), control_id);
+    assert_eq!(
+        control.get("id"),
+        Some(&Value::from(control_id)),
+        "{control}"
+    );
+    assert!(
+        control.get("result").is_some(),
+        "normal request still answered: {control}"
+    );
+
+    assert!(conn.shutdown().success());
+}

--- a/crates/assay-mcp-server/tests/outer_fallback_contract.rs
+++ b/crates/assay-mcp-server/tests/outer_fallback_contract.rs
@@ -488,12 +488,23 @@ fn notifications_produce_no_output() {
     );
 
     // `"id": null` is a REQUEST (it gets a response); only an absent `id`
-    // member is a notification.
+    // member is a notification. Both lines go out before either read, so a
+    // swallowed null-id response fails the exact-id assertion at once
+    // instead of surfacing only as the read deadline.
     conn.send(serde_json::json!({
         "jsonrpc": "2.0",
         "method": "tools/list",
         "params": {},
         "id": null
+    }));
+    // Normal request control.
+    next_id += 1;
+    let control_id = next_id;
+    conn.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "tools/list",
+        "params": {},
+        "id": control_id
     }));
     let null_id = conn.read_response();
     assert_eq!(null_id.get("id"), Some(&Value::Null), "{null_id}");
@@ -502,10 +513,7 @@ fn notifications_produce_no_output() {
         "`id: null` request still answered: {null_id}"
     );
 
-    // Normal request control.
-    next_id += 1;
-    let control_id = next_id;
-    let control = conn.request("tools/list", serde_json::json!({}), control_id);
+    let control = conn.read_response();
     assert_eq!(
         control.get("id"),
         Some(&Value::from(control_id)),
@@ -514,6 +522,54 @@ fn notifications_produce_no_output() {
     assert!(
         control.get("result").is_some(),
         "normal request still answered: {control}"
+    );
+
+    assert!(conn.shutdown().success());
+}
+
+/// Slice C follow-up: duplicate top-level members are rejected exactly as on
+/// base 89e9124ad, which answered none of the three probes below. The old
+/// two-step parse (`Value` keeps the last duplicate) answered them last-wins,
+/// so each probe is followed by a control request whose exact-id response
+/// proves the probe emitted nothing.
+#[test]
+fn duplicate_top_level_members_produce_no_output() {
+    let (mut conn, _root) = spawn_server(None);
+    initialize(&mut conn);
+
+    let mut next_id: u64 = 300;
+    let mut probe = |conn: &mut Conn, line: &str| {
+        conn.send_line(line);
+        next_id += 1;
+        let id = next_id;
+        conn.send(serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "tools/list",
+            "params": {},
+            "id": id
+        }));
+        let response = conn.read_response();
+        assert_eq!(response.get("id"), Some(&Value::from(id)), "{response}");
+        assert!(
+            response.get("result").is_some(),
+            "control after duplicate-member probe: {response}"
+        );
+    };
+
+    // Duplicate method: last-wins would answer tools/list for id 3.
+    probe(
+        &mut conn,
+        r#"{"jsonrpc":"2.0","method":"no/such","method":"tools/list","params":{},"id":3}"#,
+    );
+    // Duplicate params: last-wins would take the version-mismatched one (-32022).
+    probe(
+        &mut conn,
+        r#"{"jsonrpc":"2.0","method":"tools/list","params":{},"params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2099-01-01"}},"id":4}"#,
+    );
+    // Duplicate id: last-wins would answer with id 62.
+    probe(
+        &mut conn,
+        r#"{"jsonrpc":"2.0","method":"tools/list","params":{},"id":61,"id":62}"#,
     );
 
     assert!(conn.shutdown().success());


### PR DESCRIPTION
**Merge head `03849fd135660d03bd88f434a1bf06b6a0c510a2`** is `gh pr update-branch` over the reviewed/carried head `b63f7ed6ac5ebe442dbb2a3c9778e9e99416f307`; carry record with both AGENTS.md checks: https://github.com/Rul1an/assay/pull/2903#issuecomment-5625771254.

**Merge head `b63f7ed6ac5ebe442dbb2a3c9778e9e99416f307`** is `gh pr update-branch` over the reviewed/carried head `e91f656193542adcd9044a6634a8d06676d9e8fd`; carry record with both AGENTS.md checks: https://github.com/Rul1an/assay/pull/2903#issuecomment-5625745493.

Candidate, not a landing. Head SHA e91f656193542adcd9044a6634a8d06676d9e8fd. Sole author; needs an independent exact-head review record before merge.

## What changed

- `crates/assay-mcp-server/src/server.rs`: the stdio loop now parses each line directly into the typed `JsonRpcRequest` in one step and skips silently (`notification_skipped`) when the `id` member is absent — before the protocol-version check and before method dispatch. The `id` field is `Option<Option<Value>>` (absent member = notification, `"id": null` = `Some(None)` = request, via `#[serde(default, deserialize_with)]`), so duplicate top-level members are rejected exactly as on base instead of answered last-wins. Scalar/array lines now land in the `json_parse_error` arm rather than `notification_skipped`; all stay silent. The `notifications/initialized` arm is behavior-unchanged, with its comment corrected (reachable only with an `id` present).
- `crates/assay-mcp-server/tests/outer_fallback_contract.rs`: `notifications_produce_no_output` as before, except the `"id": null` leg now sends the null-id request and its control before reading either, so a swallowed response fails the exact-id assertion at once instead of after the 30s deadline. New `duplicate_top_level_members_produce_no_output` test — duplicate `method`, duplicate `params`, and duplicate `id` probes each followed by an exact-id `tools/list` control, so any wrongful answer is consumed under the wrong id and fails.

## RED / GREEN

- RED (cycle 1, pre-fix, same tree): `notifications_produce_no_output ... FAILED` — `{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":null}` consumed where id 101 was expected.
- RED (cycle 2, old two-step parse + new test): `duplicate_top_level_members_produce_no_output ... FAILED` in 0.03s — tools/list result with `id` 3 consumed where control id 301 was expected.
- GREEN (post-fix): `outer_fallback_contract` 9 passed; full `cargo test -p assay-mcp-server --no-fail-fast` green except pre-existing environmental `auth_integration::test_legacy_validator_rejects_invalid_token` (wiremock port bind denied in sandbox; fails identically on base 89e9124ad). `cargo clippy -p assay-mcp-server --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean; `git diff --check` clean.

## Mutation table

| Mutation | Result |
|---|---|
| Drop the `continue` so a notification is answered with any response | Test FAILS in 0.65s (`-32601`/`id:null` consumed for id 101) — bites |
| Presence check `req.id.is_none()` weakened to `req.id.clone().flatten().is_none()` (treats `"id": null` as notification) | Test FAILS in 0.06s on the exact-id assertion, not the deadline (pipelined leg) — bites |
| Skip weakened to `req.id.is_none() && check_request_version(..).is_ok()` (version-mismatched notifications reach refusal) | Test FAILS in 0.14s (`-32022`/`id:null` consumed for id 104) — bites |
| Old two-step parse (`Value` + `get("id")`) under the new duplicate test | Test FAILS in 0.03s (last-wins answer with id 3) — bites |

## Review follow-ups

Follow-ups from the review record on head acaae2c30, all addressed here: duplicate top-level members are rejected again (base 89e9124ad confirmed by inspection to parse directly into `JsonRpcRequest` and stay silent, matching the record's binary probe); the null-id leg is pipelined so it fails on content; the stale `notifications/initialized` comment and both parse-arm comments are corrected, and non-object lines now log `json_parse_error`, never `notification_skipped`. Requests otherwise behave exactly as before — including the positional-array frame, which the typed parse answers as the base did. The initialized-with-id silence itself is unchanged pre-existing behavior, kept per the record's documented-deviation disposition.

## Follow-up (not in this slice)

`modern_adapter.rs:92` has the same fallback shape (`_ => error_response(id, ...)`), but it is library-public and not wired to stdio (`Server::run` never calls it; see the closed-gate docs). Deliberately NOT changed here; needs its own issue/slice decision on whether a `Value`-level adapter should model notifications at all.

Refs #2776


