### PR TITLE
fix(cli): make assay demo pass and report its write failures

### DIFF
--- a/crates/assay-cli/src/cli/commands/demo.rs
+++ b/crates/assay-cli/src/cli/commands/demo.rs
@@ -1,4 +1,5 @@
 use crate::cli::args::DemoArgs;
+use anyhow::Context;
 use assay_core::config::path_resolver::PathResolver;
 use assay_core::validate::{validate, ValidateOptions};
 use std::fs;
@@ -21,7 +22,8 @@ tools:
       properties:
         operation: { enum: ["add", "subtract"] }
 "#;
-    let _ = fs::write(&policy_path, policy_content);
+    fs::write(&policy_path, policy_content)
+        .with_context(|| format!("failed to write demo file {}", policy_path.display()))?;
 
     // 2. Create Config File (The Test Runner)
     let config_path = demo_dir.join("assay.yaml");
@@ -35,7 +37,8 @@ tests:
       type: args_valid
       policy: policy.yaml
 "#;
-    let _ = fs::write(&config_path, config_content);
+    fs::write(&config_path, config_content)
+        .with_context(|| format!("failed to write demo file {}", config_path.display()))?;
 
     // 2. Create Traces
     let trace_path = demo_dir.join("traces.jsonl");
@@ -43,7 +46,8 @@ tests:
     let trace_content = r#"{"id": "demo_trace_1", "tool": "Search", "args": {"query": "assay rules"}, "prompt": "find assay rules", "response": "detecting 123"}
 {"tool": "Calculate", "args": {"operation": "add", "x": 1, "y": 2}, "response": "3"}
 "#;
-    let _ = fs::write(&trace_path, trace_content);
+    fs::write(&trace_path, trace_content)
+        .with_context(|| format!("failed to write demo file {}", trace_path.display()))?;
 
     println!("✓ Created demo environment in {}", demo_dir.display());
     println!("  - Config: {}", config_path.display());

--- a/crates/assay-cli/src/cli/commands/demo.rs
+++ b/crates/assay-cli/src/cli/commands/demo.rs
@@ -10,17 +10,25 @@ pub async fn cmd_demo(args: DemoArgs) -> anyhow::Result<i32> {
 
     // 1. Create Policy File (The Rules)
     let policy_path = demo_dir.join("policy.yaml");
-    let policy_content = r#"version: 1
+    // ToolsPolicy is deny_unknown_fields: allow / deny / require_args / arg_constraints.
+    // validate() serializes arg_constraints into evaluate_tool_args, which compiles
+    // each tool entry as a JSON Schema (Map<Tool, Schema>), not the RFC arg-map dialect.
+    let policy_content = r#"version: "1"
 name: demo-policy
 tools:
-  Search:
-    args:
+  arg_constraints:
+    Search:
+      type: object
       properties:
-        query: { pattern: "^[a-zA-Z0-9 ]+$" }
-  Calculate:
-    args:
+        query:
+          type: string
+          pattern: "^[a-zA-Z0-9 ]+$"
+    Calculate:
+      type: object
       properties:
-        operation: { enum: ["add", "subtract"] }
+        operation:
+          type: string
+          enum: ["add", "subtract"]
 "#;
     fs::write(&policy_path, policy_content)
         .with_context(|| format!("failed to write demo file {}", policy_path.display()))?;

--- a/crates/assay-cli/tests/demo_write_errors.rs
+++ b/crates/assay-cli/tests/demo_write_errors.rs
@@ -3,8 +3,10 @@
 //! The write-error gap was `let _ = fs::write(...)` on policy.yaml, assay.yaml,
 //! and traces.jsonl, followed by an unconditional "Created demo environment".
 //! The parse gap was a shipped policy in the old `tools: Search:` shape, which
-//! `Policy` rejects (`allow`, `deny`, `require_args`, `arg_constraints`). These
-//! tests drive the built binary and read exit code, stdout, and stderr.
+//! `Policy` rejects (`allow`, `deny`, `require_args`, `arg_constraints`). The
+//! negative pin rewrites the demo Search query after a passing first run so a
+//! vacuous schema cannot stay green. These tests drive the built binary and
+//! read exit code, stdout, and stderr.
 
 use assert_cmd::Command;
 use std::fs;
@@ -67,6 +69,16 @@ fn run_printed_validate(stdout: &str) -> (i32, String, String) {
     (code, stdout, stderr)
 }
 
+fn rewrite_search_query(traces: &str, query: &str) -> String {
+    let needle = r#""query": "assay rules""#;
+    let replacement = format!(r#""query": "{query}""#);
+    assert!(
+        traces.contains(needle),
+        "traces.jsonl missing the demo Search query to rewrite:\n{traces}"
+    );
+    traces.replacen(needle, &replacement, 1)
+}
+
 #[test]
 fn demo_completes_and_printed_validate_passes() {
     let dir = tempdir().unwrap();
@@ -90,6 +102,33 @@ fn demo_completes_and_printed_validate_passes() {
     assert!(
         vstderr.contains("Validation OK"),
         "printed next-step validate should report Validation OK\nstdout:\n{vstdout}\nstderr:\n{vstderr}"
+    );
+}
+
+#[test]
+fn printed_validate_rejects_forbidden_search_query() {
+    let dir = tempdir().unwrap();
+    let out = dir.path();
+    let (code, stdout, stderr) = run_demo(out);
+
+    assert_eq!(
+        code, 0,
+        "assay demo --out should exit 0\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let traces = out.join("traces.jsonl");
+    let rewritten = rewrite_search_query(&fs::read_to_string(&traces).unwrap(), "assay;rules");
+    fs::write(&traces, rewritten).unwrap();
+
+    let (vcode, vstdout, vstderr) = run_printed_validate(&stdout);
+    assert_ne!(
+        vcode, 0,
+        "printed next-step validate should reject a forbidden Search query\nstdout:\n{vstdout}\nstderr:\n{vstderr}"
+    );
+    let combined = format!("{vstdout}{vstderr}");
+    assert!(
+        combined.contains("E_ARG_SCHEMA"),
+        "validate output should name E_ARG_SCHEMA\nstdout:\n{vstdout}\nstderr:\n{vstderr}"
     );
 }
 

--- a/crates/assay-cli/tests/demo_write_errors.rs
+++ b/crates/assay-cli/tests/demo_write_errors.rs
@@ -1,0 +1,137 @@
+//! `assay demo` must not claim it created files when the writes failed (#2902).
+//!
+//! The measured gap was `let _ = fs::write(...)` on policy.yaml, assay.yaml, and
+//! traces.jsonl, followed by an unconditional "Created demo environment". These
+//! tests drive the built binary and read exit code, stdout, and stderr.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+const DEMO_FILES: [&str; 3] = ["policy.yaml", "assay.yaml", "traces.jsonl"];
+
+fn run_demo(out: &Path) -> (i32, String, String) {
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .current_dir(out)
+        .arg("demo")
+        .arg("--out")
+        .arg(out)
+        .output()
+        .expect("spawn assay demo");
+    let code = output.status.code().expect("assay demo exit code");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+#[test]
+fn demo_reports_write_failure_when_target_is_a_directory() {
+    for name in DEMO_FILES {
+        let dir = tempdir().unwrap();
+        let out = dir.path();
+        let blocked = out.join(name);
+        fs::create_dir(&blocked).unwrap();
+
+        let (code, stdout, stderr) = run_demo(out);
+
+        assert_ne!(
+            code, 0,
+            "{name}: expected non-zero exit, got {code}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            !stdout.contains("Created demo environment"),
+            "{name}: stdout claimed success after a failed write:\n{stdout}"
+        );
+        assert!(
+            stderr.contains("failed to write demo file"),
+            "{name}: stderr missing write-failure context:\n{stderr}"
+        );
+        assert!(
+            stderr.contains(&blocked.display().to_string()),
+            "{name}: stderr missing path {}:\n{stderr}",
+            blocked.display()
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn demo_does_not_report_validation_passed_on_stale_unwritable_files() {
+    let dir = tempdir().unwrap();
+    let out = dir.path();
+
+    let (_code, _stdout, _) = run_demo(out);
+    // The shipped demo policy no longer parses, so leftover files would not
+    // print "Validation Passed" on their own. Plant a policy the current
+    // loader accepts so an ignored rewrite can still claim success.
+    fs::write(
+        out.join("policy.yaml"),
+        "version: \"1\"\nname: stale-demo\ntools:\n  arg_constraints:\n    Search:\n      type: object\n      properties:\n        query:\n          type: string\n",
+    )
+    .unwrap();
+
+    let restore = RestoreWritable {
+        dir: out.to_path_buf(),
+    };
+    for name in DEMO_FILES {
+        let path = out.join(name);
+        let mut perms = fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o444);
+        fs::set_permissions(&path, perms).unwrap();
+    }
+    let mut dir_perms = fs::metadata(out).unwrap().permissions();
+    dir_perms.set_mode(0o555);
+    fs::set_permissions(out, dir_perms).unwrap();
+
+    if fs::write(out.join("probe_write"), "x").is_ok() {
+        eprintln!(
+            "skipping stale-file write-failure test: probe write succeeded (running as root)"
+        );
+        return;
+    }
+
+    let (code, stdout, stderr) = run_demo(out);
+    assert_ne!(
+        code, 0,
+        "expected non-zero exit on unwritable stale files\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("Validation Passed"),
+        "stdout reported validation success from stale files:\n{stdout}"
+    );
+    drop(restore);
+}
+
+#[cfg(unix)]
+struct RestoreWritable {
+    dir: std::path::PathBuf,
+}
+
+#[cfg(unix)]
+impl Drop for RestoreWritable {
+    fn drop(&mut self) {
+        let mut dir_perms = match fs::metadata(&self.dir) {
+            Ok(meta) => meta.permissions(),
+            Err(_) => return,
+        };
+        dir_perms.set_mode(0o755);
+        let _ = fs::set_permissions(&self.dir, dir_perms);
+        for name in DEMO_FILES {
+            let path = self.dir.join(name);
+            if let Ok(meta) = fs::metadata(&path) {
+                let mut perms = meta.permissions();
+                perms.set_mode(0o644);
+                let _ = fs::set_permissions(&path, perms);
+            }
+        }
+        let probe = self.dir.join("probe_write");
+        if probe.exists() {
+            let _ = fs::remove_file(probe);
+        }
+    }
+}

--- a/crates/assay-cli/tests/demo_write_errors.rs
+++ b/crates/assay-cli/tests/demo_write_errors.rs
@@ -1,7 +1,9 @@
-//! `assay demo` must not claim it created files when the writes failed (#2902).
+//! `assay demo` write failures (#2902) and a first-run that actually validates (#2905).
 //!
-//! The measured gap was `let _ = fs::write(...)` on policy.yaml, assay.yaml, and
-//! traces.jsonl, followed by an unconditional "Created demo environment". These
+//! The write-error gap was `let _ = fs::write(...)` on policy.yaml, assay.yaml,
+//! and traces.jsonl, followed by an unconditional "Created demo environment".
+//! The parse gap was a shipped policy in the old `tools: Search:` shape, which
+//! `Policy` rejects (`allow`, `deny`, `require_args`, `arg_constraints`). These
 //! tests drive the built binary and read exit code, stdout, and stderr.
 
 use assert_cmd::Command;
@@ -27,6 +29,68 @@ fn run_demo(out: &Path) -> (i32, String, String) {
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     (code, stdout, stderr)
+}
+
+fn run_printed_validate(stdout: &str) -> (i32, String, String) {
+    let line = stdout
+        .lines()
+        .find(|line| line.contains("assay validate --config"))
+        .unwrap_or_else(|| panic!("demo stdout missing next-step validate command:\n{stdout}"));
+    let command = line
+        .find("assay validate")
+        .map(|idx| &line[idx..])
+        .unwrap_or(line);
+    let mut parts = command.split_whitespace();
+    assert_eq!(parts.next(), Some("assay"));
+    assert_eq!(parts.next(), Some("validate"));
+    assert_eq!(parts.next(), Some("--config"));
+    let config = parts
+        .next()
+        .unwrap_or_else(|| panic!("next-step missing --config path:\n{line}"));
+    assert_eq!(parts.next(), Some("--trace-file"));
+    let trace = parts
+        .next()
+        .unwrap_or_else(|| panic!("next-step missing --trace-file path:\n{line}"));
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("validate")
+        .arg("--config")
+        .arg(config)
+        .arg("--trace-file")
+        .arg(trace)
+        .output()
+        .expect("spawn assay validate");
+    let code = output.status.code().expect("assay validate exit code");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+#[test]
+fn demo_completes_and_printed_validate_passes() {
+    let dir = tempdir().unwrap();
+    let out = dir.path();
+    let (code, stdout, stderr) = run_demo(out);
+
+    assert_eq!(
+        code, 0,
+        "assay demo --out should exit 0\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("Validation Passed"),
+        "assay demo should report Validation Passed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let (vcode, vstdout, vstderr) = run_printed_validate(&stdout);
+    assert_eq!(
+        vcode, 0,
+        "printed next-step validate should exit 0\nstdout:\n{vstdout}\nstderr:\n{vstderr}"
+    );
+    assert!(
+        vstderr.contains("Validation OK"),
+        "printed next-step validate should report Validation OK\nstdout:\n{vstdout}\nstderr:\n{vstderr}"
+    );
 }
 
 #[test]
@@ -65,15 +129,15 @@ fn demo_does_not_report_validation_passed_on_stale_unwritable_files() {
     let dir = tempdir().unwrap();
     let out = dir.path();
 
-    let (_code, _stdout, _) = run_demo(out);
-    // The shipped demo policy no longer parses, so leftover files would not
-    // print "Validation Passed" on their own. Plant a policy the current
-    // loader accepts so an ignored rewrite can still claim success.
-    fs::write(
-        out.join("policy.yaml"),
-        "version: \"1\"\nname: stale-demo\ntools:\n  arg_constraints:\n    Search:\n      type: object\n      properties:\n        query:\n          type: string\n",
-    )
-    .unwrap();
+    let (seed_code, seed_stdout, seed_stderr) = run_demo(out);
+    assert_eq!(
+        seed_code, 0,
+        "stale-file seed must be the demo's own passing output\nstdout:\n{seed_stdout}\nstderr:\n{seed_stderr}"
+    );
+    assert!(
+        seed_stdout.contains("Validation Passed"),
+        "stale-file seed must be content that already printed Validation Passed:\n{seed_stdout}"
+    );
 
     let restore = RestoreWritable {
         dir: out.to_path_buf(),


### PR DESCRIPTION
**Merge head `72b223ab7a24c3da0785923b03fe7e780540690c`** is `gh pr update-branch` over the reviewed/carried head `7235ace629220b7ea4df99af338f97caccccc155`; carry record with both AGENTS.md checks: https://github.com/Rul1an/assay/pull/2904#issuecomment-5625431612.

**Merge head `7235ace629220b7ea4df99af338f97caccccc155`** is `gh pr update-branch` over the builder head `1e61883c06f1c369f26ddf7b6d18c804a97af39b`; the review is requested on this merge head.

1e61883c06f1c369f26ddf7b6d18c804a97af39b

Candidate, not a landing. Sole author; needs an independent exact-head review record before merge.

`assay demo` had two first-run defects. Writes to policy.yaml, assay.yaml, and traces.jsonl were discarded, so a leftover-file run could print Validation Passed for content this invocation never wrote. Separately, the shipped policy used the old `tools: Search` / `tools: Calculate` map. Policy::load rejects those keys (`allow`, `deny`, `require_args`, `arg_constraints`), so every user on 6.1.2 got E_CFG_PARSE.

The same two rules are now under `tools.arg_constraints` as JSON Schema objects, which is the map `validate()` serializes into `evaluate_tool_args`. An RFC-shaped `{ query: { pattern } }` also parses, but compiles as an empty schema and would not enforce the rules.

Demo trace: pass only. The suite test matches the Search record (prompt `find assay rules`; query `assay rules` matches `^[a-zA-Z0-9 ]+$`). The Calculate line is a second well-formed call (`operation: add`) and is not bound to a test (legacy tool-only records key as prompt `ignore`). No violation is shown.

Success test stays in `demo_write_errors.rs` rather than a sibling file: it shares the binary helpers, and the stale-file case now seeds from the demo's own passing output.

Negative test: after a passing `assay demo --out <tmp>`, rewrite the Search query in `<tmp>/traces.jsonl` to `assay;rules` and run the printed validate command. It must exit non-zero and name `E_ARG_SCHEMA`. That is the pin an RFC-shaped constraint map and a `pattern: ".*"` both fail: they leave the success path green.

RED (success test only, old `tools: Search` policy still shipped):

```
running 1 test
test demo_completes_and_printed_validate_passes ... FAILED
assertion left == right failed: assay demo --out should exit 0
❌ [E_CFG_PARSE] Failed to parse policy: tools: unknown field `Search`, expected one of `allow`, `deny`, `require_args`, `arg_constraints` at line 4 column 3
test result: FAILED. 0 passed; 1 failed
```

GREEN (after the policy rewrite; worktree /Users/roelschuurkes/wt-cursor-2902, CARGO_INCREMENTAL=0):

```
running 3 tests
test demo_reports_write_failure_when_target_is_a_directory ... ok
test demo_does_not_report_validation_passed_on_stale_unwritable_files ... ok
test demo_completes_and_printed_validate_passes ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s
```

RED (new test; RFC-shape policy or pattern ".*"):

```
running 4 tests
test printed_validate_rejects_forbidden_search_query ... FAILED
assertion `left != right` failed: printed next-step validate should reject a forbidden Search query
test result: FAILED. 3 passed; 1 failed
```

GREEN (new test on this head; same worktree, CARGO_INCREMENTAL=0):

```
running 4 tests
test demo_reports_write_failure_when_target_is_a_directory ... ok
test demo_does_not_report_validation_passed_on_stale_unwritable_files ... ok
test demo_completes_and_printed_validate_passes ... ok
test printed_validate_rejects_forbidden_search_query ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
```

Mutation table:

| Mutation | Result | Failing assertion |
|---|---|---|
| RFC-shape `{ query: { pattern } }` | RED | `printed_validate_rejects_forbidden_search_query` — printed next-step validate should reject a forbidden Search query |
| pattern `".*"` | RED | `printed_validate_rejects_forbidden_search_query` — printed next-step validate should reject a forbidden Search query |
| revert policy to `tools: Search` | RED | `demo_completes_and_printed_validate_passes` — exit 1, `E_CFG_PARSE` / unknown field `Search` |
| `let _ =` on policy.yaml write | RED | `demo_reports_write_failure_when_target_is_a_directory` — Created demo environment after failed write |
| `let _ =` on assay.yaml write | RED | `demo_reports_write_failure_when_target_is_a_directory` — Created demo environment after failed write |
| `let _ =` on traces.jsonl write | RED | `demo_reports_write_failure_when_target_is_a_directory` — Created demo environment after failed write |

Closes #2902
Closes #2905

