### PR TITLE
docs(packs): name the closed A2A version set in the signal-followup pack

### DIFF
--- a/crates/assay-evidence/packs/a2a-signal-followup.yaml
+++ b/crates/assay-evidence/packs/a2a-signal-followup.yaml
@@ -12,7 +12,7 @@ disclaimer: |
   "A2A security." Rules do not reuse MCP G3 predicates; A2A authorization and signing surfaces
   are out of scope unless future adapter versions emit first-class typed fields.
   P2b v1 reflects Assay adapter evidence for supported upstream 0.x lines (see adapter
-  `SUPPORTED_SPEC_VERSION_RANGE` / version gate) — not full "A2A v1.0" protocol marketing coverage.
+  `SUPPORTED_SPEC_VERSIONS` / version gate) — not full "A2A v1.0" protocol marketing coverage.
   requires.assay_min_version is ">=3.2.3" (evidence-substrate floor; see MIGRATION-TRUST-COMPILER-3.2.md
   and PLAN-P2b — confirm the first published Assay release that embeds this built-in pack).
 

--- a/packs/open/a2a-signal-followup/pack.yaml
+++ b/packs/open/a2a-signal-followup/pack.yaml
@@ -12,7 +12,7 @@ disclaimer: |
   "A2A security." Rules do not reuse MCP G3 predicates; A2A authorization and signing surfaces
   are out of scope unless future adapter versions emit first-class typed fields.
   P2b v1 reflects Assay adapter evidence for supported upstream 0.x lines (see adapter
-  `SUPPORTED_SPEC_VERSION_RANGE` / version gate) — not full "A2A v1.0" protocol marketing coverage.
+  `SUPPORTED_SPEC_VERSIONS` / version gate) — not full "A2A v1.0" protocol marketing coverage.
   requires.assay_min_version is ">=3.2.3" (evidence-substrate floor; see MIGRATION-TRUST-COMPILER-3.2.md
   and PLAN-P2b — confirm the first published Assay release that embeds this built-in pack).
 


### PR DESCRIPTION
**Merge head `4278dafd200fa4ddab98aeb38448429ee9a34341`** is `gh pr update-branch` over the reviewed/carried head `c7d7de10bff4aef629d1f76e4eb5414f0a855692`; carry record with both AGENTS.md checks: https://github.com/Rul1an/assay/pull/2909#issuecomment-5625093076.

Candidate, not a landing. Head SHA c7d7de10bff4aef629d1f76e4eb5414f0a855692. Sole author; needs an independent exact-head review record before merge.

Updates line 15 of both `packs/open/a2a-signal-followup/pack.yaml` and its vendored counterpart `crates/assay-evidence/packs/a2a-signal-followup.yaml` to reference `SUPPORTED_SPEC_VERSIONS` instead of the removed `SUPPORTED_SPEC_VERSION_RANGE` constant following PR #2889. Local verification confirmed byte-for-byte equivalence via `cmp` (clean), vendored pack sync via `bash scripts/check-vendored-packs.sh` (passed), and pack unit tests via `CARGO_INCREMENTAL=0 cargo test -p assay-evidence --test a2a_signal_followup_pack` (8 passed, 0 failed).

Closes #2890

Made with [Cursor](https://cursor.com)
