### PR TITLE
fix(release): bind the crates token source and reject contradicting runbook text

### DIFF
--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -57,8 +57,7 @@ This document outlines the canonical checklist for releasing new versions of Ass
   `python3 scripts/ci/check-release-runbook-truth.py`, compare its expected identity with every
   owner-visible crates.io publisher row, and retain a redacted receipt containing only the crate,
   repository, workflow, environment, publisher count, observation time, and result.
-  No credentials.
-  on every current crates.io crate:
+  No credentials. Apply this on every current crates.io crate:
   - `assay-common`
   - `assay-registry`
   - `assay-canonical`

--- a/scripts/ci/check-release-runbook-truth.py
+++ b/scripts/ci/check-release-runbook-truth.py
@@ -51,10 +51,28 @@ _CRATES_LEGACY_REMOVAL_SENTENCE = (
 _CRATES_UNSET_ENVIRONMENT_SENTENCE = (
     "An unset environment is broader authority and does not match this contract."
 )
+_PYPI_RECEIPT_SENTENCE = (
+    "compare its expected identity with every "
+    "owner-visible PyPI publisher row, and retain a redacted receipt containing only the project, "
+    "repository, workflow, environment, publisher count, observation time, and result."
+)
 _CRATES_RECEIPT_SENTENCE = (
-    "retain a redacted receipt containing only the crate, "
+    "compare its expected identity with every "
+    "owner-visible crates.io publisher row, and retain a redacted receipt containing only the crate, "
     "repository, workflow, environment, publisher count, observation time, and result. "
-    "No credentials."
+    "No credentials. Apply this on every current crates.io crate:"
+)
+# Additive contradictions of the environment contract. Closed-form ownership of
+# the whole checklist item would pin the crate inventory and receipt procedure, so
+# a crate-list edit would fail the publisher-identity check. Both halves share this
+# list so fixing one cannot reintroduce the parity overclaim.
+_FORBIDDEN_ENVIRONMENT_PHRASES = (
+    "optional",
+    "may be left unset",
+)
+_CRATES_REGISTRY_TOKEN = "CARGO_REGISTRY_TOKEN"
+_CRATES_SECRET_TOKEN_SOURCE_MESSAGE = (
+    "publish-crates CARGO_REGISTRY_TOKEN is sourced from secrets.*, not the auth step output"
 )
 _BEFORE_CLAIM = re.compile(
     r"GitHub Release is created before crates publication",
@@ -168,8 +186,8 @@ def _publish_crates_needs_release(workflow: str) -> bool:
     return "release" in _job_needs_ids(job)
 
 
-def _active_step_uses(job: str) -> list[str]:
-    """Return direct-step actions that have no step-level condition."""
+def _direct_step_blocks(job: str) -> list[list[str]]:
+    """Return list-item step blocks under the job's direct steps: key."""
     step_blocks: list[list[str]] = []
     current: list[str] = []
     in_steps = False
@@ -193,31 +211,50 @@ def _active_step_uses(job: str) -> list[str]:
             current.append(line)
     if current:
         step_blocks.append(current)
+    return step_blocks
 
-    uses: list[str] = []
-    for block in step_blocks:
-        action = ""
-        condition = ""
-        for line in block:
-            stripped = line.lstrip()
-            indent = len(line) - len(stripped)
-            if indent == 6 and stripped.startswith("- "):
-                direct = stripped[2:]
-            elif indent == 8:
-                direct = stripped
-            else:
-                continue
-            match = re.match(r"^([^:]+?)\s*:\s*(.*)$", direct)
-            if match is None:
-                continue
-            key = match.group(1).strip().strip("'\"")
-            value = match.group(2).split(" #", 1)[0].strip(" '\"")
-            if key == "uses":
-                action = value
-            elif key == "if":
-                condition = value
-        if condition:
+
+def _step_direct_fields(block: list[str]) -> dict[str, str]:
+    """Direct keys of a list-item step (indent 6/8), comment-stripped values."""
+    fields: dict[str, str] = {}
+    for line in block:
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+        if indent == 6 and stripped.startswith("- "):
+            direct = stripped[2:]
+        elif indent == 8:
+            direct = stripped
+        else:
             continue
+        match = re.match(r"^([^:]+?)\s*:\s*(.*)$", direct)
+        if match is None:
+            continue
+        key = match.group(1).strip().strip("'\"")
+        value = match.group(2).split(" #", 1)[0].strip(" '\"")
+        if key:
+            fields[key] = value
+    return fields
+
+
+def _step_env_entries(block: list[str]) -> dict[str, str] | None:
+    """Return the step's env mapping. Empty if absent; None if unparsable."""
+    text = "".join(line + "\n" for line in block)
+    try:
+        return _child_entries(_mapping_block(text, "env", 8))
+    except AssertionError as exc:
+        if "found 0" in str(exc):
+            return {}
+        return None
+
+
+def _active_step_uses(job: str) -> list[str]:
+    """Return direct-step actions that have no step-level condition."""
+    uses: list[str] = []
+    for block in _direct_step_blocks(job):
+        fields = _step_direct_fields(block)
+        if fields.get("if"):
+            continue
+        action = fields.get("uses", "")
         if action:
             uses.append(action)
     return uses
@@ -269,10 +306,46 @@ def _pinned_publish_action_problems(
     return []
 
 
+def _crates_registry_token_source_problems(job: str) -> list[str]:
+    auth_ids: list[str] = []
+    token_sources: list[str] = []
+    for block in _direct_step_blocks(job):
+        fields = _step_direct_fields(block)
+        if fields.get("if"):
+            continue
+        if fields.get("uses") == _CRATES_PUBLISH_ACTION:
+            auth_ids.append(fields.get("id", ""))
+        env_entries = _step_env_entries(block)
+        if env_entries is None:
+            return [
+                "publish-crates cannot determine the crates.io registry token source"
+            ]
+        raw = env_entries.get(_CRATES_REGISTRY_TOKEN)
+        if raw is None:
+            continue
+        token_sources.append(raw.split(" #", 1)[0].strip(" '\""))
+    if len(token_sources) != 1:
+        return [
+            "publish-crates cannot determine the crates.io registry token source"
+        ]
+    source = token_sources[0]
+    if re.search(r"\bsecrets\.", source):
+        return [_CRATES_SECRET_TOKEN_SOURCE_MESSAGE]
+    if len(auth_ids) != 1 or not auth_ids[0]:
+        return ["publish-crates cannot determine the crates.io auth step id"]
+    expected = "${{ steps." + auth_ids[0] + ".outputs.token }}"
+    if source != expected:
+        return [
+            f"publish-crates CARGO_REGISTRY_TOKEN is {source!r}, expected {expected!r}"
+        ]
+    return []
+
+
 def _pypi_workflow_problems(workflow: str) -> list[str]:
     job, entries, problems = _publisher_job(workflow, "publish-pypi", "PyPI")
-    if job is None or entries is None:
+    if job is None:
         return problems
+    assert entries is not None
     problems.extend(
         _environment_problems(
             entries, job_id="publish-pypi", expected=_PYPI_ENVIRONMENT
@@ -292,8 +365,9 @@ def _pypi_workflow_problems(workflow: str) -> list[str]:
 
 def _crates_workflow_problems(workflow: str) -> list[str]:
     job, entries, problems = _publisher_job(workflow, "publish-crates", "crates.io")
-    if job is None or entries is None:
+    if job is None:
         return problems
+    assert entries is not None
     problems.extend(
         _environment_problems(
             entries, job_id="publish-crates", expected=_CRATES_ENVIRONMENT
@@ -308,6 +382,7 @@ def _crates_workflow_problems(workflow: str) -> list[str]:
             label="crates.io",
         )
     )
+    problems.extend(_crates_registry_token_source_problems(job))
     return problems
 
 
@@ -352,7 +427,6 @@ def _trusted_publisher_docs_problems(
     *,
     title: str,
     label: str,
-    required_literals: tuple[str, ...],
     required_sentences: tuple[tuple[str, str], ...],
 ) -> list[str]:
     try:
@@ -361,16 +435,15 @@ def _trusted_publisher_docs_problems(
         return [str(exc)]
 
     problems: list[str] = []
-    for literal in required_literals:
-        if literal not in item:
-            problems.append(f"{label} item omits {literal}")
     normalized = " ".join(item.split())
     for sentence, message in required_sentences:
         if sentence not in normalized:
             problems.append(message)
     lowered = normalized.lower()
-    if "owner-visible" not in lowered or "redacted receipt" not in lowered:
-        problems.append(f"{label} item omits the redacted owner-visible receipt")
+    if any(phrase in lowered for phrase in _FORBIDDEN_ENVIRONMENT_PHRASES):
+        problems.append(
+            f"{label} item contradicts the required environment by treating it as optional or unset"
+        )
     return problems
 
 
@@ -379,12 +452,6 @@ def _pypi_docs_problems(docs: str) -> list[str]:
         docs,
         title=_PYPI_ITEM_TITLE,
         label="PyPI Trusted Publisher",
-        required_literals=(
-            f"`{_PYPI_REPOSITORY}`",
-            f"`{_PYPI_WORKFLOW}`",
-            f"`{_PYPI_ENVIRONMENT}`",
-            f"`{_PYPI_LEGACY_WORKFLOW}`",
-        ),
         required_sentences=(
             (
                 _PYPI_SINGLE_PUBLISHER_SENTENCE,
@@ -398,6 +465,10 @@ def _pypi_docs_problems(docs: str) -> list[str]:
                 _PYPI_EMPTY_ENVIRONMENT_SENTENCE,
                 "PyPI Trusted Publisher item does not reject an empty environment",
             ),
+            (
+                _PYPI_RECEIPT_SENTENCE,
+                "PyPI Trusted Publisher item omits the redacted owner-visible receipt",
+            ),
         ),
     )
 
@@ -407,11 +478,6 @@ def _crates_docs_problems(docs: str) -> list[str]:
         docs,
         title=_CRATES_ITEM_TITLE,
         label="crates.io Trusted Publishing",
-        required_literals=(
-            f"`{_CRATES_REPOSITORY}`",
-            f"`{_CRATES_WORKFLOW}`",
-            f"`{_CRATES_ENVIRONMENT}`",
-        ),
         required_sentences=(
             (
                 _CRATES_IDENTITY_SENTENCE,
@@ -427,7 +493,7 @@ def _crates_docs_problems(docs: str) -> list[str]:
             ),
             (
                 _CRATES_RECEIPT_SENTENCE,
-                "crates.io Trusted Publishing item omits the redacted crates.io receipt sentence",
+                "crates.io Trusted Publishing item omits the redacted crates.io receipt sentence ending with Apply this on every current crates.io crate",
             ),
         ),
     )

--- a/scripts/ci/check-release-runbook-truth.py
+++ b/scripts/ci/check-release-runbook-truth.py
@@ -62,13 +62,14 @@ _CRATES_RECEIPT_SENTENCE = (
     "repository, workflow, environment, publisher count, observation time, and result. "
     "No credentials. Apply this on every current crates.io crate:"
 )
-# Additive contradictions of the environment contract. Closed-form ownership of
-# the whole checklist item would pin the crate inventory and receipt procedure, so
-# a crate-list edit would fail the publisher-identity check. Both halves share this
-# list so fixing one cannot reintroduce the parity overclaim.
-_FORBIDDEN_ENVIRONMENT_PHRASES = (
-    "optional",
-    "may be left unset",
+# Environment vocabulary is an allowlist of pinned item sentences, not a
+# forbidden-phrase list. Closed-form ownership of the whole item would still pin
+# the crate inventory; those lines do not mention environment, so a crate-list
+# edit stays green. Both halves share this check so fixing one cannot reintroduce
+# the parity overclaim.
+_CHECKLIST_ITEM_PREFIX = re.compile(r"^- \[[ x]\] \*\*[^*]+\*\*: ")
+_RECEIPT_COMMAND_PREFIX = (
+    "Before creating a tag, run `python3 scripts/ci/check-release-runbook-truth.py`, "
 )
 _CRATES_REGISTRY_TOKEN = "CARGO_REGISTRY_TOKEN"
 _CRATES_SECRET_TOKEN_SOURCE_MESSAGE = (
@@ -422,6 +423,44 @@ def _visible_docs(docs: str) -> str:
     return re.sub(r"<!--.*?-->", "", docs, flags=re.DOTALL)
 
 
+def _item_sentences(item: str) -> list[str]:
+    text = _CHECKLIST_ITEM_PREFIX.sub("", " ".join(item.split()), count=1)
+    return [part.strip() for part in re.split(r"(?<=\.)\s+", text) if part.strip()]
+
+
+def _mentions_environment(text: str) -> bool:
+    return "environment" in text.lower()
+
+
+def _environment_allowlist(
+    required_sentences: tuple[tuple[str, str], ...],
+) -> frozenset[str]:
+    allowed: set[str] = set()
+    for sentence, _ in required_sentences:
+        if not _mentions_environment(sentence):
+            continue
+        if sentence.startswith("compare its expected identity"):
+            first = sentence.split(". ", 1)[0].rstrip(".") + "."
+            allowed.add(_RECEIPT_COMMAND_PREFIX + first)
+        else:
+            allowed.add(sentence)
+    return frozenset(allowed)
+
+
+def _unpinned_environment_sentence_problems(
+    item: str,
+    required_sentences: tuple[tuple[str, str], ...],
+    *,
+    label: str,
+) -> list[str]:
+    allowed = _environment_allowlist(required_sentences)
+    return [
+        f"{label} item includes an unpinned sentence that mentions environment"
+        for sentence in _item_sentences(item)
+        if _mentions_environment(sentence) and sentence not in allowed
+    ]
+
+
 def _trusted_publisher_docs_problems(
     docs: str,
     *,
@@ -439,11 +478,11 @@ def _trusted_publisher_docs_problems(
     for sentence, message in required_sentences:
         if sentence not in normalized:
             problems.append(message)
-    lowered = normalized.lower()
-    if any(phrase in lowered for phrase in _FORBIDDEN_ENVIRONMENT_PHRASES):
-        problems.append(
-            f"{label} item contradicts the required environment by treating it as optional or unset"
+    problems.extend(
+        _unpinned_environment_sentence_problems(
+            item, required_sentences, label=label
         )
+    )
     return problems
 
 

--- a/scripts/ci/test-release-runbook-truth.py
+++ b/scripts/ci/test-release-runbook-truth.py
@@ -341,6 +341,72 @@ class ReleaseRunbookTruthMutations(unittest.TestCase):
         )
         self.assert_mutation_bites(workflow=mutated)
 
+    def test_crates_secret_token_source_bites(self) -> None:
+        mutated = replace_once(
+            self.workflow,
+            "          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}\n",
+            "          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}\n",
+        )
+        problems = contract.contract_problems(mutated, self.docs)
+        self.assertTrue(problems, "mutation survived")
+        self.assertIn(contract._CRATES_SECRET_TOKEN_SOURCE_MESSAGE, problems)
+
+    def test_pypi_appended_optional_environment_contradiction_bites(self) -> None:
+        item = contract._checklist_item(self.docs, contract._PYPI_ITEM_TITLE)
+        mutated = replace_once(
+            self.docs,
+            item,
+            item.rstrip("\n")
+            + "\n  The environment field is optional and may be left unset.\n",
+        )
+        problems = contract.contract_problems(self.workflow, mutated)
+        self.assertTrue(problems, "mutation survived")
+        self.assertTrue(
+            any("optional" in problem.lower() for problem in problems),
+            problems,
+        )
+
+    def test_crates_appended_optional_environment_contradiction_bites(self) -> None:
+        item = contract._checklist_item(self.docs, contract._CRATES_ITEM_TITLE)
+        mutated = replace_once(
+            self.docs,
+            item,
+            item.rstrip("\n")
+            + "\n  The environment field is optional and may be left unset.\n",
+        )
+        problems = contract.contract_problems(self.workflow, mutated)
+        self.assertTrue(problems, "mutation survived")
+        self.assertTrue(
+            any("optional" in problem.lower() for problem in problems),
+            problems,
+        )
+
+    def test_crates_credentials_lead_in_is_complete(self) -> None:
+        item = contract._checklist_item(self.docs, contract._CRATES_ITEM_TITLE)
+        normalized = " ".join(item.split())
+        self.assertIn(
+            "No credentials. Apply this on every current crates.io crate:",
+            normalized,
+        )
+
+    def test_crates_lead_in_fragment_bites(self) -> None:
+        item = contract._checklist_item(self.docs, contract._CRATES_ITEM_TITLE)
+        if "Apply this on every current crates.io crate:" in item:
+            mutated_item = item.replace(
+                "Apply this on every current crates.io crate:",
+                "on every current crates.io crate:",
+                1,
+            )
+        else:
+            mutated_item = item
+        mutated = replace_once(self.docs, item, mutated_item)
+        problems = contract.contract_problems(self.workflow, mutated)
+        self.assertTrue(problems, "mutation survived")
+        self.assertTrue(
+            any("Apply this" in problem for problem in problems),
+            problems,
+        )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/ci/test-release-runbook-truth.py
+++ b/scripts/ci/test-release-runbook-truth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -351,35 +352,111 @@ class ReleaseRunbookTruthMutations(unittest.TestCase):
         self.assertTrue(problems, "mutation survived")
         self.assertIn(contract._CRATES_SECRET_TOKEN_SOURCE_MESSAGE, problems)
 
-    def test_pypi_appended_optional_environment_contradiction_bites(self) -> None:
-        item = contract._checklist_item(self.docs, contract._PYPI_ITEM_TITLE)
-        mutated = replace_once(
+    def _append_publisher_sentence(self, title: str, sentence: str) -> str:
+        item = contract._checklist_item(self.docs, title)
+        return replace_once(
             self.docs,
             item,
-            item.rstrip("\n")
-            + "\n  The environment field is optional and may be left unset.\n",
+            item.rstrip("\n") + f"\n  {sentence}\n",
         )
+
+    def _assert_unpinned_environment_bites(self, *, title: str, sentence: str) -> None:
+        mutated = self._append_publisher_sentence(title, sentence)
         problems = contract.contract_problems(self.workflow, mutated)
         self.assertTrue(problems, "mutation survived")
         self.assertTrue(
-            any("optional" in problem.lower() for problem in problems),
+            any(
+                "unpinned" in problem.lower() and "environment" in problem.lower()
+                for problem in problems
+            ),
             problems,
         )
 
+    def test_pypi_appended_optional_environment_contradiction_bites(self) -> None:
+        self._assert_unpinned_environment_bites(
+            title=contract._PYPI_ITEM_TITLE,
+            sentence="The environment field is optional and may be left unset.",
+        )
+
     def test_crates_appended_optional_environment_contradiction_bites(self) -> None:
-        item = contract._checklist_item(self.docs, contract._CRATES_ITEM_TITLE)
-        mutated = replace_once(
+        self._assert_unpinned_environment_bites(
+            title=contract._CRATES_ITEM_TITLE,
+            sentence="The environment field is optional and may be left unset.",
+        )
+
+    def test_pypi_codex_omitted_when_unavailable_paraphrase_bites(self) -> None:
+        self._assert_unpinned_environment_bites(
+            title=contract._PYPI_ITEM_TITLE,
+            sentence="The environment value can be omitted when unavailable.",
+        )
+
+    def test_crates_codex_omitted_when_unavailable_paraphrase_bites(self) -> None:
+        self._assert_unpinned_environment_bites(
+            title=contract._CRATES_ITEM_TITLE,
+            sentence="The environment value can be omitted when unavailable.",
+        )
+
+    def test_pypi_blank_environment_accepted_paraphrase_bites(self) -> None:
+        self._assert_unpinned_environment_bites(
+            title=contract._PYPI_ITEM_TITLE,
+            sentence="Publication proceeds when the environment is not configured.",
+        )
+
+    def test_crates_blank_environment_accepted_paraphrase_bites(self) -> None:
+        self._assert_unpinned_environment_bites(
+            title=contract._CRATES_ITEM_TITLE,
+            sentence="Publication proceeds when the environment is not configured.",
+        )
+
+    def test_adding_or_removing_a_crates_inventory_line_stays_green(self) -> None:
+        added = replace_once(
             self.docs,
-            item,
-            item.rstrip("\n")
-            + "\n  The environment field is optional and may be left unset.\n",
+            "  - `assay-cli`\n",
+            "  - `assay-cli`\n  - `assay-newcrate`\n",
         )
-        problems = contract.contract_problems(self.workflow, mutated)
-        self.assertTrue(problems, "mutation survived")
-        self.assertTrue(
-            any("optional" in problem.lower() for problem in problems),
-            problems,
+        self.assert_clean(self.workflow, added)
+        removed = replace_once(
+            self.docs,
+            "  - `assay-sim`\n",
+            "",
         )
+        self.assert_clean(self.workflow, removed)
+        item = contract._checklist_item(added, contract._CRATES_ITEM_TITLE)
+        self.assertNotIn("environment", item.split("assay-newcrate")[1].lower())
+
+    def test_removing_environment_allowlist_lets_paraphrases_survive(self) -> None:
+        source = Path(contract.__file__).read_text(encoding="utf-8")
+        needle = (
+            "    problems.extend(\n"
+            "        _unpinned_environment_sentence_problems(\n"
+            "            item, required_sentences, label=label\n"
+            "        )\n"
+            "    )\n"
+        )
+        self.assertEqual(source.count(needle), 1)
+        paraphrases = (
+            (contract._PYPI_ITEM_TITLE, "The environment value can be omitted when unavailable."),
+            (contract._CRATES_ITEM_TITLE, "The environment value can be omitted when unavailable."),
+            (contract._PYPI_ITEM_TITLE, "Publication proceeds when the environment is not configured."),
+            (contract._CRATES_ITEM_TITLE, "Publication proceeds when the environment is not configured."),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "check-release-runbook-truth.py"
+            path.write_text(source.replace(needle, "", 1), encoding="utf-8")
+            spec = importlib.util.spec_from_file_location(
+                "disabled_release_runbook_truth", path
+            )
+            if spec is None or spec.loader is None:
+                raise AssertionError("disabled checker is not loadable")
+            disabled = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(disabled)
+            for title, sentence in paraphrases:
+                mutated = self._append_publisher_sentence(title, sentence)
+                problems = disabled.contract_problems(self.workflow, mutated)
+                with self.assertRaisesRegex(AssertionError, "mutation survived"):
+                    self.assertTrue(problems, "mutation survived")
+                live = contract.contract_problems(self.workflow, mutated)
+                self.assertTrue(live, "live allowlist must still bite")
 
     def test_crates_credentials_lead_in_is_complete(self) -> None:
         item = contract._checklist_item(self.docs, contract._CRATES_ITEM_TITLE)


### PR DESCRIPTION
**Merge head `47974997d0664c2300f915de7b44e7f84d74d670`** is `gh pr update-branch` over the reviewed/carried head `bbd12731449ac7616e2fe89db8f9e0b2f1ebd320`; carry record with both AGENTS.md checks: https://github.com/Rul1an/assay/pull/2928#issuecomment-5633690035.

Candidate, not a landing. Head SHA bbd12731449ac7616e2fe89db8f9e0b2f1ebd320. Sole author; needs an independent exact-head review record before merge.

D2 decision: a shared allowlist of environment-mentioning sentences per publisher item, not closed-form item text and not a forbidden-phrase list. The checklist items include the crate inventory and receipt procedure; owning the whole item would make a crate-list edit fail the publisher-identity check. Crate inventory lines do not mention environment, so a crate-list edit stays green. Both halves share the check so fixing one cannot reintroduce the parity overclaim.

| Gap | Test | Mutation | RED | GREEN |
| --- | --- | --- | --- | --- |
| D4 token source | `test_crates_secret_token_source_bites` | `CARGO_REGISTRY_TOKEN` from `secrets.CARGO_REGISTRY_TOKEN` | mutation survived (empty problems) | named `secrets.*` assertion |
| D2 PyPI | `test_pypi_appended_optional_environment_contradiction_bites` | append optional/unset sentence to PyPI item | mutation survived | unpinned environment sentence |
| D2 crates | `test_crates_appended_optional_environment_contradiction_bites` | same append on crates item | mutation survived | unpinned environment sentence |
| D5 lead-in | `test_crates_credentials_lead_in_is_complete`; `test_crates_lead_in_fragment_bites` | fragment `No credentials. on every` | Apply this absent; mutation survived | real docs complete; fragment bites |
| control | `test_current_tree_control_stays_green` | none (real files) | stayed green on pre-fix tree | stays green on head |

## Review follow-ups

Codex blocked D2 only. D4 and D5 held against its own bypass mutants. Its paraphrase mutant, appending "The environment value can be omitted when unavailable." to a publisher item, survived the forbidden-phrase list (`problems=[]`).

D2 is now an allowlist: within each publisher item, every sentence that mentions environment must be exactly one of that item's pinned sentences. Any other sentence mentioning environment is a problem.

| Follow-up | Test | Mutation | RED | GREEN |
| --- | --- | --- | --- | --- |
| Codex paraphrase, PyPI | `test_pypi_codex_omitted_when_unavailable_paraphrase_bites` | append omitted-when-unavailable | mutation survived | unpinned environment sentence |
| Codex paraphrase, crates | `test_crates_codex_omitted_when_unavailable_paraphrase_bites` | same append on crates item | mutation survived | unpinned environment sentence |
| second paraphrase, both items | `test_pypi_blank_environment_accepted_paraphrase_bites`; `test_crates_blank_environment_accepted_paraphrase_bites` | append "Publication proceeds when the environment is not configured." | mutation survived | unpinned environment sentence |
| crate-list control | `test_adding_or_removing_a_crates_inventory_line_stays_green` | add or remove a crate inventory line | stayed green | stays green |
| must-bite | `test_removing_environment_allowlist_lets_paraphrases_survive` | delete `_unpinned_environment_sentence_problems` call | paraphrase tests fail on `mutation survived` | needle present; live allowlist still bites |

Closes #2912
