### PR TITLE
fix(evidence): require an explicit ceiling before retaining events

### DIFF
--- a/conformance/adequacy/results.json
+++ b/conformance/adequacy/results.json
@@ -100,7 +100,7 @@
       "manifest": "conformance/adequacy/privileged-mcp-action-v0.manifest.json",
       "manifest_sha256": "sha256:405211af4bc5fe3c14076ea1a86058db40d51de4e8b0c6d699b07c009e353f40",
       "measured_at": {
-        "commit": "a82bbe7de093234de44a9274b1909a27c0572a5d",
+        "commit": "94154243b1abc04bd4ce8a3dae9f9ec2a8bec36b",
         "depends_on": [
           "conformance/adequacy/privileged-mcp-action-v0.manifest.json",
           "conformance/adequacy/privileged-mcp-action-v0.vectors.json",

--- a/crates/assay-cli/src/cli/commands/evidence/diff.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/diff.rs
@@ -82,7 +82,7 @@ pub fn cmd_diff(args: DiffArgs) -> Result<i32> {
     let candidate_file = File::open(&candidate_path)
         .with_context(|| format!("failed to open candidate {}", candidate_path.display()))?;
 
-    let limits = VerifyLimits::default();
+    let limits = VerifyLimits::for_retained_events();
     let report = diff_bundles(baseline_file, candidate_file, limits)?;
 
     match args.format {

--- a/crates/assay-cli/src/cli/commands/evidence/explore.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/explore.rs
@@ -119,10 +119,11 @@ pub fn cmd_explore(args: ExploreArgs) -> Result<i32> {
     let f = std::fs::File::open(&args.bundle)
         .with_context(|| format!("failed to open bundle {}", args.bundle.display()))?;
 
+    let limits = assay_evidence::VerifyLimits::for_retained_events_capped(args.max_events);
     let br = if args.no_verify {
-        assay_evidence::bundle::BundleReader::open_unverified(f)
+        assay_evidence::bundle::BundleReader::open_unverified_with_limits(f, limits)
     } else {
-        assay_evidence::bundle::BundleReader::open(f)
+        assay_evidence::bundle::BundleReader::open_with_limits(f, limits)
     }
     .context("failed to open bundle")?;
 

--- a/crates/assay-cli/src/cli/commands/evidence/lint.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/lint.rs
@@ -78,7 +78,7 @@ pub fn cmd_lint(args: LintArgs) -> Result<i32> {
     let f = File::open(bundle)
         .with_context(|| format!("failed to open bundle {}", bundle.display()))?;
 
-    let limits = VerifyLimits::default();
+    let limits = VerifyLimits::for_retained_events();
 
     // Load packs: explicit --pack or default (ADR-023)
     let (packs, is_default_pack) = if let Some(pack_refs) = &args.pack {

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -303,10 +303,11 @@ fn cmd_show(args: EvidenceShowArgs) -> Result<i32> {
         )
     })?;
 
+    let limits = assay_evidence::VerifyLimits::for_retained_events();
     let reader = if args.no_verify {
-        assay_evidence::bundle::BundleReader::open_unverified(f)
+        assay_evidence::bundle::BundleReader::open_unverified_with_limits(f, limits)
     } else {
-        assay_evidence::bundle::BundleReader::open(f)
+        assay_evidence::bundle::BundleReader::open_with_limits(f, limits)
     };
     let br = reader.map_err(|error| {
         classify_show_error(&args.bundle, error, "failed to open bundle reader")

--- a/crates/assay-cli/src/cli/commands/evidence/project_skill_bom.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/project_skill_bom.rs
@@ -38,7 +38,10 @@ pub fn cmd_project_skill_bom(args: ProjectSkillBomArgs) -> Result<i32> {
             return Ok(exit_codes::EXIT_CONFIG_ERROR);
         }
     };
-    let reader = match assay_evidence::bundle::BundleReader::open(file) {
+    let reader = match assay_evidence::bundle::BundleReader::open_with_limits(
+        file,
+        assay_evidence::VerifyLimits::for_retained_events(),
+    ) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("error: bundle integrity verification failed: {e}");

--- a/crates/assay-cli/src/cli/commands/evidence/push.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/push.rs
@@ -56,16 +56,15 @@ pub async fn cmd_push(args: PushArgs) -> Result<i32> {
     // 2. Verify bundle (unless --no-verify)
     let bundle_id = if args.no_verify {
         let cursor = std::io::Cursor::new(&buffer);
-        // Deliberately `open_unverified_with_limits` and not `BundleInfo::peek_with_limits`, even
-        // though only `bundle_id` is read from the result. This looks like the same waste the
-        // verification-only callers had, and it is not: with `--no-verify` the reader's events
-        // pass is the *only* consumption of `events.ndjson`, so it is what applies
-        // `max_line_bytes`, `max_events`, UTF-8 validity and JSON depth. Switching to peek drops
-        // those ceilings — `contract_bounded_ingest_cli` catches it immediately, which is how this
-        // comment came to exist. Retention here is load-bearing.
-        let reader = assay_evidence::BundleReader::open_unverified_with_limits(cursor, limits)
+        // Deliberately `peek_and_bound_events` and not `BundleInfo::peek_with_limits`, even
+        // though only `bundle_id` is read from the result. With `--no-verify` this pass is the
+        // *only* consumption of `events.ndjson`, so it is what applies `max_line_bytes`,
+        // `max_events`, UTF-8 validity and JSON depth. Switching to peek drops those ceilings —
+        // `contract_bounded_ingest_cli` catches it immediately, which is how this comment came
+        // to exist. The events member is checked into a discard sink; it is not retained.
+        let info = assay_evidence::BundleInfo::peek_and_bound_events(cursor, limits)
             .context("failed to read bundle manifest")?;
-        reader.manifest().bundle_id.clone()
+        info.manifest.bundle_id.clone()
     } else {
         let cursor = std::io::Cursor::new(&buffer);
         let result = assay_evidence::bundle::writer::verify_bundle_with_limits(cursor, limits)
@@ -75,10 +74,8 @@ pub async fn cmd_push(args: PushArgs) -> Result<i32> {
     };
 
     // The upload takes ownership of the same buffer that was just checked rather than cloning it.
-    // Stated narrowly, because the earlier note overclaimed: this removes one copy, not all of
-    // them. `BundleReader` still materializes its own `Vec` internally, so a bundle near the
-    // ceiling is held more than once regardless. Both copies are bounded; what changed is that
-    // one of them is no longer gratuitous.
+    // `--no-verify` no longer materializes `events.ndjson` beside that buffer; the verified
+    // branch never did. Both copies that remain are the source snapshot and the upload bytes.
     let bytes = Bytes::from(buffer);
 
     // 3. Connect to store

--- a/crates/assay-cli/src/cli/commands/evidence/verify_privileged_mcp_action.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/verify_privileged_mcp_action.rs
@@ -16,7 +16,7 @@ use crate::evidence_verify_reason::{
 };
 use crate::exit_codes::{self, ReasonCode};
 use anyhow::{Context, Result};
-use assay_evidence::bundle::BundleReader;
+use assay_evidence::bundle::{BundleReader, VerifyLimits};
 use assay_evidence::denial_marker::{classify_denial_marker, DenialMarkerVersion};
 use assay_evidence::types::EvidenceEvent;
 use clap::{Args, ValueEnum};
@@ -303,10 +303,10 @@ pub fn verify_bundle_report_for(
 fn read_bundle_events(bundle: &Path) -> anyhow::Result<Vec<EvidenceEvent>> {
     let file = File::open(bundle)
         .with_context(|| format!("failed to open bundle {}", bundle.display()))?;
-    // Stage 1: BundleReader::open runs the full shipped bundle verification
-    // (verify_bundle_with_limits with default limits) before exposing any event.
+    // Stage 1: open_with_limits runs the shipped bundle verification before exposing
+    // any event. The retain ceiling is explicit and tighter than the 500 MiB default.
     // Context names the caller argv without replacing a typed VerifyError in the chain.
-    let reader = BundleReader::open(file)
+    let reader = BundleReader::open_with_limits(file, VerifyLimits::for_retained_events())
         .with_context(|| format!("failed to read bundle {}", bundle.display()))?;
     reader
         .events_vec()

--- a/crates/assay-cli/src/cli/commands/evidence/verify_side_effects.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/verify_side_effects.rs
@@ -25,7 +25,7 @@ use crate::cli::commands::monitor::monitor_next::observed_peers::{
 };
 use crate::exit_codes;
 use anyhow::{Context, Result};
-use assay_evidence::bundle::BundleReader;
+use assay_evidence::bundle::{BundleReader, VerifyLimits};
 use assay_evidence::{
     coding_agent_claim_decision, coding_agent_weakest_ceiling, CodingAgentClaimCeiling,
     CodingAgentClaimDecision, CodingAgentClaimKind, CodingAgentCoverageState,
@@ -245,7 +245,7 @@ pub fn cmd_verify_side_effects(args: &VerifySideEffectsArgs) -> Result<i32> {
     let file = File::open(&args.bundle)
         .with_context(|| format!("cannot open bundle {}", args.bundle.display()))?;
     // Integrity first: the ladder is meaningless over bytes that did not verify.
-    let events = BundleReader::open(file)
+    let events = BundleReader::open_with_limits(file, VerifyLimits::for_retained_events())
         .context("bundle failed verification")?
         .events_vec()
         .context("cannot read bundle events")?;

--- a/crates/assay-cli/src/cli/commands/evidence/verify_skill_supply_chain.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/verify_skill_supply_chain.rs
@@ -9,7 +9,7 @@
 
 use crate::exit_codes;
 use anyhow::{Context, Result};
-use assay_evidence::bundle::BundleReader;
+use assay_evidence::bundle::{BundleReader, VerifyLimits};
 use assay_evidence::types::EvidenceEvent;
 use clap::{Args, ValueEnum};
 use serde::Serialize;
@@ -66,7 +66,8 @@ pub fn cmd_verify_skill_supply_chain(args: VerifySkillSupplyChainArgs) -> Result
     let file = File::open(&args.bundle)
         .with_context(|| format!("failed to open bundle {}", args.bundle.display()))?;
     // Verify-before-read: bundle integrity first, carrier semantics second.
-    let reader = BundleReader::open(file).context("bundle integrity verification failed")?;
+    let reader = BundleReader::open_with_limits(file, VerifyLimits::for_retained_events())
+        .context("bundle integrity verification failed")?;
     let events = reader
         .events_vec()
         .context("failed to read bundle events")?;

--- a/crates/assay-cli/src/cli/commands/evidence/verify_tool_decision_truth.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/verify_tool_decision_truth.rs
@@ -10,7 +10,7 @@ use crate::exit_codes;
 use anyhow::{Context, Result};
 use assay_core::mcp::tool_decision_truth as tdt;
 use assay_core::otel::projection::TdtDecision;
-use assay_evidence::bundle::BundleReader;
+use assay_evidence::bundle::{BundleReader, VerifyLimits};
 use assay_evidence::types::EvidenceEvent;
 use clap::{Args, ValueEnum};
 use serde::Serialize;
@@ -72,7 +72,8 @@ pub fn cmd_verify_tool_decision_truth(args: VerifyToolDecisionTruthArgs) -> Resu
     let file = File::open(&args.bundle)
         .with_context(|| format!("failed to open bundle {}", args.bundle.display()))?;
     // BundleReader::open verifies manifest hashes and the deterministic run-root digest before we read events.
-    let reader = BundleReader::open(file).context("bundle integrity verification failed")?;
+    let reader = BundleReader::open_with_limits(file, VerifyLimits::for_retained_events())
+        .context("bundle integrity verification failed")?;
     let events = reader
         .events_vec()
         .context("failed to read bundle events")?;

--- a/crates/assay-cli/src/cli/commands/project_otel.rs
+++ b/crates/assay-cli/src/cli/commands/project_otel.rs
@@ -94,8 +94,11 @@ fn run_tool_decision_truth(bundle: &Path, out: Option<&Path>) -> anyhow::Result<
             return Ok(EXIT_CONFIG_ERROR);
         }
     };
-    // BundleReader::open verifies manifest hashes and the deterministic run-root digest.
-    let reader = match assay_evidence::bundle::BundleReader::open(file) {
+    // open_with_limits verifies manifest hashes and the deterministic run-root digest.
+    let reader = match assay_evidence::bundle::BundleReader::open_with_limits(
+        file,
+        assay_evidence::VerifyLimits::for_retained_events(),
+    ) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("error: bundle integrity verification failed: {e}");

--- a/crates/assay-cli/src/cli/commands/trust_basis.rs
+++ b/crates/assay-cli/src/cli/commands/trust_basis.rs
@@ -43,9 +43,12 @@ fn cmd_generate(args: TrustBasisGenerateArgs) -> Result<i32> {
         None
     };
 
-    let trust_basis =
-        generate_trust_basis(bundle, VerifyLimits::default(), TrustBasisOptions { lint })
-            .context("failed to generate trust basis")?;
+    let trust_basis = generate_trust_basis(
+        bundle,
+        VerifyLimits::for_retained_events(),
+        TrustBasisOptions { lint },
+    )
+    .context("failed to generate trust basis")?;
 
     let output =
         to_canonical_json_bytes(&trust_basis).context("failed to serialize trust basis")?;

--- a/crates/assay-cli/src/cli/commands/trust_card.rs
+++ b/crates/assay-cli/src/cli/commands/trust_card.rs
@@ -39,9 +39,12 @@ fn cmd_generate(args: TrustCardGenerateArgs) -> Result<i32> {
         None
     };
 
-    let trust_basis =
-        generate_trust_basis(bundle, VerifyLimits::default(), TrustBasisOptions { lint })
-            .context("failed to generate trust basis for trust card")?;
+    let trust_basis = generate_trust_basis(
+        bundle,
+        VerifyLimits::for_retained_events(),
+        TrustBasisOptions { lint },
+    )
+    .context("failed to generate trust basis for trust card")?;
 
     let card = trust_basis_to_trust_card(&trust_basis);
 

--- a/crates/assay-evidence/src/bundle/reader.rs
+++ b/crates/assay-evidence/src/bundle/reader.rs
@@ -1,18 +1,13 @@
 //! Bundle reader for evidence bundles.
 //!
-//! Provides a safe way to read and iterate over events from a bundle
-//! without needing to handle tar/gzip internals.
-//!
-//! # Design Choice: Memory-Based (Option A)
-//!
-//! This implementation reads the entire events.ndjson into memory.
-//! For v1, this is acceptable because:
-//! - Bundles are typically <100MB
-//! - Simplifies lifetime management
-//! - Avoids streaming complexity
-//!
-//! For very large bundles (>1GB), consider tempfile-based streaming
-//! or the `into_events()` consuming pattern in a future version.
+//! [`BundleReader::open`] retains the decompressed `events.ndjson` so a caller can
+//! iterate it. That residency is bounded only by the limits passed at open; the
+//! default `max_events_bytes` is 500 MiB, five times `max_bundle_bytes`. A small
+//! compressible archive can therefore cost far more resident memory than its size
+//! on disk. Callers that only need a verify or manifest answer must use
+//! [`crate::bundle::verify_bundle`] or [`BundleInfo::peek_and_bound_events`].
+//! Callers that need events must pass [`VerifyLimits::for_retained_events`] (or a
+//! tighter cap) before materializing.
 
 use crate::bundle::writer::{
     check_entry_path_len, classify_reader_io, classify_strict_json, read_events_bounded,
@@ -240,7 +235,9 @@ impl BundleReader {
 
 /// Info-only bundle inspection (manifest only, no event loading).
 ///
-/// Faster than `BundleReader::open()` when you only need metadata.
+/// Use this when the caller needs the manifest and not the events stream.
+/// Peeking still expands the archive under [`VerifyLimits`]; it does not make
+/// opening cheap relative to on-disk size.
 pub struct BundleInfo {
     pub manifest: Manifest,
 }
@@ -249,7 +246,7 @@ impl BundleInfo {
     /// Read only the manifest from a bundle.
     ///
     /// Does NOT verify event integrity.
-    /// Use `BundleReader::open()` for full verification.
+    /// Use [`crate::bundle::verify_bundle`] when the caller needs a verify answer.
     pub fn peek<R: Read>(reader: R) -> Result<Self> {
         Self::peek_with_limits(reader, VerifyLimits::default())
     }
@@ -309,6 +306,52 @@ impl BundleInfo {
 
         anyhow::bail!("Bundle missing manifest.json")
     }
+
+    /// Apply event-member ceilings and return the manifest without retaining `events.ndjson`.
+    ///
+    /// Use this when the caller needs the identifier (or other manifest fields) and must still
+    /// enforce `max_line_bytes`, `max_events`, UTF-8 and JSON depth — the ceilings
+    /// [`Self::peek_with_limits`] does not apply because it never reads the events member.
+    pub fn peek_and_bound_events<R: Read>(reader: R, limits: VerifyLimits) -> Result<Self> {
+        let mut source = Vec::new();
+        LimitReader::new(reader, limits.max_bundle_bytes, LimitKind::SourceBytes)
+            .read_to_end(&mut source)
+            .map_err(classify_reader_io)
+            .context("Bundle source")?;
+
+        let info = Self::peek_with_limits(Cursor::new(&source), limits)?;
+
+        let decoder = LimitReader::new(
+            GzDecoder::new(Cursor::new(&source)),
+            limits.max_decode_bytes,
+            LimitKind::DecodedBytes,
+        );
+        let mut archive = tar::Archive::new(decoder);
+        let mut events_found = false;
+
+        for entry in archive.entries().map_err(classify_reader_io)?.raw(true) {
+            let entry = entry.map_err(classify_reader_io)?;
+            check_entry_path_len(entry.path_bytes().len(), limits.max_path_len)?;
+            let path = entry.path()?.to_string_lossy().to_string();
+            if path == "events.ndjson" {
+                events_found = true;
+                let entry =
+                    LimitReader::new(entry, limits.max_events_bytes, LimitKind::MemberBytes);
+                read_events_bounded(entry, &mut std::io::sink(), limits)?;
+                break;
+            }
+        }
+
+        if !events_found {
+            return Err(anyhow::Error::new(VerifyError::new(
+                ErrorClass::Contract,
+                ErrorCode::ContractMissingFile,
+                "events.ndjson missing from bundle".to_string(),
+            )));
+        }
+
+        Ok(info)
+    }
 }
 
 #[cfg(test)]
@@ -346,6 +389,16 @@ mod tests {
     fn test_bundle_info_peek() {
         let bundle = create_test_bundle(5);
         let info = BundleInfo::peek(Cursor::new(&bundle)).unwrap();
+
+        assert_eq!(info.manifest.event_count, 5);
+        assert_eq!(info.manifest.run_id, "run_test");
+    }
+
+    #[test]
+    fn peek_and_bound_events_returns_the_manifest() {
+        let bundle = create_test_bundle(5);
+        let info = BundleInfo::peek_and_bound_events(Cursor::new(&bundle), VerifyLimits::default())
+            .unwrap();
 
         assert_eq!(info.manifest.event_count, 5);
         assert_eq!(info.manifest.run_id, "run_test");

--- a/crates/assay-evidence/src/bundle/writer.rs
+++ b/crates/assay-evidence/src/bundle/writer.rs
@@ -26,7 +26,7 @@
 mod writer_next;
 
 use anyhow::Result;
-use std::io::Read;
+use std::io::{Read, Write};
 
 pub use writer_next::errors::{ErrorClass, ErrorCode, VerifyError};
 /// The conditions a bundle must satisfy to exist, shared by the writer and the verifier.
@@ -70,9 +70,9 @@ pub(crate) fn check_entry_path_len(raw_len: usize, max_path_len: usize) -> Resul
 /// checked line length and event count, so the allocation happened before the dimensions that
 /// govern it were consulted, and `max_json_depth` never reached event lines on this path at all.
 /// Reading line by line refuses at the first line that crosses a ceiling.
-pub(crate) fn read_events_bounded<R: std::io::Read>(
+pub(crate) fn read_events_bounded<R: std::io::Read, W: Write>(
     reader: R,
-    out: &mut Vec<u8>,
+    out: &mut W,
     limits: VerifyLimits,
 ) -> anyhow::Result<()> {
     let mut reader = std::io::BufReader::new(reader);
@@ -87,7 +87,7 @@ pub(crate) fn read_events_bounded<R: std::io::Read>(
         }
         let payload = line.strip_suffix(b"\n").unwrap_or(&line);
         if payload.is_empty() {
-            out.extend_from_slice(&line);
+            out.write_all(&line).map_err(classify_reader_io)?;
             continue;
         }
 
@@ -118,7 +118,7 @@ pub(crate) fn read_events_bounded<R: std::io::Read>(
         crate::json_strict::validate_json_strict_with_depth(text, limits.max_json_depth)
             .map_err(|e| classify_strict_json(e, "Event", limits.max_json_depth))?;
 
-        out.extend_from_slice(&line);
+        out.write_all(&line).map_err(classify_reader_io)?;
     }
     Ok(())
 }

--- a/crates/assay-evidence/src/bundle/writer_next/limits.rs
+++ b/crates/assay-evidence/src/bundle/writer_next/limits.rs
@@ -49,6 +49,31 @@ pub struct VerifyLimitsOverrides {
 }
 
 impl VerifyLimits {
+    /// Limits for a caller that retains decompressed `events.ndjson`.
+    ///
+    /// `max_events_bytes` is the compressed-bundle ceiling (100 MiB), five times
+    /// tighter than [`Self::default`]. Call this at the open site so residency is a
+    /// chosen bound, not the 500 MiB default inherited by [`crate::bundle::BundleReader::open`].
+    pub fn for_retained_events() -> Self {
+        let defaults = Self::default();
+        Self {
+            max_events_bytes: defaults.max_bundle_bytes,
+            ..defaults
+        }
+    }
+
+    /// [`Self::for_retained_events`] with the caller's event cap applied before materialization.
+    ///
+    /// `max_events_bytes` is also capped at `max_events * max_line_bytes` so a small
+    /// `--max-events` cannot still hold the full retain ceiling.
+    pub fn for_retained_events_capped(max_events: usize) -> Self {
+        let mut limits = Self::for_retained_events();
+        limits.max_events = max_events;
+        let from_lines = (max_events as u64).saturating_mul(limits.max_line_bytes as u64);
+        limits.max_events_bytes = limits.max_events_bytes.min(from_lines);
+        limits
+    }
+
     /// Apply overrides onto these defaults. Only `Some` values override.
     pub fn apply(self, overrides: VerifyLimitsOverrides) -> Self {
         Self {

--- a/crates/assay-evidence/tests/retain_callsite_inventory.rs
+++ b/crates/assay-evidence/tests/retain_callsite_inventory.rs
@@ -1,0 +1,201 @@
+//! Production retain paths must choose a ceiling; `BundleReader::open` is not that choice.
+//!
+//! `open` / `open_unverified` inherit `VerifyLimits::default().max_events_bytes` (500 MiB) and
+//! keep the whole decompressed `events.ndjson`. A new untrusted or long-lived caller that picks
+//! those constructors re-adopts full residency without saying so. Comments cannot carry that
+//! rule: this walk fails when a production `src/` call site writes one of those constructors.
+//!
+//! Tests, rustdoc, and `#[cfg(test)]` modules are out of scope. They are not ingest entrypoints.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root")
+}
+
+/// One path component, admitted only if it is an ordinary name.
+///
+/// Same rule `error_enums_non_exhaustive` uses: `read_dir` entries are untrusted input to a
+/// static analyser, and a symlink under `crates/` must not send this walk outside the workspace.
+fn safe_component(name: &std::ffi::OsStr) -> Option<String> {
+    let s = name.to_str()?;
+    let ordinary = !s.is_empty()
+        && s != "."
+        && s != ".."
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+    ordinary.then(|| s.to_string())
+}
+
+fn resolves_inside(root: &Path, p: &Path) -> bool {
+    p.canonicalize().is_ok_and(|r| r.starts_with(root))
+}
+
+fn walk_src_rs(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries {
+        let entry = entry.expect("dir entry");
+        let Some(name) = safe_component(&entry.file_name()) else {
+            continue;
+        };
+        let path = dir.join(&name);
+        if !resolves_inside(root, &path) {
+            continue;
+        }
+        if path.is_dir() {
+            walk_src_rs(root, &path, out);
+            continue;
+        }
+        if name.ends_with(".rs") && name != "tests.rs" {
+            out.push(path);
+        }
+    }
+}
+
+fn crate_src_files(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let crates_dir = root.join("crates");
+    for entry in fs::read_dir(&crates_dir).expect("crates/ is readable") {
+        let Some(name) = safe_component(&entry.expect("dir entry").file_name()) else {
+            continue;
+        };
+        let src = crates_dir.join(&name).join("src");
+        if src.is_dir() && resolves_inside(root, &src) {
+            walk_src_rs(root, &src, &mut out);
+        }
+    }
+    out
+}
+
+/// `BundleReader::open(` / `open_unverified(` — not the `*_with_limits` siblings.
+fn is_default_open_call(line: &str) -> bool {
+    let Some(idx) = line.find("BundleReader::open") else {
+        return false;
+    };
+    let rest = &line[idx + "BundleReader::open".len()..];
+    rest.starts_with('(') || rest.starts_with("_unverified(")
+}
+
+fn is_comment_or_doc(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("//") || trimmed.starts_with("///") || trimmed.starts_with("//!")
+}
+
+fn is_mod_start(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let after_vis = trimmed
+        .strip_prefix("pub(crate) ")
+        .or_else(|| trimmed.strip_prefix("pub(super) "))
+        .or_else(|| trimmed.strip_prefix("pub "))
+        .unwrap_or(trimmed);
+    after_vis.starts_with("mod ")
+}
+
+/// Skip bodies of `#[cfg(test)] mod ... { ... }`. Those are not ingest entrypoints.
+fn default_open_hits(source: &str) -> Vec<(usize, String)> {
+    let mut hits = Vec::new();
+    let mut in_test_mod = false;
+    let mut test_depth = 0usize;
+    let mut pending_test_mod = false;
+
+    for (idx, line) in source.lines().enumerate() {
+        if !in_test_mod && line.contains("#[cfg(test)]") {
+            pending_test_mod = true;
+        }
+
+        if pending_test_mod && is_mod_start(line) {
+            in_test_mod = true;
+            pending_test_mod = false;
+            test_depth = 0;
+        }
+
+        if in_test_mod {
+            for c in line.chars() {
+                match c {
+                    '{' => test_depth += 1,
+                    '}' => {
+                        test_depth = test_depth.saturating_sub(1);
+                        if test_depth == 0 {
+                            in_test_mod = false;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            continue;
+        }
+
+        if pending_test_mod && !line.trim().is_empty() && !line.contains("#[cfg(test)]") {
+            // `#[cfg(test)]` on a single item, not a module. Still skip this line if it is
+            // the item itself; otherwise the attribute did not introduce a skipped region.
+            pending_test_mod = false;
+        }
+
+        if is_comment_or_doc(line) {
+            continue;
+        }
+        if is_default_open_call(line) {
+            hits.push((idx + 1, line.trim().to_string()));
+        }
+    }
+    hits
+}
+
+#[test]
+fn production_src_does_not_call_default_bundle_reader_open() {
+    let root = workspace_root();
+    let mut offenders = Vec::new();
+
+    for path in crate_src_files(&root) {
+        let source = fs::read_to_string(&path).expect("read rust source");
+        for (line, text) in default_open_hits(&source) {
+            let rel = path
+                .strip_prefix(&root)
+                .unwrap_or(&path)
+                .display()
+                .to_string();
+            offenders.push(format!("{rel}:{line}: {text}"));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "production src called BundleReader::open or open_unverified, which inherit the 500 MiB \
+         default residency ceiling. Untrusted or long-lived callers that only need a verify or \
+         manifest answer must use verify_bundle / BundleInfo::peek_and_bound_events; callers that \
+         need events must pass an explicit tighter limit via open_with_limits. Offenders:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn public_reader_docs_do_not_claim_open_is_cheap_relative_to_disk() {
+    let root = workspace_root();
+    let reader = root.join("crates/assay-evidence/src/bundle/reader.rs");
+    let source = fs::read_to_string(&reader).expect("reader.rs");
+
+    let banned = [
+        "typically <100MB",
+        "typically < 100MB",
+        "acceptable because",
+        "Faster than `BundleReader::open()`",
+        "Faster than BundleReader::open()",
+    ];
+    let mut hits = Vec::new();
+    for phrase in banned {
+        if source.contains(phrase) {
+            hits.push(phrase);
+        }
+    }
+
+    assert!(
+        hits.is_empty(),
+        "public reader docs claimed opening a bundle is cheap relative to on-disk size ({hits:?})"
+    );
+}

--- a/crates/assay-evidence/tests/verification_does_not_retain.rs
+++ b/crates/assay-evidence/tests/verification_does_not_retain.rs
@@ -147,7 +147,7 @@ fn verification_streams_where_the_reader_retains() {
     let baseline = LIVE.load(Ordering::Relaxed);
     PEAK.store(baseline, Ordering::Relaxed);
 
-    let reader = assay_evidence::bundle::BundleReader::open(std::io::Cursor::new(bundle))
+    let reader = assay_evidence::bundle::BundleReader::open(bundle.as_slice())
         .expect("the bundle must open");
     let retained = reader.events_raw().len();
     let reader_peak = PEAK.load(Ordering::Relaxed).saturating_sub(baseline);
@@ -157,5 +157,63 @@ fn verification_streams_where_the_reader_retains() {
         "the reader is documented to load events into memory ({retained} bytes here) but peaked at \
          {reader_peak}. If it has become streaming, the retention question is answered and this \
          test's rationale needs rewriting rather than deleting."
+    );
+    drop(reader);
+
+    // Same process-wide counters: a second `#[test]` would race this one. The discard path is
+    // the remaining untrusted shape — manifest plus event ceilings, no `events_content`.
+    let baseline = LIVE.load(Ordering::Relaxed);
+    PEAK.store(baseline, Ordering::Relaxed);
+
+    let info = assay_evidence::bundle::BundleInfo::peek_and_bound_events(
+        bundle.as_slice(),
+        VerifyLimits::default(),
+    )
+    .expect("peek_and_bound_events must apply event ceilings");
+    assert_eq!(info.manifest.event_count, 4_000);
+
+    let peek_peak = PEAK.load(Ordering::Relaxed).saturating_sub(baseline);
+    assert!(
+        peek_peak < ceiling,
+        "peek_and_bound_events held {peek_peak} bytes at peak for a bundle whose events decompress \
+         to {decompressed} bytes ({on_disk} on disk). That is the retain path — the caller asked \
+         only for the manifest and the event ceilings, not events_content."
+    );
+
+    let mut tight = VerifyLimits::for_retained_events();
+    tight.max_events_bytes = 1_000_000;
+    let baseline = LIVE.load(Ordering::Relaxed);
+    PEAK.store(baseline, Ordering::Relaxed);
+    let err = assay_evidence::bundle::BundleReader::open_with_limits(bundle.as_slice(), tight);
+    assert!(
+        err.is_err(),
+        "a 1 MiB events ceiling must refuse a bundle whose events decompress to {decompressed} bytes"
+    );
+    let tight_peak = PEAK.load(Ordering::Relaxed).saturating_sub(baseline);
+    assert!(
+        tight_peak < ceiling,
+        "tight-limit open held {tight_peak} bytes at peak ({decompressed} decompressed). Ignoring \
+         max_events_bytes and retaining under the 500 MiB default is the defect this pins."
+    );
+}
+
+#[test]
+fn retained_event_limits_are_tighter_than_the_default() {
+    let default = VerifyLimits::default();
+    let retain = VerifyLimits::for_retained_events();
+    assert!(
+        retain.max_events_bytes < default.max_events_bytes,
+        "for_retained_events must choose a tighter residency ceiling than the 500 MiB default"
+    );
+    assert_eq!(
+        retain.max_events_bytes, default.max_bundle_bytes,
+        "the retain ceiling is the compressed-bundle ceiling, not a second invented number"
+    );
+
+    let capped = VerifyLimits::for_retained_events_capped(4);
+    assert_eq!(capped.max_events, 4);
+    assert!(
+        capped.max_events_bytes < retain.max_events_bytes,
+        "a small event cap must also shrink max_events_bytes so open cannot hold the retain ceiling"
     );
 }


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: no programme is active
- Slice: BundleReader residency (#2282)
- Builder: Cursor Grok 4.6
- Reviewers: one non-building exact-head review required
- Final head SHA: b850e29d108cb8cb05f9fb15a7c2cd8bc1992228
- Worktree: /Users/roelschuurkes/.claude/worktrees/assay-2282-residency
- ADR invariants affected: ADR-043 section 1 bounded ingest (call-site residency, not the streaming verifier)

Candidate, not a landing. Sole author; needs an independent exact-head review record before merge.

## Adequacy re-measurement

Command (clean sibling worktree, no `target/`, instrument pinned):

```
cd /Users/roelschuurkes/.claude/worktrees/assay-2282-residency && cd /Users/roelschuurkes/.claude/worktrees/assay-2282-measure-root/assay && python3 conformance/adequacy/measure_all.py --only privileged-mcp-action-v0
```

- Worktree HEAD / measured_at: 94154243b1abc04bd4ce8a3dae9f9ec2a8bec36b
- Instrument: corpus-adequacy @ 13048989c84ab6b4e0281f9514ea45fb79a2d8b4
- Old privileged-mcp-action-v0: 6 of 28 in scope (21.4%), 22 survivors, 4 out of scope, 2 known holes; measured_at a82bbe7de093234de44a9274b1909a27c0572a5d
- New privileged-mcp-action-v0: 6 of 28 in scope (21.4%), 22 survivors, 4 out of scope, 2 known holes; measured_at 94154243b1abc04bd4ce8a3dae9f9ec2a8bec36b
- Report digest unchanged: sha256:172fb6b471f67017c251733f7e239f7a422209813e9262a9713dc6e8316c4bae

## Behavior

Untrusted CLI retain paths no longer inherit `VerifyLimits::default().max_events_bytes` (500 MiB).

- Manifest-only `push --no-verify` uses `BundleInfo::peek_and_bound_events`: event ceilings apply into `io::sink()`, `events.ndjson` is not retained.
- Callers that need events open with `VerifyLimits::for_retained_events()` (100 MiB, equal to `max_bundle_bytes`) or `for_retained_events_capped(--max-events)` on explore.
- A source inventory fails if production `src/` re-adopts `BundleReader::open` / `open_unverified`.
- Public reader docs no longer claim that opening is cheap relative to on-disk size.

## Caller classification (step 1, before any change)

`git grep -n BundleReader::open` on `12546ee39` (`origin/main`). Production ingest only:

| file:line | needs events | notes |
|---|---|---|
| `evidence/mod.rs:291` `cmd_verify` | no | already `verify_bundle` |
| `evidence/push.rs:66` `--no-verify` | no | only `bundle_id`; retained for ceilings |
| `evidence/explore.rs:123,125` | yes | default open, then truncated |
| `evidence/mod.rs:307,309` show | yes | default open |
| `evidence/project_skill_bom.rs:41` | yes | default open |
| `evidence/verify_privileged_mcp_action.rs:309` | yes | default open |
| `evidence/verify_side_effects.rs:248` | yes | default open |
| `evidence/verify_skill_supply_chain.rs:69` | yes | default open |
| `evidence/verify_tool_decision_truth.rs:75` | yes | default open |
| `project_otel.rs:98` | yes | default open |
| `project_enforcement_health.rs:152` | yes | already `projection_bundle_limits` (512 KiB) |
| `evidence/diff.rs` -> `diff/engine.rs:17,19` | yes | `open_with_limits`; CLI passed default |
| `evidence/lint.rs` -> `lint/engine.rs:51` | yes | `open_with_limits`; CLI passed default |
| `trust_basis.rs` / `trust_card.rs` -> `generation.rs:31` | yes | `open_with_limits`; CLI passed default |
| `sandbox/bundle.rs:200` | yes | unit test of own write |

Matches the issue and the 2026-08-25/08-27 comments: verify/attest/pull/verified push already stream; residual was explore/show, typed verifiers, projections, lint/diff, and `push --no-verify`. No `BundleReader` under `assay-mcp-server`.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim
- Not a claim that `verify_bundle` is unbounded
- Not a claim that `BundleReader` itself stopped retaining; it still does when events are needed
- Not a new peak-RSS measurement of the 5.7 MB / 530 MB pair

## Test Evidence

Worktree `/Users/roelschuurkes/.claude/worktrees/assay-2282-residency`, `CARGO_INCREMENTAL=0`.

### RED

Against the pre-change tree (inventory and cheap-claim tests only; peek stub still retained):

- `cargo test -p assay-evidence --test retain_callsite_inventory`
  - `production_src_does_not_call_default_bundle_reader_open` FAILED listing explore, show, `project_otel`, `project_skill_bom`, and the four typed verifiers
  - `public_reader_docs_do_not_claim_open_is_cheap_relative_to_disk` FAILED on `typically <100MB`, `acceptable because`, `Faster than BundleReader::open()`
- `cargo test -p assay-evidence --test verification_does_not_retain`
  - `peek_and_bound_events` held 22768775 bytes at peak vs 21908655 decompressed (261819 on disk)

### GREEN

On head `94154243b1abc04bd4ce8a3dae9f9ec2a8bec36b`:

- `cargo test -p assay-evidence --test retain_callsite_inventory`: 2 passed
- `cargo test -p assay-evidence --test verification_does_not_retain`: 2 passed
- `cargo test -p assay-evidence --test bounded_ingest_reader`: 26 passed
- `cargo test -p assay-evidence --test typed_limit_classification`: 9 passed
- `cargo test -p assay-evidence --test bounded_ingest_lint`: 3 passed
- `cargo test -p assay-cli --test contract_bounded_ingest_cli`: 3 passed (including `push --no-verify` line ceiling)
- `cargo test -p assay-cli --test push_refuses_before_upload`: 2 passed
- `cargo fmt --all -- --check`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: pass
- `git diff --check`: clean

### Mutation (inventory bite)

Reintroduced `BundleReader::open(f)` on `explore.rs`. Inventory failed naming `crates/assay-cli/src/cli/commands/evidence/explore.rs:126`. Reverted before commit.

## Review Quorum

- [ ] One non-building agent review
- [ ] Every actionable finding is fixed or has a technical disposition
- [ ] Any delegated proof targets this exact head SHA

Refs #2282

---

Current head `b7e16a8ee82dbca2d1d1504d95c013a062c6537e` after the branch update. Carry record: https://github.com/Rul1an/assay/pull/2947#issuecomment-5645307319
