### PR TITLE
test(conformance): remove tautological authorship mutation guards (#2948)

### DIFF
--- a/conformance/tests/test_implementations.py
+++ b/conformance/tests/test_implementations.py
@@ -201,6 +201,7 @@ class PositiveFixtureAndHostileMatrix(unittest.TestCase):
         for extra in (
             {"kind": "human", "model": "claude-opus"},
             {"kind": "human", "prompt_strategy": "spec-first"},
+            {"kind": "human", "model": "claude-opus", "prompt_strategy": "spec-first"},
         ):
             path = self._write(_doc([_valid_row(id="human-extra", authorship=extra)]))
             with self.subTest(extra=extra), self.assertRaises(
@@ -596,59 +597,6 @@ class AuthorshipProjectionContract(unittest.TestCase):
             ), self.assertRaises(AssertionError):
                 self._assert_document_parity(protocol, template)
 
-    def test_unknown_fallback_mutation_is_caught(self) -> None:
-        human_rule = self.module.AUTHORSHIP_RULES["human"]
-        with mock.patch.object(
-            self.module, "_authorship_rule", return_value=human_rule
-        ), self.assertRaises(AssertionError):
-            self._assert_unknown_is_rejected()
-
-    def test_missing_agent_metadata_mutation_is_caught(self) -> None:
-        original = self.module.AUTHORSHIP_RULES
-        mutation = dict(original)
-        mutation["agent-assisted"] = mutation["agent-assisted"]._replace(
-            fields=("kind",), value_field=None
-        )
-        with mock.patch.object(self.module, "AUTHORSHIP_RULES", mutation):
-            with self.assertRaises(AssertionError):
-                with self.assertRaises(self.module.ImplementationRegistryError):
-                    self.module._validate_authorship(
-                        {"kind": "agent-assisted"}, "missing-agent-metadata"
-                    )
-
-    def test_agent_only_metadata_on_human_mutation_is_caught(self) -> None:
-        original = self.module.AUTHORSHIP_RULES
-        mutation = dict(original)
-        mutation["human"] = mutation["human"]._replace(
-            fields=("kind", "model", "prompt_strategy"), value_field="model"
-        )
-        value = {
-            "kind": "human",
-            "model": "should-not-be-accepted",
-            "prompt_strategy": "should-not-be-accepted",
-        }
-        with mock.patch.object(self.module, "AUTHORSHIP_RULES", mutation):
-            with self.assertRaises(AssertionError):
-                with self.assertRaises(self.module.ImplementationRegistryError):
-                    self.module._validate_authorship(value, "human-agent-fields")
-
-    def test_model_normalization_mutation_is_caught(self) -> None:
-        original = self.module.authorship_trailer
-
-        def normalized(value: object) -> str:
-            return original(value).strip().lower()
-
-        value = {
-            "kind": "agent-assisted",
-            "model": "  Grok Bot/version? undisclosed  ",
-            "prompt_strategy": "compatibility probe",
-        }
-        with mock.patch.object(self.module, "authorship_trailer", normalized):
-            with self.assertRaises(AssertionError):
-                self.assertEqual(
-                    self.module.authorship_trailer(value),
-                    "Assisted-By:   Grok Bot/version? undisclosed  ",
-                )
 
     def test_comment_only_control_stays_green(self) -> None:
         protocol = PROTOCOL.read_text(encoding="utf-8") + "\n<!-- control comment -->\n"


### PR DESCRIPTION
Candidate, not a landing. Sole author; needs an independent exact-head review record before merge.

Refs #2948

## Summary
Classifies all eight `mock.patch.object` occurrences in `conformance/tests/test_implementations.py` as either genuine seam doubles or patch-then-call tautologies. Removes the four hollow tautological mutation tests that patched the unit under test and stayed green under production mutations, strengthens `test_human_authorship_forbids_model_and_prompt_strategy` to cover the combined model/prompt_strategy case, and demonstrates real test failures on production mutations.

## Classification Table (8/8)

| Line (prior to edit) | Enclosing Test / Class | Target Patched | Classification | Reason |
|---|---|---|---|---|
| 385 | `HostileRegistryInput.test_loads_through_the_shared_regular_file_reader` | `published_rows.read_regular_file` | Genuine seam double | Patches collaborator `published_rows.read_regular_file` (with `wraps`) to observe whether `load_implementations` delegates to the shared reader. Fails (`AssertionError`) if `load_implementations` bypasses the shared reader. |
| 461 | `OneRuleNoNetwork.test_main_calls_load_implementations` | `module.load_implementations` | Genuine seam double | Patches collaborator `load_implementations` to isolate CLI entrypoint `main()` and assert single-call coordination and returncode 0. Fails (`AssertionError`) if `main()` does not call `load_implementations()`. |
| 594 | `AuthorshipProjectionContract.test_mapping_mutations_break_document_parity` | `self.module.AUTHORSHIP_RULES` | Genuine seam double / dynamic parity proof | Patches input mapping to verify that `authorship_protocol_table` and `authorship_template_line` dynamically derive outputs from `AUTHORSHIP_RULES` rather than returning static text. Fails if renderers hardcode static strings or if trailers are swapped. |
| 601 | `AuthorshipProjectionContract.test_unknown_fallback_mutation_is_caught` | `self.module._authorship_rule` | Patch-then-call tautology | Patches `_authorship_rule` with mock returning `human_rule` and asserts `AssertionError` on `_assert_unknown_is_rejected()`. Never runs production `_authorship_rule`; stays GREEN if production falls back to `human`. |
| 612 | `AuthorshipProjectionContract.test_missing_agent_metadata_mutation_is_caught` | `self.module.AUTHORSHIP_RULES` | Patch-then-call tautology | Patches `AUTHORSHIP_RULES` with stripped `agent-assisted` and asserts `AssertionError` on `_validate_authorship`. Stays GREEN if production `AUTHORSHIP_RULES` omits required fields. |
| 630 | `AuthorshipProjectionContract.test_agent_only_metadata_on_human_mutation_is_caught` | `self.module.AUTHORSHIP_RULES` | Patch-then-call tautology | Patches `AUTHORSHIP_RULES` to admit agent fields on `human` and asserts `AssertionError` on `_validate_authorship`. Stays GREEN if production `AUTHORSHIP_RULES` admits agent fields on human. |
| 646 | `AuthorshipProjectionContract.test_model_normalization_mutation_is_caught` | `self.module.authorship_trailer` | Patch-then-call tautology | Patches `authorship_trailer` with a locally normalizing wrapper and asserts `AssertionError` on its own wrapper. Stays GREEN if production `authorship_trailer` normalizes the model string. |
| 720 | `PublicImageValidator.test_row_validation_goes_through_the_public_validator` | `self.module.validate_image_reference` | Genuine seam double | Patches collaborator `validate_image_reference` to return `"accepted"`, proving behavioural single-source delegation in `_validate_row`. Fails if `_validate_row` maintains duplicate regex matching. |

## Architectural Decisions

1. **Why lines 385, 461, and 720 are genuinely fine as written:**
   - They patch collaborator functions at legitimate seams (`published_rows.read_regular_file`, `load_implementations` as called by `main()`, and `validate_image_reference` as called by `_validate_row`).
   - Each verifies that the unit under test delegates to the single-source implementation rather than duplicating logic.
   - Mutating the production code under test causes each test to go RED with a named failure or error.

2. **Why line 594 is retained as a dynamic wiring proof:**
   - Unlike lines 601, 612, 630, and 646 (which mask production defects and stay green when production logic is mutated), line 594 executes the real production renderers `authorship_protocol_table()` and `authorship_template_line()`.
   - If someone replaces those renderers with hardcoded strings that match `PROTOCOL` and `REPORT_TEMPLATE`, line 594 immediately fails on all three subtests (`deleted`, `renamed`, `swapped`).
   - If someone swaps trailers in production `AUTHORSHIP_RULES`, line 594 fails.

3. **Why deleting the four hollow tests is superior to rewriting them:**
   - **Real behavioral tests already exist for each claim:**
     - Unknown-kind fallback is guarded by `test_unknown_kind_has_no_fallback`.
     - Missing agent metadata is guarded by `test_all_agent_kinds_require_current_structured_metadata` and `test_agent_assisted_requires_nonempty_model_and_prompt_strategy`.
     - Agent-only metadata on human is guarded by `test_human_authorship_forbids_model_and_prompt_strategy` (strengthened with the combined case).
     - Model opacity / non-normalization is guarded by `test_projection_is_exact_and_model_is_opaque`.
   - **Tests cannot mutate production source files on disk:** A unit test in `conformance/tests/test_implementations.py` cannot rewrite `conformance/implementations.py` during test execution without causing filesystem side effects, race conditions, and failures on read-only checkouts.
   - **Consistency with Slice B (#2940):** Commit `cd24c22c7` deleted the identical set of hollow `mock.patch.object` mutation tests for the projection pipeline.

## Verified Source Mutations

Each mutation was applied directly to production source code in `conformance/implementations.py` and executed against the test suite (`python3 -W error::ResourceWarning conformance/tests/test_implementations.py`):

1. **Mutation 1 (unknown-kind fallback):**
   - Production line: `conformance/implementations.py:117` (`return AUTHORSHIP_RULES.get(kind, AUTHORSHIP_RULES["human"])`)
   - Test RED: `conformance.tests.test_implementations.AuthorshipProjectionContract.test_unknown_kind_has_no_fallback`
   - First line of RED output:
     ```
     AssertionError: ImplementationRegistryError not raised
     ```

2. **Mutation 2 (missing agent metadata admitted):**
   - Production line: `conformance/implementations.py:32` (`AGENT_AUTHORSHIP_FIELDS = ("kind",)`)
   - Test RED: `conformance.tests.test_implementations.PositiveFixtureAndHostileMatrix.test_all_agent_kinds_require_current_structured_metadata`
   - First line of RED output:
     ```
     implementations.ImplementationRegistryError: agent-assisted authorship has unknown field(s): model, prompt_strategy
     ```

3. **Mutation 3 (agent-only metadata admitted on human):**
   - Production line: `conformance/implementations.py:31` (`HUMAN_AUTHORSHIP_FIELDS = ("kind", "model", "prompt_strategy")`)
   - Test RED: `conformance.tests.test_implementations.PositiveFixtureAndHostileMatrix.test_human_authorship_forbids_model_and_prompt_strategy`
   - First line of RED output:
     ```
     AssertionError: ImplementationRegistryError not raised
     ```

4. **Mutation 4 (model normalization / stripping / lowercasing):**
   - Production line: `conformance/implementations.py:140` (`authorship[rule.value_field].strip().lower()`)
   - Test RED: `conformance.tests.test_implementations.AuthorshipProjectionContract.test_projection_is_exact_and_model_is_opaque`
   - First line of RED output:
     ```
     AssertionError: 'Generated-By: generator/model-v1+build.7' != 'Generated-By: generator/model-v1+BUILD.7'
     ```

## Control Verification
- `test_comment_only_control_stays_green` passed and remained green throughout all runs.
- 44 tests pass in `conformance/tests/test_implementations.py`.

---

Current head `0551cfd7cc42fa57dec2f644692b08220020cad1` after the branch update. The earlier exact-head review record (8f2a6580a) carries forward under the checker-derived carry landed by #2955: `review-record-carry=derived reviewed=8f2a6580a merged=4d9871cb4 conditions=tree-equivalence+no-overlap-re-derived-by-checker`.
