### PR TITLE
chore(deps): land jsonschema 0.53.0 as one head

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2749,9 +2749,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.52.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
+checksum = "ca2ea2207f8ccb34b6d4d041fe9deb08fff3cbc43750012caa2c3d1e860188e4"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2778,22 +2778,23 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.52.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d90ea83fa606c96f0b4737ecedf1fa6b624272022edc42039565f8d8af0b78"
+checksum = "5426a01d944d044c9c5e459f603419d1b539358f5496b1041df45a7a86d2d38f"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.52.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4ab4cbe58181a117d8c3582844ce20b07184319b51ba6d756596c1c451aebc"
+checksum = "65b6ec7deaeaab6320efc3084d8a9e91d5b4985ee36ffffef45dbff9516ff7a8"
 dependencies = [
  "ahash",
  "bytecount",
  "fraction",
+ "getrandom 0.3.4",
  "num-cmp",
  "num-traits",
  "serde_json",
@@ -4240,9 +4241,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.52.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38a014525040cdc9893361b7419bcf1f43b7ba7055eabaf6d91d6b75caa8b3f"
+checksum = "fb406ba984c08d1b91781d7507d103296cf6dec3256c33c388b468957f4b43bb"
 dependencies = [
  "ahash",
  "fluent-uri",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,4 +115,4 @@ aya-log = "0.2"
 object = { version = "=0.36.7", default-features = false, features = ["elf", "read_core", "std"] }
 ratatui = "0.30"
 crossterm = "0.29"
-jsonschema = { version = "0.52", default-features = false, features = ["idna"] }
+jsonschema = { version = "0.53", default-features = false, features = ["idna"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.52.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
+checksum = "ca2ea2207f8ccb34b6d4d041fe9deb08fff3cbc43750012caa2c3d1e860188e4"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1511,22 +1511,23 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.52.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d90ea83fa606c96f0b4737ecedf1fa6b624272022edc42039565f8d8af0b78"
+checksum = "5426a01d944d044c9c5e459f603419d1b539358f5496b1041df45a7a86d2d38f"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.52.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4ab4cbe58181a117d8c3582844ce20b07184319b51ba6d756596c1c451aebc"
+checksum = "65b6ec7deaeaab6320efc3084d8a9e91d5b4985ee36ffffef45dbff9516ff7a8"
 dependencies = [
  "ahash",
  "bytecount",
  "fraction",
+ "getrandom 0.3.4",
  "num-cmp",
  "num-traits",
  "serde_json",
@@ -2213,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.52.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38a014525040cdc9893361b7419bcf1f43b7ba7055eabaf6d91d6b75caa8b3f"
+checksum = "fb406ba984c08d1b91781d7507d103296cf6dec3256c33c388b468957f4b43bb"
 dependencies = [
  "ahash",
  "fluent-uri",


### PR DESCRIPTION
## Summary

Head: `4b6ea79ebe96e3596899f95366eefa2254021a5e`

Candidate, not a landing. Sole author; needs an independent exact-head review record before merge.

This supersedes #2950 and #2949. Dependabot opened the 0.53.0 bump as two complementary halves: the root requirement plus workspace `Cargo.lock` on one PR, and `fuzz/Cargo.lock` on the other. On each head alone the other lock is stale and `cargo metadata --locked` exits 101. The fuzz lane guards exactly that (`.github/workflows/fuzz-smoke.yml` triggers on the root manifest and runs `(cd fuzz && cargo metadata --locked)`), so landing either half would leave main failing a guarded lane.

This head carries all three files on 0.53.0: root `Cargo.toml`, workspace `Cargo.lock`, and `fuzz/Cargo.lock`.

Refs #2950
Refs #2949

I will close the two Dependabot PRs by hand after this lands. A closing keyword on those numbers does the wrong thing.

## Lock proof

Regenerated both locks with this toolchain (`CARGO_INCREMENTAL=0 cargo update -p jsonschema --precise 0.53.0` at the workspace root and again with `--manifest-path fuzz/Cargo.toml`). Not copied from Dependabot. The regenerated files are byte-identical to Dependabot's halves:

- `Cargo.lock` git hash-object `f1c46522750859316d09f64daa5828ae13a4eca0` matches `origin/dependabot/cargo/jsonschema-0.53.0:Cargo.lock`
- `fuzz/Cargo.lock` git hash-object `0c5caa567da0eb009b966c927c07d08cd7501733` matches `origin/dependabot/cargo/fuzz/jsonschema-0.53.0:fuzz/Cargo.lock`

`cargo metadata --locked` exit codes on this head:

- workspace: 0
- fuzz: 0

## Behaviour

Cited from the independent review already recorded on #2950 and #2949, not re-derived here: 0.53.0's validation changes are Draft-4 integer handling and numeric `uniqueItems` only. All 21 of our schemas are draft 2020-12, our `uniqueItems` uses are string-only, we do not enable `arbitrary-precision`, differential probes were 15/16 identical with the one delta stricter and out of scope.

Re-run on this combined head (worktree `assay-jsonschema-combined`, `CARGO_INCREMENTAL=0`):

- assay-core --lib: 980 passed
- assay-core jsonschema_semantics_probe: 8 passed
- assay-core policy_state_cache: 14 passed
- assay-metrics: 65 passed
- assay-cli receipt_schema_registry_test: 16 passed
- assay-cli agent_plugin_package_contract: 10 passed
- assay-cli coverage_contract: 3 passed
- assay-cli policy_validate_machine_contract: 18 passed, 1 ignored
- total: 1114 passed, 0 failed

`cargo fmt --all -- --check` exit 0. `cargo clippy -p assay-core -p assay-cli -p assay-metrics -p assay-evidence --all-targets -- -D warnings` exit 0.

## Test plan

- [x] Both `cargo metadata --locked` commands exit 0
- [x] Combined-head suites above, 1114 passed
- [ ] Independent exact-head review record before merge

Made with [Cursor](https://cursor.com)