### PR TITLE
ci(dependabot): fold cargo / and /fuzz into one updater

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,17 +24,41 @@ updates:
       # bencherdev/bencher: pinned to @main SHA, can cause update conflicts
       - dependency-name: "bencherdev/bencher"
 
-  # Cargo - weekly dependency updates
+  # Cargo - weekly dependency updates, including the fuzz crate's own lockfile.
+  #
+  # `Cargo.toml` sets `exclude = ["fuzz"]`, so a root-only cargo updater never sees this tree and
+  # `fuzz/Cargo.lock` had no updater at all: it sat at workspace 3.34.0 against a 3.35.0 tree,
+  # missing a dependency edge, holding six advisories the root lock had already moved past. The
+  # lock is kept rather than deleted — cargo-fuzz's own generated `.gitignore` covers
+  # `target/corpus/artifacts/coverage` and not `Cargo.lock`, and this is a `publish = false` binary
+  # crate, for which committing the lock is the Cargo convention — so it needs an updater to match
+  # the staleness assertion the fuzz lane now runs. That assertion is a separate
+  # `cargo metadata --locked` step, not a flag on the fuzz run: `cargo fuzz run` has no `--locked`.
+  #
+  # Two independent cargo updaters (`/` and `/fuzz`) then opened complementary halves of one bump:
+  # each PR left the other lock stale, and `cargo metadata --locked` failed on the unmoved tree.
+  # `directories` plus `group-by: dependency-name` keeps fuzz covered without splitting a shared
+  # dependency into two PRs. Incompatible version constraints still fall back to separate PRs.
   - package-ecosystem: "cargo"
-    directory: "/"
+    directories:
+      - "/"
+      - "/fuzz"
     schedule:
       interval: "weekly"
       day: "monday"
     groups:
       # These two move together through the digest crate line and do not land
-      # reliably as separate PRs.
+      # reliably as separate PRs. Listed first so first-match keeps them together
+      # instead of the per-name group below splitting them.
       crypto-digest-line:
         patterns:
+          - "sha2"
+          - "hmac"
+      # One PR per remaining dependency across both cargo trees, not one PR per
+      # directory. Version updates only; security updates stay ungrouped.
+      across-cargo-trees:
+        group-by: dependency-name
+        exclude-patterns:
           - "sha2"
           - "hmac"
     commit-message:
@@ -100,33 +124,6 @@ updates:
     labels:
       - "dependencies"
       - "python"
-    open-pull-requests-limit: 5
-    cooldown:
-      default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 7
-
-  # Cargo - the fuzz crate carries its own lockfile.
-  #
-  # `Cargo.toml` sets `exclude = ["fuzz"]`, so the root cargo entry above never sees this tree and
-  # `fuzz/Cargo.lock` had no updater at all: it sat at workspace 3.34.0 against a 3.35.0 tree,
-  # missing a dependency edge, holding six advisories the root lock had already moved past. The
-  # lock is kept rather than deleted — cargo-fuzz's own generated `.gitignore` covers
-  # `target/corpus/artifacts/coverage` and not `Cargo.lock`, and this is a `publish = false` binary
-  # crate, for which committing the lock is the Cargo convention — so it needs an updater to match
-  # the staleness assertion the fuzz lane now runs. That assertion is a separate
-  # `cargo metadata --locked` step, not a flag on the fuzz run: `cargo fuzz run` has no `--locked`.
-  - package-ecosystem: "cargo"
-    directory: "/fuzz"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    commit-message:
-      prefix: "chore(deps)"
-    labels:
-      - "dependencies"
-      - "rust"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Summary

Head: `67276383e2f8b7266c73071ddd22f2389e9ee8ed`

Candidate, not a landing. Sole author; needs an independent exact-head review record before merge.

This is CI configuration only. It does not carry the jsonschema 0.53.0 bump.

The root `Cargo.toml` sets `exclude = ["fuzz"]`, so Dependabot needed a second cargo updater for `/fuzz`. Those two updaters do not coordinate. Any dependency present in both trees produces two PRs, each with the other lock stale, each failing `cargo metadata --locked`. That is what happened to the jsonschema 0.53.0 pair.

GitHub's Dependabot options reference documents the fix: `directories` (plural) takes a list in one updater, and a group with `group-by: dependency-name` "create[s] a single pull request for each dependency update across all specified directories, rather than separate pull requests per directory". It requires the same ecosystem (both cargo), applies to version updates only, and falls back to separate PRs if the directories have incompatible version constraints — an acceptable, visible degradation, not a silent one.

I concluded `directories` is the right tool here, not a tidy config that still splits. `directories` alone is not enough (Dependabot still opened one PR per directory before `group-by` existed). The pair is what stops the recurrence.

Refs #2950
Refs #2949

## What changed

One cargo updater with `directories: ["/", "/fuzz"]`. The old `/fuzz` block is gone. The load-bearing fuzz comment is carried onto the combined entry, plus a short note on why the two updaters were folded.

### Groups

- `crypto-digest-line` is unchanged (`sha2` + `hmac`) and listed first. Official rule: if a dependency matches more than one group, it is included in the first group that it matches.
- `across-cargo-trees` uses `group-by: dependency-name` for everything else, with `exclude-patterns: [sha2, hmac]` so a later reorder cannot split the digest line.
- Both `sha2` and `hmac` appear in `fuzz/Cargo.lock` today, so the digest group can still span both trees.

### `open-pull-requests-limit` and cooldown

- Root was 10, fuzz was 5, cooldown was already identical.
- Combined entry keeps 10. Dropping to 5 would silently cut root capacity now that one updater covers both trees.

### Ignores now also apply to `/fuzz`

Checked one by one, not asserted wholesale. Each reason is a property of the dependency (or of Assay's MSRV / coordinated pins), not of which tree:

- **rand / rand_core** (semver-major): ADR-020, trait incompatibility with ed25519-dalek. Direct 0.8 deps in assay-core, assay-cli, assay-evidence, assay-sim, assay-registry. Fuzz does not declare them; the lock already has 0.8 and 0.10 as transitives. A fuzz-only major bump would still compile those path deps. Correct to ignore on fuzz.
- **nix** (semver-major): Clippy ICE on 0.31. Direct 0.27 deps in assay-core, assay-cli, assay-common, assay-runner-linux. Fuzz lock already has 0.27.1 and 0.31.3. The ignore blocks the next major. Correct: the same path deps compile under cargo fuzz.
- **aya-ebpf / aya-log-ebpf** (all updates): coordinated git-tag pins in assay-ebpf. Absent from the fuzz manifest and lock. No-op on fuzz today; correct if they appear, because the pin is a coordinated manual bump.
- **rusqlite** (all updates): 0.38+ dropped u64 FromSql/ToSql. Direct in assay-core 0.31. Fuzz lock has 0.31.0 via that path dep. A fuzz-only bump compiles assay-core against 0.38+ and breaks the same way. Correct.
- **sysinfo** (semver-major): breaking API at 0.38+. Direct in assay-cli 0.30 (optional in assay-core). Fuzz lock has 0.30.13. Same path-dep reason. Correct.
- **serial_test** (semver-major): needs Rust 1.93.1, above the public 1.89 MSRV. Dev-dep in assay-core, assay-cli, assay-registry. Absent from the fuzz lock (fuzz targets set `test = false`). No-op on fuzz today; MSRV is a repo property if it appears. Correct.

## Validation before push

- YAML parse: ok
- Structural check: one cargo block, `directories: ["/", "/fuzz"]`, no leftover singular `directory`, both groups present
- JSON Schema: `SCHEMA_OK` against schemastore `dependabot-2.0.json` (`https://json.schemastore.org/dependabot-2.0.json`, title "GitHub Dependabot v2 config")
- `scripts/ci/test-check-assay-action-pin.sh` and `scripts/ci/check-assay-action-pin.sh`: pass (`pin_exit=0`). The assay-action ignore is untouched.

## Test plan

- [x] File parses and validates against the Dependabot v2 schema
- [x] Assay-action consumer pin contract still green
- [ ] Independent exact-head review record before merge
- [ ] After merge, the next shared cargo bump should be one PR across `/` and `/fuzz`, not two complementary halves

Made with [Cursor](https://cursor.com)