### PR TITLE
chore(ci): ignore the aya stack in Dependabot, it moves as one unit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,9 +84,17 @@ updates:
       # Revisit when Clippy is updated or nix stabilizes
       - dependency-name: "nix"
         update-types: ["version-update:semver-major"]
-      # assay-ebpf pins aya-ebpf and aya-log-ebpf to the same git tag; bump both together manually
+      # The aya stack moves as one unit or not at all (#2972). assay-ebpf pins aya-ebpf and
+      # aya-log-ebpf to the git tag aya-v0.13.0, the workspace pins aya and aya-log to the
+      # matching released versions, and `object` is exact-pinned to the one aya resolves so a
+      # second object never enters the tree (Cargo.toml:114). Dependabot can only ever offer half
+      # the change: it opened aya 0.14.0, aya-log 0.3 and object =0.40.0 as three separate PRs,
+      # and object =0.40.0 satisfies neither aya version, since aya 0.14 requires object ^0.39.
       - dependency-name: "aya-ebpf"
       - dependency-name: "aya-log-ebpf"
+      - dependency-name: "aya"
+      - dependency-name: "aya-log"
+      - dependency-name: "object"
       # rusqlite 0.38+ removed FromSql/ToSql impl for u64; requires code migration
       # Manual upgrade path: change row.get<_, Option<u64>>() to row.get<_, Option<i64>>().map(|v| v as u64)
       - dependency-name: "rusqlite"


### PR DESCRIPTION
**Candidate, not a landing.** Head SHA `a9427c1ae4e3ee0b5b1c1bd2b0d2e4b83e0ad0ba`. Sole author; needs an independent exact-head review record before merge.

Adds `aya`, `aya-log` and `object` to the cargo `ignore:` list, beside `aya-ebpf` and `aya-log-ebpf` which were already there.

## Why

The five pins move as one unit and Dependabot can only ever offer part of the change. Measured on `origin/main` and crates.io:

- `Cargo.toml:112-115` pins `aya = "0.13.0"`, `aya-log = "0.2"`, and `object = { version = "=0.36.7", ... }` with the inline reason *"Pin to aya's object 0.36.7 (no second object line for P1 ELF reads)"*.
- `crates/assay-ebpf/Cargo.toml:27-28` pins `aya-ebpf` and `aya-log-ebpf` to the git tag `aya-v0.13.0`.
- crates.io: `aya 0.14.0` requires `object ^0.39`.

Dependabot opened the upgrade as three separate PRs and each was wrong alone:

| PR | proposed | why it fails |
|---|---|---|
| #2966 | `aya` 0.13.0 → 0.14.0 | leaves the kernel-side crates on the `aya-v0.13.0` git tag — the desync the existing ignore entries exist to prevent |
| #2967 | `aya-log` 0.2 → 0.3 | same shape against `aya-log-ebpf` |
| #2968 | `object` `=0.36.7` → `=0.40.0` | satisfies neither aya version: 0.13 resolves 0.36.7, and `^0.39` excludes 0.40.0 |

All three are closed. The coordinated upgrade is #2972.

## What this changes

Only which updates Dependabot offers. No pin moves, no dependency resolves differently, and the existing `crypto-digest-line` and `across-cargo-trees` groups are untouched. `yaml.safe_load` parses the file and the cargo updater still carries `directories: ["/", "/fuzz"]` with both groups.

The ignore list is not a statement that these upgrades are unwanted — it records that they are manual, exactly as the two `-ebpf` entries already did.

Refs #2972

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Current head `5f0af4fe8b7f715fe249d2aa1c8fd1c5723d56be`. Review record: https://github.com/Rul1an/assay/pull/2974#issuecomment-5648292325
