### PR TITLE
trace: bound truncation readings to medium declaration

### DIFF
--- a/crates/assay-core/src/storage/store_observations.rs
+++ b/crates/assay-core/src/storage/store_observations.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::trace::observation::{
-    bound_sha256, decode_stored_observation, episode_column_values, read_truncation,
-    step_column_values, tool_call_column_values, tool_call_target_key, ObservedTraceEvent,
-    TruncationObservation, TruncationReading,
+    bound_sha256, decode_stored_observation, episode_column_values, pointer_covers,
+    read_truncation, step_column_values, tool_call_column_values, tool_call_target_key,
+    ObservedTraceEvent, TruncationObservation, TruncationReading,
 };
 use crate::trace::schema::{TraceEvent, TruncationMeta};
 use anyhow::Context;
@@ -135,6 +135,11 @@ impl Store {
         let conn = self.conn.lock().unwrap();
         let (truncations, bound, require_parity) = match kind {
             "episode_start" => {
+                if !pointer_covers("/input/prompt", pointer) && !pointer_covers("/meta", pointer) {
+                    anyhow::bail!(
+                        "pointer {pointer:?} is outside stored column map for episode_start"
+                    );
+                }
                 let (prompt, meta): (Option<String>, Option<String>) = conn.query_row(
                     "SELECT prompt, meta_json FROM episodes WHERE id = ?1",
                     rusqlite::params![key],

--- a/crates/assay-core/src/trace/observation.rs
+++ b/crates/assay-core/src/trace/observation.rs
@@ -232,11 +232,9 @@ pub fn read_truncation(
         if !scope_covers_field(&obs.scope, pointer) {
             continue;
         }
-        if obs
-            .losses
-            .iter()
-            .any(|loss| pointer_covers(pointer, &loss.field))
-        {
+        if obs.losses.iter().any(|loss| {
+            pointer_covers(pointer, &loss.field) || pointer_covers(&loss.field, pointer)
+        }) {
             continue;
         }
         return TruncationReading::MeasuredClean {
@@ -272,14 +270,14 @@ fn reported_loss_at_or_under(
 ) -> bool {
     truncations
         .iter()
-        .any(|loss| pointer_covers(pointer, &loss.field))
+        .any(|loss| pointer_covers(pointer, &loss.field) || pointer_covers(&loss.field, pointer))
         || observations
             .iter()
             .filter(|obs| is_known_version(obs))
             .any(|obs| {
-                obs.losses
-                    .iter()
-                    .any(|loss| pointer_covers(pointer, &loss.field))
+                obs.losses.iter().any(|loss| {
+                    pointer_covers(pointer, &loss.field) || pointer_covers(&loss.field, pointer)
+                })
             })
 }
 
@@ -315,8 +313,7 @@ fn scope_covers_field(scope: &[String], pointer: &str) -> bool {
     scope.iter().any(|s| pointer_covers(s, pointer))
 }
 
-/// `parent` covers `child` when they are equal or `child` is a descendant segment.
-fn pointer_covers(parent: &str, child: &str) -> bool {
+pub(crate) fn pointer_covers(parent: &str, child: &str) -> bool {
     child == parent
         || (child.len() > parent.len()
             && child.as_bytes().get(parent.len()) == Some(&b'/')

--- a/crates/assay-core/src/trace/upgrader.rs
+++ b/crates/assay-core/src/trace/upgrader.rs
@@ -91,6 +91,10 @@ fn observe_event(
     mut event: TraceEvent,
     mut prior: Vec<TruncationObservation>,
 ) -> ObservedTraceEvent {
+    // Foreign observations with no losses must not be carried forward across stages.
+    // Otherwise, our ingest writer attaches its own digest binding to the foreign observation,
+    // falsely certifying foreign completeness as origin completeness under our key.
+    prior.retain(|obs| !obs.losses.is_empty());
     if let Some(obs) = scan_and_truncate(&mut event) {
         prior.push(obs);
     }

--- a/crates/assay-core/tests/truncation_observations.rs
+++ b/crates/assay-core/tests/truncation_observations.rs
@@ -1048,3 +1048,120 @@ fn test_15_jsonl_sqlite_media_parity_including_malformed_losses() -> anyhow::Res
     );
     Ok(())
 }
+
+#[test]
+fn probe_a_sqlite_reader_refuses_pointer_outside_stored_column_map() -> anyhow::Result<()> {
+    let store = Store::memory()?;
+    store.init_schema()?;
+
+    let event = TraceEvent::EpisodeStart(EpisodeStart {
+        episode_id: "ep-a".into(),
+        timestamp: 1,
+        input: json!({
+            "prompt": "short prompt",
+            "system": "also short system prompt"
+        }),
+        meta: Value::Null,
+    });
+    let line = serde_json::to_string(&event)?;
+    let observed = StreamUpgrader::new(Cursor::new(&line))
+        .observed()
+        .next()
+        .expect("one event")?;
+    store.insert_observed_event(&observed, None, None)?;
+
+    let prompt_reading =
+        store.read_truncation("episode_start", "ep-a", "/input/prompt", TRUSTED)?;
+    assert_eq!(
+        prompt_reading,
+        TruncationReading::MeasuredClean {
+            stage: UPGRADER_STAGE.into(),
+            ceiling: INGEST_STRING_CEILING,
+        }
+    );
+
+    let system_result = store.read_truncation("episode_start", "ep-a", "/input/system", TRUSTED);
+    assert!(
+        system_result.is_err(),
+        "read_truncation for /input/system must return Err because it is outside stored column map, but got: {:?}",
+        system_result
+    );
+    Ok(())
+}
+
+#[test]
+fn probe_b_loss_at_ancestor_pointer_covers_descendants() -> anyhow::Result<()> {
+    let loss = meta_loss("/meta", 5000, 4096, "sha-meta");
+    let obs = clean_observation(&["/content", "/meta"], vec![loss.clone()]);
+    let step = observed_step(vec![loss], obs);
+
+    let meta_reading = read_observed(&step, "/meta", TRUSTED);
+    assert_eq!(meta_reading, TruncationReading::Lossy);
+
+    let child_reading = read_observed(&step, "/meta/a", TRUSTED);
+    assert_eq!(
+        child_reading,
+        TruncationReading::Lossy,
+        "loss at /meta must make descendant /meta/a read Lossy, but got: {:?}",
+        child_reading
+    );
+    Ok(())
+}
+
+#[test]
+fn probe_c_foreign_empty_loss_observation_not_carried_at_ingest() -> anyhow::Result<()> {
+    let store = Store::memory()?;
+    store.init_schema()?;
+
+    let line = json!({
+        "type": "step",
+        "episode_id": "ep-c",
+        "step_id": "s1",
+        "idx": 0,
+        "timestamp": 1,
+        "kind": "llm_completion",
+        "name": "model",
+        "content": "hello",
+        "content_sha256": "abc",
+        "truncations": [],
+        "meta": null,
+        "observations": [{
+            "v": 1,
+            "stage": "vendor.exporter",
+            "ceiling": 4096,
+            "scope": ["/content", "/meta"],
+            "losses": []
+        }]
+    })
+    .to_string();
+
+    ensure_episode(&store, "ep-c")?;
+
+    let observed = StreamUpgrader::new(Cursor::new(&line))
+        .observed()
+        .next()
+        .expect("one event")?;
+    store.insert_observed_event(&observed, None, None)?;
+
+    let count: i64 = store.conn.lock().unwrap().query_row(
+        "SELECT COUNT(*) FROM trace_observations WHERE target_kind = 'step' AND target_key = 's1'",
+        [],
+        |r| r.get(0),
+    )?;
+    assert_eq!(
+        count, 1,
+        "only the fresh scan observation should be stored; foreign empty-loss observation must be dropped at ingest, but found {count} rows"
+    );
+
+    let vendor_reading = store.read_truncation("step", "s1", "/content", &["vendor.exporter"])?;
+    assert_ne!(
+        vendor_reading,
+        TruncationReading::MeasuredClean {
+            stage: "vendor.exporter".into(),
+            ceiling: 4096,
+        },
+        "foreign empty-loss observation must not yield MeasuredClean after ingest"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Candidate for #2957, not a landing. This PR is submitted for independent exact-head review and will not be self-merged or self-reviewed.

Refs #2957. Closes #2957.

## Behavioral Changes

Closes the three measured defects where readers answer beyond what the medium's own declaration covers (ADR-050):

1. **Defect A (SQLite reader refuses unmapped pointers):** In `crates/assay-core/src/storage/store_observations.rs`, `Store::read_truncation("episode_start", ...)` checks that the queried pointer is covered by the stored column map (`/input/prompt` or `/meta`). Pointers outside this map (e.g. `/input/system`) return `Err(...)` rather than answering `MeasuredClean` over data the medium never persisted.
2. **Defect B (Loss covers descendants):** In `crates/assay-core/src/trace/observation.rs`, `reported_loss_at_or_under` and `read_truncation` check `pointer_covers` bidirectionally (`pointer_covers(pointer, &loss.field) || pointer_covers(&loss.field, pointer)`). A loss at `/meta` correctly covers descendant pointer queries such as `/meta/a`.
3. **Defect C (Drop empty-loss foreign observations at ingest):** In `crates/assay-core/src/trace/upgrader.rs`, `observe_event` discards prior observations with empty `losses` (`prior.retain(|obs| !obs.losses.is_empty())`). Carried loss records are preserved across stages, but foreign empty-loss observations are not re-bound under our ingest writer's binding digest.

### Rationale for Defect C Fix (Dropping vs Carried Marker)
Dropping empty-loss observations at ingest is strictly superior to adding a `carried` flag:
- **No wire or schema churn:** Does not require modifying the DDL, database columns, JSONL schema, or breaking reader compatibility across tool versions.
- **Byte-exact truth:** The local ingest scan evaluates the actual incoming bytes and attaches its own fresh `MeasuredClean` observation. Carrying a foreign empty-loss record and writing it into SQLite creates duplicate rows bound with our `bound_sha256`, giving the false appearance of origin completeness verified under our key.
- **Loss preservation:** Upstream losses are still preserved intact through `prior.retain(|obs| !obs.losses.is_empty())`.

---

## Reproduction Outputs (Unpatched Tree - RED)

Command: `cargo test -p assay-core --test truncation_observations -- probe_`

### Probe A Failure
```text
---- probe_a_sqlite_reader_refuses_pointer_outside_stored_column_map stdout ----
thread 'probe_a_sqlite_reader_refuses_pointer_outside_stored_column_map' panicked at tests/truncation_observations.rs:1084:9:
read_truncation for /input/system must return Err because it is outside stored column map, but got: Ok(MeasuredClean { stage: "assay.trace.upgrader", ceiling: 4096 })
```

### Probe B Failure
```text
---- probe_b_loss_at_ancestor_pointer_covers_descendants stdout ----
thread 'probe_b_loss_at_ancestor_pointer_covers_descendants' panicked at tests/truncation_observations.rs:1102:5:
assertion `left == right` failed: loss at /meta must make descendant /meta/a read Lossy, but got: MeasuredClean { stage: "assay.trace.upgrader", ceiling: 4096 }
  left: MeasuredClean { stage: "assay.trace.upgrader", ceiling: 4096 }
 right: Lossy
```

### Probe C Failure
```text
---- probe_c_foreign_empty_loss_observation_not_carried_at_ingest stdout ----
thread 'probe_c_foreign_empty_loss_observation_not_carried_at_ingest' panicked at tests/truncation_observations.rs:1151:5:
assertion `left == right` failed: only the fresh scan observation should be stored; foreign empty-loss observation must be dropped at ingest, but found 2 rows (left: 2, right: 1)
```

---

## Verification & Must-Fail Controls (Patched Tree - GREEN)

- **Head SHA:** `6ea06fb53c5a5c4f5b1b4e9796016e789b26931a`
- **Worktree:** `/Users/roelschuurkes/wt-antigravity-2957`

### Suite Results
- `cargo test -p assay-core --test truncation_observations`: 18 passed; 0 failed
- `cargo test --all`: all workspace tests pass cleanly
- `cargo fmt --all -- --check`: passed
- `cargo clippy -p assay-core -- -D warnings`: passed
- Pre-push gates (fmt, clippy, Linux compilation gate): passed

### Must-Fail Controls on Mutated Lines
1. **Control A (mutate `store_observations.rs` to skip pointer check):** `probe_a` failed with `Ok(MeasuredClean)`. Reverted -> passed.
2. **Control B (mutate `observation.rs` to single-direction `pointer_covers`):** `probe_b` failed with `left: MeasuredClean, right: Lossy`. Reverted -> passed.
3. **Control C (mutate `upgrader.rs` to retain all prior observations):** `probe_c` failed with `left: 2, right: 1`. Reverted -> passed.
4. **Comment-only Control:** Adding comments to production code leaves all tests green.

---

## Call-Site Sweep & Impact Analysis

### 1. `read_truncation`
```text
crates/assay-core/src/storage/store_observations.rs:4:    read_truncation, step_column_values, tool_call_column_values, tool_call_target_key,
crates/assay-core/src/storage/store_observations.rs:128:    pub fn read_truncation(
crates/assay-core/src/storage/store_observations.rs:207:        Ok(read_truncation(
crates/assay-core/src/trace/observation.rs:218:pub fn read_truncation(
crates/assay-core/src/trace/observation.rs:257:    read_truncation(
crates/assay-core/tests/truncation_observations.rs:9:    bound_sha256, parse_observed_line, read_observed, read_truncation, tool_call_target_key,
crates/assay-core/tests/truncation_observations.rs:235:        store.read_truncation("step", "s1", "/content", TRUSTED)?,
crates/assay-core/tests/truncation_observations.rs:414:        store.read_truncation("episode_start", "ep-loss", "/input/prompt", TRUSTED)?,
crates/assay-core/tests/truncation_observations.rs:418:        store.read_truncation("episode_start", "ep-loss", "/meta/a/b", TRUSTED)?,
crates/assay-core/tests/truncation_observations.rs:477:        store.read_truncation("episode_start", "mcp-ep", "/input/prompt", TRUSTED)?,
crates/assay-core/tests/truncation_observations.rs:498:        store.read_truncation("step", "s1", "/content", TRUSTED)?,
crates/assay-core/tests/truncation_observations.rs:525:        store.read_truncation("step", "s1", "/content", TRUSTED)?,
crates/assay-core/tests/truncation_observations.rs:544:        store.read_truncation("episode_start", "ep-bind", "/input/prompt", TRUSTED)?,
crates/assay-core/tests/truncation_observations.rs:564:        store.read_truncation("episode_start", "ep-bind", "/input/prompt", TRUSTED)?,
crates/assay-core/tests/truncation_observations.rs:602:    let first_reading = store.read_truncation(
crates/assay-core/tests/truncation_observations.rs:626:        store.read_truncation(
crates/assay-core/tests/truncation_observations.rs:839:        read_truncation("/content", &[], &[in_memory], TRUSTED, true),
crates/assay-core/tests/truncation_observations.rs:941:        .map(|pointer| store.read_truncation(kind, key, pointer, TRUSTED))
crates/assay-core/tests/truncation_observations.rs:1073:    let prompt_reading = store.read_truncation("episode_start", "ep-a", "/input/prompt", TRUSTED)?;
crates/assay-core/tests/truncation_observations.rs:1082:    let system_result = store.read_truncation("episode_start", "ep-a", "/input/system", TRUSTED);
crates/assay-core/tests/truncation_observations.rs:1085:        "read_truncation for /input/system must return Err because it is outside stored column map, but got: {:?}",
crates/assay-core/tests/truncation_observations.rs:1155:    let vendor_reading = store.read_truncation("step", "s1", "/content", &["vendor.exporter"])?;
```
- **Impact:** `Store::read_truncation` now returns `Err` when queried on `episode_start` with pointers outside the column map (`/input/prompt`, `/meta`). All existing callers and tests query within valid column maps (`/input/prompt`, `/content`, `/args`, `/result`, `/meta`) and continue to function identically. `read_truncation` in `observation.rs` now properly reports `Lossy` for child pointers when an ancestor has a reported loss.

### 2. `read_observed`
```text
crates/assay-core/src/trace/observation.rs:252:pub fn read_observed(
crates/assay-core/tests/truncation_observations.rs:9:    bound_sha256, parse_observed_line, read_observed, read_truncation, tool_call_target_key,
crates/assay-core/tests/truncation_observations.rs:217:        read_observed(&parsed, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:225:        read_observed(&parsed, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:242:        read_observed(&control, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:260:        read_observed(&parsed, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:277:        read_observed(&observed, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:328:        read_observed(&observed, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:340:        read_observed(&observed, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:346:        read_observed(&trusted_obs, "/content", &[]),
crates/assay-core/tests/truncation_observations.rs:351:        read_observed(&trusted_obs, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:452:        read_observed(&otel_observed, "/input/prompt", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:469:        read_observed(&mcp_observed, "/input/prompt", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:766:        read_observed(&rerun, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:789:        read_observed(&rerun_empty, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:815:        read_observed(&parsed, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:825:        read_observed(&parsed, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:856:        read_observed(&observed, "/meta", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:860:        read_observed(&observed, "/meta/a", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:864:        read_observed(&observed, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:871:        read_observed(&observed, "/meta2", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:887:        read_observed(&observed, "/meta/a", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:892:        read_observed(&observed, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:903:        read_observed(&control, "/content", TRUSTED),
crates/assay-core/tests/truncation_observations.rs:930:        .map(|pointer| read_observed(&parsed, pointer, TRUSTED))
crates/assay-core/tests/truncation_observations.rs:1097:    let meta_reading = read_observed(&step, "/meta", TRUSTED);
crates/assay-core/tests/truncation_observations.rs:1100:    let child_reading = read_observed(&step, "/meta/a", TRUSTED);
```
- **Impact:** Delegates directly to `read_truncation`. Inherits bidirectional loss check behavior without signature changes.

### 3. `insert_observed*`
```text
crates/assay-core/src/storage/store_observations.rs:11:    pub fn insert_observed_event(
crates/assay-core/src/storage/store_observations.rs:19:        Self::insert_observed_in_tx(&tx, observed, run_id, test_id)?;
crates/assay-core/src/storage/store_observations.rs:24:    pub fn insert_observed_batch(
crates/assay-core/src/storage/store_observations.rs:33:            Self::insert_observed_in_tx(&tx, observed, run_id, test_id)?;
crates/assay-core/src/storage/store_observations.rs:39:    fn insert_observed_in_tx(
crates/assay-core/src/trace/ingest.rs:65:            store.insert_observed_batch(&batch, None, None)?;
crates/assay-core/src/trace/ingest.rs:70:        store.insert_observed_batch(&batch, None, None)?;
crates/assay-core/tests/truncation_observations.rs:496:    store.insert_observed_event(&clean, None, None)?;
crates/assay-core/tests/truncation_observations.rs:542:    store.insert_observed_event(&ep, None, None)?;
crates/assay-core/tests/truncation_observations.rs:601:    store.insert_observed_event(&first_tc, None, None)?;
crates/assay-core/tests/truncation_observations.rs:624:    store.insert_observed_event(&second_tc, None, None)?;
crates/assay-core/tests/truncation_observations.rs:670:    assert!(store.insert_observed_event(&observed, None, None).is_err());
crates/assay-core/tests/truncation_observations.rs:951:    store.insert_observed_event(observed, None, None)?;
crates/assay-core/tests/truncation_observations.rs:1031:    store.insert_observed_event(
crates/assay-core/tests/truncation_observations.rs:1071:    store.insert_observed_event(&observed, None, None)?;
crates/assay-core/tests/truncation_observations.rs:1143:    store.insert_observed_event(&observed, None, None)?;
```
- **Impact:** No changes made to `insert_observed*`. Receives filtered `ObservedTraceEvent` from `StreamUpgrader` where foreign empty-loss observations were dropped prior to storage.

---

Current head `91ea1d52f1eac0c49c52508b37aea083b196d6b1`. Review record: https://github.com/Rul1an/assay/pull/2977#issuecomment-5648315002 (carried to this head by the checker's own derivation after the branch update).
