### PR TITLE
ci: assert the fuzz lockfile is current from the required gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,8 +225,10 @@ jobs:
       # the selection there too rather than being shadowed by the script's own default.
       #
       # Scope, deliberately: no step in this job builds or tests the workspace -- checkout, two tool
-      # installs, a `sed`-only alignment check, `cargo-deny check` and two `cargo audit` runs. The
-      # only crates this job compiles are the dependency tools themselves, installed from source.
+      # installs, a `sed`-only alignment check, `cargo-deny check`, two `cargo audit` runs, and a
+      # read-only `cargo metadata --locked` staleness assertion over `fuzz/Cargo.toml` (#2975). The
+      # only crates this job compiles are the dependency tools themselves, installed from source;
+      # the metadata step resolves the fuzz graph without compiling anything.
       # `rust-toolchain.toml` stays the source for every job that compiles workspace code.
       RUSTUP_TOOLCHAIN: stable
     steps:
@@ -289,6 +291,23 @@ jobs:
           # to be quietly excused, which is the point.
           # Same isolated-db runner as the root audit / pre-push hook (CI-4F / #2188).
           ( cd "${RUNNER_TEMP}" && bash "${GITHUB_WORKSPACE}/scripts/ci/cargo-audit-with-isolated-db.sh" --file "${GITHUB_WORKSPACE}/fuzz/Cargo.lock" )
+
+      - name: Fuzz lockfile is current
+        # #2975: this assertion ran only in fuzz-smoke.yml, which is not a required context, so a
+        # PR that staled `fuzz/Cargo.lock` (e.g. #2970 bumping base64 in five manifests, none of
+        # them a fuzz file) stayed green on every required gate. This job owns the fuzz lockfile
+        # already (the audit above), has a toolchain (job-level RUSTUP_TOOLCHAIN), and is in the
+        # required gate's `needs:`, so the check runs on every PR with no path list to maintain.
+        # Not shared with the lane's inline form: that spelling is pinned by
+        # `scripts/ci/test-fuzz-lane-contract.sh` (which executes the lane's own run block) and
+        # selects the date-pinned fuzz toolchain, while this one resolves read-only under stable.
+        # The wrapper adds an exit code and nothing else; `--locked` also fails on registry or
+        # network faults, so the message must not name a cause -- Cargo's stderr stays the
+        # diagnosis. Pinned by `scripts/ci/test-fuzz-lock-required-gate.sh`.
+        run: |
+          set -euo pipefail
+          cargo metadata --locked --format-version 1 --manifest-path fuzz/Cargo.toml >/dev/null \
+            || { echo "::error::locked fuzz metadata validation failed; inspect the Cargo error above"; exit 1; }
 
   clippy:
     name: Clippy (deny warnings)
@@ -1176,6 +1195,7 @@ jobs:
           bash scripts/ci/test-ci-job-timeouts-contract.sh --self-test
           bash scripts/ci/test-classify-lightweight-changes.sh
           bash scripts/ci/test-deps-security-toolchain-contract.sh
+          bash scripts/ci/test-fuzz-lock-required-gate.sh
           bash scripts/ci/test-mcp-preflight-windows-contract.sh
           bash scripts/ci/test-reconcile-docs-auto-pr.sh
           bash scripts/ci/test-setup-rust-composite-contract.sh

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -73,6 +73,7 @@ HARDENING_RUN_SCRIPT = (
     "bash scripts/ci/test-ci-job-timeouts-contract.sh --self-test",
     "bash scripts/ci/test-classify-lightweight-changes.sh",
     "bash scripts/ci/test-deps-security-toolchain-contract.sh",
+    "bash scripts/ci/test-fuzz-lock-required-gate.sh",
     "bash scripts/ci/test-mcp-preflight-windows-contract.sh",
     "bash scripts/ci/test-reconcile-docs-auto-pr.sh",
     "bash scripts/ci/test-setup-rust-composite-contract.sh",

--- a/scripts/ci/test-ci-hardening-b1.sh
+++ b/scripts/ci/test-ci-hardening-b1.sh
@@ -611,6 +611,7 @@ required = (
     "bash scripts/ci/test-ci-job-timeouts-contract.sh --self-test",
     "bash scripts/ci/test-classify-lightweight-changes.sh",
     "bash scripts/ci/test-deps-security-toolchain-contract.sh",
+    "bash scripts/ci/test-fuzz-lock-required-gate.sh",
     "bash scripts/ci/test-mcp-preflight-windows-contract.sh",
     "bash scripts/ci/test-reconcile-docs-auto-pr.sh",
     "bash scripts/ci/test-setup-rust-composite-contract.sh",

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -106,6 +106,7 @@ HARDENING_STEP_COMMANDS = (
     "bash scripts/ci/test-ci-job-timeouts-contract.sh --self-test",
     "bash scripts/ci/test-classify-lightweight-changes.sh",
     "bash scripts/ci/test-deps-security-toolchain-contract.sh",
+    "bash scripts/ci/test-fuzz-lock-required-gate.sh",
     "bash scripts/ci/test-mcp-preflight-windows-contract.sh",
     "bash scripts/ci/test-reconcile-docs-auto-pr.sh",
     "bash scripts/ci/test-setup-rust-composite-contract.sh",

--- a/scripts/ci/test-fuzz-lock-required-gate.sh
+++ b/scripts/ci/test-fuzz-lock-required-gate.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# Contract: a stale fuzz/Cargo.lock must fail a required CI context on the PR that causes it.
+#
+# The staleness assertion (`cargo metadata --locked` against `fuzz/Cargo.toml`) exists in
+# `fuzz-smoke.yml`, which is not a required context, so it can find the defect without being
+# able to stop it (#2975). The fix puts the same assertion in a job the required `CI` gate
+# already waits on, on every PR, independent of any path list.
+#
+# This pins the wiring, not just the text: the invocation must be an active step in a job
+# that is in the `ci` rollup's `needs:` list, judged by its `name|result|expectation` triple,
+# and that job must have a Rust toolchain available. Mutants below prove each half red.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+ok() { echo "ok   $*"; }
+
+[[ -f "$WORKFLOW" ]] || fail "missing ${WORKFLOW#"${ROOT}"/}"
+
+SANDBOX_ROOT="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX_ROOT"' EXIT
+
+# Print the qualifying job id when the wiring holds; exit 1 otherwise.
+# Every assertion takes the workflow path so the mutants below exercise the same logic.
+check_workflow() {
+  python3 - "$1" <<'PY'
+import re
+import sys
+
+lines = open(sys.argv[1]).read().splitlines()
+
+# The `ci` rollup's needs: membership list (single-line form, as checked in).
+needs = []
+for i, line in enumerate(lines):
+    if line == "  ci:":
+        for follow in lines[i + 1 : i + 6]:
+            m = re.match(r"^    needs:\s*\[(?P<items>[^\]]*)\]\s*$", follow)
+            if m:
+                needs = [w.strip() for w in m.group("items").split(",") if w.strip()]
+                break
+        break
+if not needs:
+    sys.exit("the `ci` rollup has no readable `needs:` list")
+
+# Triples judged by the Evaluate step: job -> (var, expectation).
+triples = {}
+for line in lines:
+    m = re.match(r'^\s*"(?P<job>[A-Za-z0-9_-]+)\|\$\{(?P<var>[A-Z][A-Z0-9_]*)\}\|(?P<exp>[^"]*)"', line)
+    if m:
+        triples[m.group("job")] = (m.group("var"), m.group("exp"))
+
+# Result env bindings: VAR -> needs.job.
+bindings = {}
+for line in lines:
+    m = re.match(
+        r"^\s*(?P<var>[A-Z][A-Z0-9_]*):\s*\$\{\{\s*needs\.(?P<job>[A-Za-z0-9_-]+)\.result\s*\}\}\s*$",
+        line,
+    )
+    if m:
+        bindings[m.group("var")] = m.group("job")
+
+
+def job_block(name):
+    start = None
+    for i, line in enumerate(lines):
+        if line == f"  {name}:":
+            start = i
+            break
+    if start is None:
+        return []
+    end = next(
+        (
+            i
+            for i in range(start + 1, len(lines))
+            if re.match(r"^  [A-Za-z0-9_][A-Za-z0-9_-]*:\s*(?:#.*)?$", lines[i])
+        ),
+        len(lines),
+    )
+    return lines[start:end]
+
+
+def step_run_blocks(block):
+    """Yield (step_name, run_lines) for steps with a `run: |` body."""
+    out = []
+    i = 0
+    while i < len(block):
+        m = re.match(r"^      - (?:name:\s*(?P<name>.*?)\s*)?$", block[i])
+        if m:
+            step_name = (m.group("name") or "<unnamed>").strip()
+            # Wide window: comment blocks above `run: |` can be long, and a narrow
+            # window would stop seeing the step it already named.
+            for j in range(i, min(i + 40, len(block))):
+                if block[j].strip() == "run: |":
+                    indent = len(block[j]) - len(block[j].lstrip())
+                    body = []
+                    for k in range(j + 1, len(block)):
+                        ln = block[k]
+                        if ln.strip() and (len(ln) - len(ln.lstrip())) <= indent:
+                            break
+                        body.append(ln[indent + 2 :] if len(ln) > indent + 2 else "")
+                    out.append((step_name, body))
+                    break
+        i += 1
+    return out
+
+
+FORBIDDEN_CAUSE_WORDS = ("stale", "cargo update", "out of date", "outdated", "regenerate")
+
+for job in needs:
+    # The rollup must judge the job, not merely wait on it.
+    if job not in triples:
+        continue
+    var, _ = triples[job]
+    if bindings.get(var) != job:
+        continue
+    block = job_block(job)
+    if not block:
+        continue
+    text = "\n".join(block)
+    # A toolchain must be available: a rust setup action or an explicit selection.
+    if not (
+        "setup-rust" in text or "dtolnay/rust-toolchain" in text or "RUSTUP_TOOLCHAIN" in text
+    ):
+        continue
+    for step_name, body in step_run_blocks(block):
+        active = [ln for ln in body if ln.strip() and not ln.strip().startswith("#")]
+        hits = [
+            ln
+            for ln in active
+            if "cargo" in ln and "metadata" in ln and "--locked" in ln and "fuzz" in ln
+        ]
+        if not hits:
+            continue
+        # Only stdout may be redirected; Cargo's stderr stays the diagnosis.
+        if any("2>" in ln for ln in active):
+            sys.exit(f"`{job}` step `{step_name}` redirects stderr away from the log")
+        # The wrapper adds exit-code discipline and nothing else: it must not name a
+        # cause (`--locked` also fails on network, registry, or toolchain faults).
+        joined = "\n".join(active).lower()
+        for word in FORBIDDEN_CAUSE_WORDS:
+            if word in joined:
+                sys.exit(
+                    f"`{job}` step `{step_name}` diagnoses a cause "
+                    f"(`{word}`) it did not establish"
+                )
+        if not re.search(r"cargo error|error above|output above", joined):
+            sys.exit(f"`{job}` step `{step_name}` must point at Cargo's own error")
+        print(job)
+        sys.exit(0)
+
+sys.exit("no job in the required `CI` gate asserts the fuzz lock is current")
+PY
+}
+
+job="$(check_workflow "$WORKFLOW")" \
+  || fail "no job in the required CI gate asserts the fuzz lock is current (#2975)"
+ok "fuzz-lock assertion wired through required job \`${job}\`"
+
+# Mutants: each must turn red, naming the half that broke. A guard that stays green when
+# its wiring is cut is prose, not a gate.
+mutant() {
+  local name="$1"
+  local file="${SANDBOX_ROOT}/mutant.yml"
+  cp "$WORKFLOW" "$file"
+  shift
+  "$@" "$file" "$job"
+  if check_workflow "$file" >/dev/null 2>&1; then
+    fail "mutant stayed green: ${name}"
+  fi
+  ok "mutant red: ${name}"
+}
+
+comment_out_invocation() {
+  # Decoys in comments never execute; the check must not read them.
+  python3 - "$1" <<'PY'
+import sys
+
+path = sys.argv[1]
+out = []
+for line in open(path).read().splitlines():
+    if "metadata" in line and "--locked" in line and "fuzz" in line and "cargo" in line:
+        indent = line[: len(line) - len(line.lstrip())]
+        out.append(f"{indent}# {line.strip()}")
+    else:
+        out.append(line)
+open(path, "w").write("\n".join(out) + "\n")
+PY
+}
+
+drop_from_needs() {
+  # Waiting without judging (or neither) detaches the job from the gate.
+  python3 - "$1" "$2" <<'PY'
+import re
+import sys
+
+path, victim = sys.argv[1], sys.argv[2]
+out = []
+for line in open(path).read().splitlines():
+    m = re.match(r"^(    needs:\s*\[)([^\]]*)(\].*)$", line)
+    if m:
+        items = [w.strip() for w in m.group(2).split(",") if w.strip() != victim]
+        line = f"{m.group(1)}{', '.join(items)}{m.group(3)}"
+    out.append(line)
+open(path, "w").write("\n".join(out) + "\n")
+PY
+}
+
+drop_triple() {
+  # Membership without a triple is waited on and then ignored.
+  python3 - "$1" "$2" <<'PY'
+import sys
+
+path, victim = sys.argv[1], sys.argv[2]
+lines = open(path).read().splitlines()
+lines = [ln for ln in lines if f'"{victim}|${{' not in ln]
+open(path, "w").write("\n".join(lines) + "\n")
+PY
+}
+
+strip_toolchain() {
+  # An assertion in a job without a toolchain never runs its cargo command.
+  python3 - "$1" "$2" <<'PY'
+import re
+import sys
+
+path, victim = sys.argv[1], sys.argv[2]
+lines = open(path).read().splitlines()
+start = next(i for i, ln in enumerate(lines) if ln == f"  {victim}:")
+end = next(
+    (
+        i
+        for i in range(start + 1, len(lines))
+        if re.match(r"^  [A-Za-z0-9_][A-Za-z0-9_-]*:\s*(?:#.*)?$", lines[i])
+    ),
+    len(lines),
+)
+block = lines[start:end]
+block = [
+    ln
+    for ln in block
+    if "setup-rust" not in ln
+    and "dtolnay/rust-toolchain" not in ln
+    and "RUSTUP_TOOLCHAIN" not in ln
+]
+open(path, "w").write("\n".join(lines[:start] + block + lines[end:]) + "\n")
+PY
+}
+
+hide_stderr() {
+  # A stderr redirect keeps the step green-shaped while swallowing the diagnosis.
+  python3 - "$1" <<'PY'
+import sys
+
+path = sys.argv[1]
+out = []
+for line in open(path).read().splitlines():
+    if "metadata" in line and "--locked" in line and "fuzz" in line and "cargo" in line:
+        line = line.replace(">/dev/null", ">/dev/null 2>/dev/null")
+    out.append(line)
+open(path, "w").write("\n".join(out) + "\n")
+PY
+}
+
+claim_a_cause() {
+  # Naming one cause for every `--locked` failure misdiagnoses outages as staleness.
+  python3 - "$1" <<'PY'
+import sys
+
+path = sys.argv[1]
+out = []
+for line in open(path).read().splitlines():
+    if "::error::" in line and "fuzz metadata" in line:
+        line = line.replace("validation failed", "is stale; run cargo update --workspace")
+    out.append(line)
+open(path, "w").write("\n".join(out) + "\n")
+PY
+}
+
+mutant "comment-only invocation" comment_out_invocation
+mutant "job dropped from needs" drop_from_needs
+mutant "triple dropped from gate" drop_triple
+mutant "toolchain stripped" strip_toolchain
+mutant "stderr redirected" hide_stderr
+mutant "cause claimed" claim_a_cause


### PR DESCRIPTION
**Candidate, not a landing.** Head SHA `60bb9e86c1c99334d825dfaf35bd45209ceafbee`. Built by Muse; needs an independent exact-head review record before merge.

## Problem

The assertion that `fuzz/Cargo.lock` is current existed, worked, and could not block a merge. It ran only in `fuzz-smoke.yml`, which is not a required context, and `git grep -n "manifest-path fuzz\|cd fuzz"` over `ci.yml` returned nothing.

It has now cost real work three times: the 6.2.0 and 6.2.1 bumps left the lock stale until #2930 re-synced it, #2950/#2949 each carried one half of a two-lock change, and #2970 bumped `base64` in five crate manifests while touching no fuzz file at all — `fuzz/Cargo.toml` path-depends on three of those crates, so the lock went stale and the defect was invisible in the PR's own diff.

## Change

The assertion moves into `deps-security`, which already owns the fuzz lockfile through its isolated-db audit, already has a toolchain, and is in the required `CI` gate's `needs:` list. It therefore runs on every pull request with no path list to maintain. `scripts/ci/test-fuzz-lock-required-gate.sh` is the contract test.

Not shared with the lane's inline form: that spelling is pinned by `scripts/ci/test-fuzz-lane-contract.sh`, which executes the lane's own run block and selects the date-pinned fuzz toolchain, while this one resolves read-only under stable.

## Evidence

| step | result |
|---|---|
| clean tree baseline | `cargo metadata --locked --manifest-path fuzz/Cargo.toml` rc=0 |
| contract test, pre-fix | `FAIL: no job in the required CI gate asserts the fuzz lock is current (#2975)`, rc=1 |
| #2970 reconstruction (base64 `0.22`→`0.23` in the five manifests, 7 lines, no fuzz file) | `error: cannot update the lock file .../fuzz/Cargo.lock because --locked was passed`, rc=101 |
| must-fail control (regenerate the fuzz lock) | rc=0; probe then fully reverted |
| contract test, post-fix | passes through `deps-security`; all six mutants red (comment-only, dropped-from-needs, dropped-triple, stripped-toolchain, stderr-redirect, cause-claimed) |

Siblings green: b1, gate-expectations, fuzz-lane, plugin-versions, audit-isolated-db, gate-coverage (`ci-gate-coverage=passed`), shellcheck, YAML parse with `needs:` unchanged, `git diff --check`, `cargo fmt --check`.

## The workspace-lock-only question, answered rather than deferred

The issue asked whether a change moving only the workspace `Cargo.lock` is covered. Measured: with the workspace lock physically removed, the fuzz assertion still returns rc=0 — the workspace lock is not an input to the fuzz resolve, because `Cargo.toml` sets `exclude = ["fuzz"]` and the fuzz tree carries its own lockfile. So a workspace-lock-only change cannot stale it. And since the check now runs on every PR regardless of paths, the `paths:` hole is moot for staleness. Option 3 from the issue is deliberately not taken.


## A third coupled list, found by the hook

The first commit updated two of the three places the hardening step's invocation list lives and was refused on push by `editor-release-hook-precommit-consumer`: `HARDENING_RUN_SCRIPT` in `conformance/tests/test_completion_scope.py` is compared line-for-line against the live step, and it was stale.

Worth recording rather than just fixing, because the builder traced why the earlier guard missed it: `test-ci-hardening-b1.sh` checks the live step against **its own** copy of the list, which had been updated, so it stayed green and could not see the stale third copy. `test_completion_scope.py` would have caught it but no commit-stage hook runs it, and the consumer hook is `stages: [pre-push]` by design. So the pre-push refusal was the earliest automatic guard in the path - the system working, not failing.

The structural point outlasts this PR: the b1 `required` tuple and `HARDENING_RUN_SCRIPT` are the same rule written twice, and nothing pins them to each other - only each independently matching the live step. That is the drift shape the repo's own "one rule, one function" contract names. Filed separately rather than widened into this slice.

## Provenance

Built by Muse. Committed from the owner checkout because the `codex-host-proof-node-contract` pre-commit hook cannot run in Muse's sandbox, where `os.userInfo()` raises `uv_os_get_passwd ENOENT` for a user with no passwd entry — reproduced with bare `node -e "require('os').userInfo()"`, zero repo input, so environmental and pre-existing. **No hook was skipped**: all of them ran on the machine where they can run.

Refs #2975

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Current head `151f1cd17986abd3adde8bce21ae6874bf609bed`. Review record: https://github.com/Rul1an/assay/pull/2978#issuecomment-5648749370 (carried by the checker's derivation).
