### PR TITLE
evidence: record delegated exec outside privileged-mcp-action/v0

### DIFF
--- a/crates/assay-cli/tests/delegated_exec_observation_v0.rs
+++ b/crates/assay-cli/tests/delegated_exec_observation_v0.rs
@@ -1,0 +1,149 @@
+//! Focused #2512 contract: a delegated-exec observation can live in a bundle
+//! outside privileged-mcp-action/v0 without becoming a whole-action cell.
+//!
+//! Named assertions are the must-bite: drop the content-address binding, or
+//! move the schema into a v0 namespace, and this file fails on that name.
+
+use assay_evidence::crypto::id::compute_content_hash;
+use assay_evidence::{
+    delegated_exec_observation_event, BundleWriter, EvidenceEvent,
+    DELEGATED_EXEC_OBSERVATION_SCHEMA,
+};
+use assert_cmd::Command;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::path::Path;
+
+const V0_NAMESPACES: &[&str] = &[
+    "assay.enforcement_decision.",
+    "assay.denied_call_observation.",
+    "assay.manifest_establish.",
+];
+
+const DECISION_NON_CLAIMS: &[&str] = &[
+    "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+    "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
+    "credential referenced by alias only, never the token or declared scopes",
+    "deny is fail-closed caution and allow is a policy decision \u{2014} neither is a maliciousness verdict",
+    "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)",
+];
+
+const TOOL: &str = "github.add_deploy_key";
+const DIGEST: &str = "sha256:c3ff823d7fb2ee33b9f1a3f7be6eaf849acb980b6ec960731506436b56384dfc";
+const SOURCE: &str = "urn:assay:test";
+const RUN_ID: &str = "run-delegated-exec";
+const CHILD_ARGV: &[u8] = b"child-tool --repo acme/prod-app";
+
+fn decision_event(seq: u64) -> EvidenceEvent {
+    let payload = json!({
+        "schema": "assay.enforcement_decision.v0",
+        "caller": {"id": "ci-agent"},
+        "tool": {"name": TOOL, "action_class": "github_deploy_key"},
+        "action": {
+            "verb": "create",
+            "resource_type": "github_deploy_key",
+            "target": {"provider": "github", "owner": "acme", "repo": "prod-app"},
+            "target_digest": DIGEST,
+        },
+        "decision": "deny",
+        "reason": "no_declared_allowance",
+        "fail_closed": true,
+        "drift_state": "not_evaluated",
+        "credential_alias": "gh-deploy",
+        "non_claims": DECISION_NON_CLAIMS,
+    });
+    EvidenceEvent::new(
+        "assay.enforcement_decision.v0",
+        SOURCE,
+        RUN_ID,
+        seq,
+        payload,
+    )
+}
+
+fn write_bundle(path: &Path, events: Vec<EvidenceEvent>) {
+    let file = File::create(path).expect("create bundle");
+    let mut writer = BundleWriter::new(file);
+    writer.add_events(events);
+    writer.finish().expect("finish bundle");
+}
+
+fn verify_v0(bundle: &Path) -> Value {
+    let output = Command::cargo_bin("assay")
+        .expect("assay binary")
+        .args(["evidence", "verify-privileged-mcp-action"])
+        .arg(bundle)
+        .args(["--format", "json"])
+        .output()
+        .expect("run v0 verifier");
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "v0 verifier must accept the bundle: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("verify report is JSON")
+}
+
+#[test]
+fn delegated_exec_observation_is_present_content_addressed_and_ignored_by_v0() {
+    assert!(
+        !V0_NAMESPACES
+            .iter()
+            .any(|prefix| DELEGATED_EXEC_OBSERVATION_SCHEMA.starts_with(prefix)),
+        "delegated_exec_schema_must_stay_outside_privileged_mcp_action_v0_namespaces"
+    );
+
+    let observation = delegated_exec_observation_event(SOURCE, RUN_ID, 1, "child-tool", CHILD_ARGV)
+        .expect("producer emits observation");
+    assert_eq!(observation.type_, DELEGATED_EXEC_OBSERVATION_SCHEMA);
+    assert_eq!(
+        observation.payload["schema"],
+        DELEGATED_EXEC_OBSERVATION_SCHEMA
+    );
+    assert!(
+        observation.payload.get("decision").is_none()
+            && observation.payload.get("verdict").is_none()
+            && observation.payload.get("outcome").is_none()
+            && observation.payload.get("claims").is_none(),
+        "delegated_exec_producer_emits_observation_not_decision_or_outcome_pairing"
+    );
+    let expected_argv = format!("sha256:{}", hex::encode(Sha256::digest(CHILD_ARGV)));
+    assert_eq!(
+        observation.payload["invocation"]["argv_digest"], expected_argv,
+        "delegated_exec_observation_must_be_content_addressed"
+    );
+    assert_eq!(
+        observation.content_hash.as_deref(),
+        Some(
+            compute_content_hash(&observation)
+                .expect("recompute content hash")
+                .as_str()
+        ),
+        "delegated_exec_observation_must_be_content_addressed"
+    );
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let without_path = tmp.path().join("without.tar.gz");
+    let with_path = tmp.path().join("with.tar.gz");
+    write_bundle(&without_path, vec![decision_event(0)]);
+    write_bundle(&with_path, vec![decision_event(0), observation]);
+
+    let without = verify_v0(&without_path);
+    let with = verify_v0(&with_path);
+    assert_eq!(without["bundle_integrity"], "pass");
+    assert_eq!(with["bundle_integrity"], "pass");
+    assert_eq!(without["verdict"], "valid");
+    assert_eq!(with["verdict"], "valid");
+    assert!(
+        with["claims"].get("whole_action").is_none(),
+        "v0 must not grow a whole-action cell"
+    );
+    let without_cells = serde_json::to_vec(&without["claims"]).expect("serialize without claims");
+    let with_cells = serde_json::to_vec(&with["claims"]).expect("serialize with claims");
+    assert_eq!(
+        without_cells, with_cells,
+        "v0_claim_cells_byte_identical_with_delegated_exec_observation"
+    );
+}

--- a/crates/assay-evidence/src/delegated_exec.rs
+++ b/crates/assay-evidence/src/delegated_exec.rs
@@ -1,0 +1,47 @@
+//! Delegated-exec / child-tool observation carrier.
+//!
+//! This record is an observation of a child-tool invocation. It is not a policy
+//! decision, not an outcome pairing, and not a privileged-mcp-action/v0 record.
+
+use crate::crypto::id::compute_content_hash;
+use crate::types::EvidenceEvent;
+use anyhow::Result;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+/// Schema identity outside the privileged-mcp-action/v0 namespaces.
+pub const DELEGATED_EXEC_OBSERVATION_SCHEMA: &str = "assay.delegated_exec_observation.v0";
+
+const NON_CLAIMS: &[&str] = &[
+    "delegated exec observation only; policy decision lives in assay.enforcement_decision.v0",
+    "does not pair this invocation into a whole-action verdict",
+    "does not assert or verify the child outcome or any provider side effect",
+    "absence of this event is not proof the child did not run",
+];
+
+/// Emit one content-addressed delegated-exec observation event.
+pub fn delegated_exec_observation_event(
+    source: impl Into<String>,
+    run_id: impl Into<String>,
+    seq: u64,
+    child_tool: &str,
+    argv: &[u8],
+) -> Result<EvidenceEvent> {
+    let payload = json!({
+        "schema": DELEGATED_EXEC_OBSERVATION_SCHEMA,
+        "invocation": {
+            "tool_name": child_tool,
+            "argv_digest": format!("sha256:{}", hex::encode(Sha256::digest(argv))),
+        },
+        "non_claims": NON_CLAIMS,
+    });
+    let mut event = EvidenceEvent::new(
+        DELEGATED_EXEC_OBSERVATION_SCHEMA,
+        source,
+        run_id,
+        seq,
+        payload,
+    );
+    event.content_hash = Some(compute_content_hash(&event)?);
+    Ok(event)
+}

--- a/crates/assay-evidence/src/lib.rs
+++ b/crates/assay-evidence/src/lib.rs
@@ -3,6 +3,7 @@ pub mod bundle;
 pub mod coding_agent;
 pub mod coverage_attestation;
 pub mod crypto;
+pub mod delegated_exec;
 pub mod denial_marker;
 pub mod diff;
 pub mod g3_authorization_context;
@@ -37,6 +38,7 @@ pub use coverage_attestation::{
     Cap1Integrity, Cap1Producer, Cap1RelyingPartyContext, Cap1Rule, Cap1Stratum, Cap1Subject,
     Cap1Unexamined,
 };
+pub use delegated_exec::{delegated_exec_observation_event, DELEGATED_EXEC_OBSERVATION_SCHEMA};
 pub use denial_marker::{
     bindable_denial_marker, classify_denial_marker, BindableDenialMarker, DenialMarkerVersion,
     DENIED_CALL_OBSERVATION_V0, DENIED_CALL_OBSERVATION_V1, PROXY_DENIED_V0, PROXY_DENIED_V1,

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -103,6 +103,7 @@ revision, when this block was a bare list.
 ```text
 assay.coding_agent.evidence_pack.v0 | declared in assay-evidence as a bundle pack schema; no CLI write opened
 assay.content_hash_scope.v1 | nested object inside `assay evidence show --format json`; reader content_hash recomputation contract, not a top-level CLI document
+assay.delegated_exec_observation.v0 | assay-evidence observation event inside a bundle; ignored by privileged-mcp-action/v0
 assay.mandate.v1 | mandate event carried in evidence, not written by a command
 assay.mcp_manifest_observed.v0 | assay-mcp-server observation event inside a bundle
 assay.mcp_manifest_projection.v0 | assay-mcp-server projection event inside a bundle


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: No programme is active.
- Slice: issue 2512 delegated-exec observation outside privileged-mcp-action/v0
- Builder: Cursor Grok
- Reviewers: needs an independent exact-head review
- Final head SHA: 3847e61931e0764003c3b29d83d0bdcb7353b405
- Worktree: /Users/roelschuurkes/.claude/worktrees/assay-2512
- ADR invariants affected: ADR-042 stop list (no whole-action verdict); ADR-043 distinction between observation, policy decision, and outcome

## Re-measurement

Issue baseline was taken on `081187faa383e676a0238824334884336ce5d180` (2026-08-18). Re-measured on this worktree at origin/main `216b371f6c4bc32430a4cbb19eee02c54ff82c0d` before implementation. The baseline still holds:

- No independent issue tracks a delegated-exec / child-tool evidence event (GitHub search returned only this issue).
- No such event schema exists in the tree.
- `docs/profiles/privileged-mcp-action/v0.md` still defers gateway/kernel observations and whole-action verdicts; events outside the profile namespace are ignored.
- Verifier `PROFILE_NAMESPACES` is still `assay.enforcement_decision.`, `assay.denied_call_observation.`, `assay.manifest_establish.`; the out-of-namespace arm is still a no-op.
- Claim matrix is still the four cells; no whole-action cell.
- The stated predecessor (issue 2486) is already closed.

Main has moved since that checkout; this candidate is one commit on top of `216b371f6`.

## Behavior

A producer can emit `assay.delegated_exec_observation.v0` as its own content-addressed observation. privileged-mcp-action/v0 continues to ignore that event and does not grow a whole-action cell.

## Four boxes

1. Schema identity `assay.delegated_exec_observation.v0` in `crates/assay-evidence/src/delegated_exec.rs`, recorded as a non-CLI document in `docs/architecture/CLI-JSON-IDENTITIES.md`.
2. `delegated_exec_observation_event` emits an observation: no `decision`, `verdict`, `outcome`, or `claims` field; non-claims say it is not a policy decision and does not pair into a whole-action verdict.
3. `assay evidence verify-privileged-mcp-action --format json` over two bundles (decision only vs decision plus this event) produced byte-identical claim cells:

```
{"policy_decision_recorded":{"status":"confirmed","source_class":"producer_reported"},"caller_visible_denial":{"status":"incomplete"},"upstream_delivery":{"status":"incomplete"},"external_side_effect":{"status":"incomplete"}}
```

No `whole_action` cell. Measured at head `3847e61931e0764003c3b29d83d0bdcb7353b405`, worktree above, `CARGO_INCREMENTAL=0`.

4. Focused test `crates/assay-cli/tests/delegated_exec_observation_v0.rs` proves presence, content-address binding, and the byte-identical cells.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim

Absence of the event is not proof the child did not run. Not a live proxy wiring of every child exec.

## Test Evidence

### RED

`CARGO_INCREMENTAL=0 cargo test -p assay-cli --test delegated_exec_observation_v0` failed to compile: unresolved imports `delegated_exec_observation_event` and `DELEGATED_EXEC_OBSERVATION_SCHEMA`.

Must-bite after GREEN, same test, named assertions:

- Schema moved to `assay.enforcement_decision.delegated_exec.v0`: failed on `delegated_exec_schema_must_stay_outside_privileged_mcp_action_v0_namespaces`.
- Content-hash binding removed from the producer: failed on `delegated_exec_observation_must_be_content_addressed` (`left: None`, `right: Some("sha256:0193aa428c9bac775f73e8a77597628587f7d624c4c1b19476f78b79d2cbb169")`).

### GREEN

- `CARGO_INCREMENTAL=0 cargo test -p assay-cli --test delegated_exec_observation_v0`: pass
- `CARGO_INCREMENTAL=0 cargo test -p assay-cli --test cli_json_identities`: 15 passed
- `CARGO_INCREMENTAL=0 cargo test -p assay-evidence --lib`: 333 passed
- `cargo fmt --all -- --check`: pass
- `CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets -- -D warnings`: pass
- `git diff --check`: pass

## Review Quorum

- [ ] One non-building agent review
- [ ] Every actionable finding is fixed or has a technical disposition
- [ ] Any delegated proof targets this exact head SHA

Candidate, not a landing. Sole author; needs an independent exact-head review record before merge.

Closes #2512

Made with [Cursor](https://cursor.com)

---

Current head `45bd62cca2979f0e05f76decd9b0e1f9175c50bf`. Review record: https://github.com/Rul1an/assay/pull/2980#issuecomment-5648658956 (carried to this head by the checker's derivation).
